### PR TITLE
fix dfx environment urls

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -9,11 +9,11 @@
     },
     "test": {
       "type": "persistent",
-      "providers": ["https://icp-api.io"]
+      "providers": ["https://icp0.io"]
     },
     "production": {
       "type": "persistent",
-      "providers": ["https://icp-api.io"]
+      "providers": ["https://icp0.io"]
     }
   },
   "canisters": {


### PR DESCRIPTION
Context: https://forum.dfinity.org/t/replica-error-not-allowed-to-call-ic00-method-provisional-create-canister-with-cycles/23709/6