### PR TITLE
feat: load canisters by project id

### DIFF
--- a/src/backend-api/candid/canister.did
+++ b/src/backend-api/candid/canister.did
@@ -1,7 +1,16 @@
 import "../../canister-utils/error.did";
 
-type ListMyCanistersResponse = variant {
-  Ok : vec Canister;
+type ListProjectCanistersRequest = record {
+  project_id : text;
+  limit : opt nat64;
+  page : opt nat64;
+};
+
+type ListProjectCanistersResponse = variant {
+  Ok : record {
+    canisters : vec Canister;
+    meta : PaginationMetaResponse;
+  };
   Err : ApiError;
 };
 
@@ -100,6 +109,6 @@ type CanisterEnvironmentVariable = record {
 };
 
 service : {
-  list_my_canisters : () -> (ListMyCanistersResponse);
+  list_project_canisters : (ListProjectCanistersRequest) -> (ListProjectCanistersResponse);
   list_all_canisters : (ListAllCanistersRequest) -> (ListAllCanistersResponse) query;
 };

--- a/src/backend-tests/src/support/canister-driver.ts
+++ b/src/backend-tests/src/support/canister-driver.ts
@@ -1,0 +1,42 @@
+import type { Actor, PocketIc } from '@dfinity/pic';
+import { AnonymousIdentity, type Identity } from '@icp-sdk/core/agent';
+import type { Principal } from '@icp-sdk/core/principal';
+import { idlFactory, type _SERVICE, type Canister } from '@ssn/backend-api';
+import { extractOkResponse } from './error';
+
+export class CanisterDriver {
+  private readonly actor: Actor<_SERVICE>;
+  private readonly defaultIdentity = new AnonymousIdentity();
+
+  constructor(pic: PocketIc, canisterId: Principal) {
+    this.actor = pic.createActor<_SERVICE>(idlFactory, canisterId);
+  }
+
+  public async getAllProjectCanisters(
+    identity: Identity,
+    projectId: string,
+  ): Promise<Canister[]> {
+    try {
+      this.actor.setIdentity(identity);
+
+      const canisters: Canister[] = [];
+      let page = 1n;
+      while (true) {
+        const res = await this.actor.list_project_canisters({
+          project_id: projectId,
+          limit: [50n],
+          page: [page],
+        });
+        const okRes = extractOkResponse(res);
+        canisters.push(...okRes.canisters);
+
+        if (page >= okRes.meta.total_pages) break;
+        page = page + 1n;
+      }
+
+      return canisters;
+    } finally {
+      this.actor.setIdentity(this.defaultIdentity);
+    }
+  }
+}

--- a/src/backend-tests/src/support/proposal-driver.ts
+++ b/src/backend-tests/src/support/proposal-driver.ts
@@ -43,14 +43,17 @@ export class ProposalDriver {
     projectId: string,
     operation: ProposalOperation,
   ): Promise<Proposal> {
-    this.actor.setIdentity(identity);
-    const proposalRes = await this.actor.create_proposal({
-      project_id: projectId,
-      operation: [operation],
-    });
-    const proposal = extractOkResponse(proposalRes);
+    try {
+      this.actor.setIdentity(identity);
+      const proposalRes = await this.actor.create_proposal({
+        project_id: projectId,
+        operation: [operation],
+      });
+      const proposal = extractOkResponse(proposalRes);
 
-    this.actor.setIdentity(this.defaultIdentity);
-    return proposal;
+      return proposal;
+    } finally {
+      this.actor.setIdentity(this.defaultIdentity);
+    }
   }
 }

--- a/src/backend-tests/src/support/test-driver.ts
+++ b/src/backend-tests/src/support/test-driver.ts
@@ -9,6 +9,7 @@ import { resolve } from 'node:path';
 import { Principal } from '@icp-sdk/core/principal';
 import { controllerIdentity } from './identity';
 import { ProposalDriver } from './proposal-driver';
+import { CanisterDriver } from './canister-driver';
 import { extractOkResponse } from './error';
 import * as crypto from 'node:crypto';
 import { UserDriver } from './user-driver';
@@ -36,6 +37,7 @@ export const PRIVATE_KEY = privateKey;
 export class TestDriver {
   public readonly proposals: ProposalDriver;
   public readonly users: UserDriver;
+  public readonly canisters: CanisterDriver;
 
   public get actor(): Actor<BackendService> {
     return this.fixture.actor;
@@ -50,6 +52,7 @@ export class TestDriver {
     private readonly fixture: CanisterFixture<BackendService>,
   ) {
     this.proposals = new ProposalDriver(pic, fixture.canisterId);
+    this.canisters = new CanisterDriver(pic, fixture.canisterId);
     this.users = new UserDriver(pic, fixture.canisterId);
   }
 

--- a/src/backend-tests/src/tests/canister.spec.ts
+++ b/src/backend-tests/src/tests/canister.spec.ts
@@ -215,8 +215,10 @@ describe('Canisters', () => {
       const project = await driver.getDefaultProject();
       await driver.proposals.createCanister(aliceIdentity, project.id);
 
-      const canisterRes = await driver.actor.list_my_canisters();
-      const [canister] = extractOkResponse(canisterRes);
+      const [canister] = await driver.canisters.getAllProjectCanisters(
+        aliceIdentity,
+        project.id,
+      );
       await expectCanister(canister!);
     });
 
@@ -280,8 +282,10 @@ describe('Canisters', () => {
 
       const project = await driver.getDefaultProject();
       await driver.proposals.createCanister(controllerIdentity, project.id);
-      const canisterRes = await driver.actor.list_my_canisters();
-      const [canister] = extractOkResponse(canisterRes);
+      const [canister] = await driver.canisters.getAllProjectCanisters(
+        controllerIdentity,
+        project.id,
+      );
       await expectCanister(canister!);
     });
 
@@ -310,8 +314,10 @@ describe('Canisters', () => {
 
       const project = await driver.getDefaultProject();
       await driver.proposals.createCanister(aliceIdentity, project.id);
-      const canisterRes = await driver.actor.list_my_canisters();
-      const [canister] = extractOkResponse(canisterRes);
+      const [canister] = await driver.canisters.getAllProjectCanisters(
+        aliceIdentity,
+        project.id,
+      );
       await expectCanister(canister!);
     });
   });
@@ -420,8 +426,10 @@ describe('Canisters', () => {
 
       const project = await driver.getDefaultProject();
       await driver.proposals.createCanister(aliceIdentity, project.id);
-      const canisterRes = await driver.actor.list_my_canisters();
-      const [canister] = extractOkResponse(canisterRes);
+      const [canister] = await driver.canisters.getAllProjectCanisters(
+        aliceIdentity,
+        project.id,
+      );
       const canisterId = Principal.fromText(canister!.principal_id);
 
       await driver.proposals.addCanisterController(
@@ -455,8 +463,10 @@ describe('Canisters', () => {
 
       const project = await driver.getDefaultProject();
       await driver.proposals.createCanister(aliceIdentity, project.id);
-      const canisterRes = await driver.actor.list_my_canisters();
-      const [canister] = extractOkResponse(canisterRes);
+      const [canister] = await driver.canisters.getAllProjectCanisters(
+        aliceIdentity,
+        project.id,
+      );
 
       await driver.proposals.addCanisterController(
         aliceIdentity,
@@ -480,8 +490,10 @@ describe('Canisters', () => {
 
       const project = await driver.getDefaultProject();
       await driver.proposals.createCanister(aliceIdentity, project.id);
-      const canisterRes = await driver.actor.list_my_canisters();
-      const [canister] = extractOkResponse(canisterRes);
+      const [canister] = await driver.canisters.getAllProjectCanisters(
+        aliceIdentity,
+        project.id,
+      );
 
       driver.actor.setIdentity(controllerIdentity);
       await driver.actor.create_my_user_profile();
@@ -511,8 +523,10 @@ describe('Canisters', () => {
 
       const project = await driver.getDefaultProject();
       await driver.proposals.createCanister(aliceIdentity, project.id);
-      const canisterRes = await driver.actor.list_my_canisters();
-      const [canister] = extractOkResponse(canisterRes);
+      const [canister] = await driver.canisters.getAllProjectCanisters(
+        aliceIdentity,
+        project.id,
+      );
 
       driver.actor.setIdentity(controllerIdentity);
       await driver.actor.create_my_user_profile();
@@ -558,8 +572,10 @@ describe('Canisters', () => {
 
       const project = await driver.getDefaultProject();
       await driver.proposals.createCanister(controllerIdentity, project.id);
-      const canisterRes = await driver.actor.list_my_canisters();
-      const [canister] = extractOkResponse(canisterRes);
+      const [canister] = await driver.canisters.getAllProjectCanisters(
+        controllerIdentity,
+        project.id,
+      );
 
       await driver.proposals.addCanisterController(
         controllerIdentity,
@@ -603,8 +619,10 @@ describe('Canisters', () => {
 
       const project = await driver.getDefaultProject();
       await driver.proposals.createCanister(aliceIdentity, project.id);
-      const canisterRes = await driver.actor.list_my_canisters();
-      const [canister] = extractOkResponse(canisterRes);
+      const [canister] = await driver.canisters.getAllProjectCanisters(
+        aliceIdentity,
+        project.id,
+      );
 
       await driver.proposals.addCanisterController(
         aliceIdentity,

--- a/src/backend-tests/src/tests/canister.spec.ts
+++ b/src/backend-tests/src/tests/canister.spec.ts
@@ -87,64 +87,6 @@ describe('Canisters', () => {
     await driver.tearDown();
   });
 
-  describe('list_my_canisters', () => {
-    it('should return an error for an anonymous user', async () => {
-      driver.actor.setIdentity(anonymousIdentity);
-
-      const res = await driver.actor.list_my_canisters();
-      expect(res).toEqual(unauthenticatedError);
-    });
-
-    it('should return an error for a user without a profile', async () => {
-      const aliceIdentity = generateRandomIdentity();
-      driver.actor.setIdentity(aliceIdentity);
-
-      const res = await driver.actor.list_my_canisters();
-      expect(res).toEqual(noProfileError(aliceIdentity.getPrincipal()));
-    });
-
-    it('should return an empty array when the user has no canisters', async () => {
-      const [aliceIdentity] = await driver.users.createUser();
-      driver.actor.setIdentity(aliceIdentity);
-
-      const canistersRes = await driver.actor.list_my_canisters();
-      const canisters = extractOkResponse(canistersRes);
-      expect(canisters).toEqual([]);
-    });
-
-    it('should return all canisters owned by the user', async () => {
-      const [aliceIdentity] = await driver.users.createUser();
-      driver.actor.setIdentity(aliceIdentity);
-      const aliceProject = await driver.getDefaultProject();
-      await driver.proposals.createCanister(aliceIdentity, aliceProject.id);
-      await driver.proposals.createCanister(aliceIdentity, aliceProject.id);
-
-      const [bobIdentity] = await driver.users.createUser();
-      driver.actor.setIdentity(bobIdentity);
-      const bobProject = await driver.getDefaultProject();
-      await driver.proposals.createCanister(bobIdentity, bobProject.id);
-      await driver.proposals.createCanister(bobIdentity, bobProject.id);
-      await driver.proposals.createCanister(bobIdentity, bobProject.id);
-
-      driver.actor.setIdentity(aliceIdentity);
-      const aliceCanistersRes = await driver.actor.list_my_canisters();
-      const aliceCanisters = extractOkResponse(aliceCanistersRes);
-
-      expect(aliceCanisters.length).toBe(2);
-      await expectCanister(aliceCanisters[0]!);
-      await expectCanister(aliceCanisters[1]!);
-
-      driver.actor.setIdentity(bobIdentity);
-      const bobCanistersRes = await driver.actor.list_my_canisters();
-      const bobCanisters = extractOkResponse(bobCanistersRes);
-
-      expect(bobCanisters.length).toBe(3);
-      await expectCanister(bobCanisters[0]!);
-      await expectCanister(bobCanisters[1]!);
-      await expectCanister(bobCanisters[2]!);
-    });
-  });
-
   describe('create_canister', () => {
     it('should return an error for an anonymous user', async () => {
       driver.actor.setIdentity(anonymousIdentity);

--- a/src/backend-tests/src/tests/canister/list-all-canisters.spec.ts
+++ b/src/backend-tests/src/tests/canister/list-all-canisters.spec.ts
@@ -6,7 +6,7 @@ import {
   TestDriver,
   unauthenticatedError,
   unauthorizedError,
-} from '../support';
+} from '../../support';
 import { generateRandomIdentity } from '@dfinity/pic';
 import type { Identity } from '@icp-sdk/core/agent';
 import type { Canister, UserProfile } from '@ssn/backend-api';
@@ -81,25 +81,40 @@ describe('list_all_canisters', () => {
       const numAliceProjects = 5;
       const numBobProjects = 3;
 
-      [aliceIdentity, aliceProfile] = await driver.users.createUser();
+      aliceIdentity = generateRandomIdentity();
+      bobIdentity = generateRandomIdentity();
+
       driver.actor.setIdentity(aliceIdentity);
+      await driver.actor.create_my_user_profile();
       await driver.actor.update_my_user_profile({ email: [aliceEmail] });
+
+      const aliceProfileRes = await driver.actor.get_my_user_profile();
+      aliceProfile = extractOkResponse(aliceProfileRes)[0]!;
+
       const aliceProject = await driver.getDefaultProject();
       for (let i = 0; i < numAliceProjects; i++) {
         await driver.proposals.createCanister(aliceIdentity, aliceProject.id);
       }
-      const aliceCanistersRes = await driver.actor.list_my_canisters();
-      aliceCanisters = extractOkResponse(aliceCanistersRes);
+      aliceCanisters = await driver.canisters.getAllProjectCanisters(
+        aliceIdentity,
+        aliceProject.id,
+      );
 
-      [bobIdentity, bobProfile] = await driver.users.createUser();
       driver.actor.setIdentity(bobIdentity);
+      await driver.actor.create_my_user_profile();
       await driver.actor.update_my_user_profile({ email: [bobEmail] });
+
+      const bobProfileRes = await driver.actor.get_my_user_profile();
+      bobProfile = extractOkResponse(bobProfileRes)[0]!;
+
       const bobProject = await driver.getDefaultProject();
       for (let i = 0; i < numBobProjects; i++) {
         await driver.proposals.createCanister(bobIdentity, bobProject.id);
       }
-      const bobCanistersRes = await driver.actor.list_my_canisters();
-      bobCanisters = extractOkResponse(bobCanistersRes);
+      bobCanisters = await driver.canisters.getAllProjectCanisters(
+        bobIdentity,
+        bobProject.id,
+      );
     });
 
     it('should return one item per page', async () => {

--- a/src/backend-tests/src/tests/canister/list-project-canisters.spec.ts
+++ b/src/backend-tests/src/tests/canister/list-project-canisters.spec.ts
@@ -1,0 +1,263 @@
+import { generateRandomIdentity } from '@dfinity/pic';
+import {
+  anonymousIdentity,
+  extractOkResponse,
+  noProfileError,
+  TestDriver,
+  unauthenticatedError,
+} from '../../support';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { Identity } from '@icp-sdk/core/agent';
+import type { Canister, Project, UserProfile } from '@ssn/backend-api';
+import { Principal } from '@icp-sdk/core/principal';
+
+describe('list_project_canisters', () => {
+  let driver: TestDriver;
+
+  async function expectCanister(canister: Canister): Promise<void> {
+    expect(canister).toEqual({
+      id: expect.any(String),
+      info: [
+        {
+          cycles: 0n,
+          idle_cycles_burned_per_day: expect.any(BigInt),
+          memory_metrics: {
+            canister_history_size: expect.any(BigInt),
+            custom_sections_size: 0n,
+            global_memory_size: 0n,
+            snapshots_size: 0n,
+            stable_memory_size: 0n,
+            wasm_binary_size: 0n,
+            wasm_chunk_store_size: 0n,
+            wasm_memory_size: 0n,
+          },
+          memory_size: expect.any(BigInt),
+          module_hash: [],
+          query_stats: {
+            num_calls_total: 0n,
+            num_instructions_total: 0n,
+            request_payload_bytes_total: 0n,
+            response_payload_bytes_total: 0n,
+          },
+          ready_for_migration: false,
+          reserved_cycles: 0n,
+          settings: {
+            compute_allocation: 0n,
+            controllers: [driver.canisterId],
+            environment_variables: [],
+            freezing_threshold: expect.any(BigInt),
+            log_visibility: {
+              Controllers: null,
+            },
+            memory_allocation: 0n,
+            reserved_cycles_limit: expect.any(BigInt),
+            wasm_memory_limit: expect.any(BigInt),
+            wasm_memory_threshold: 0n,
+          },
+          status: {
+            Running: null,
+          },
+          version: 0n,
+        },
+      ],
+      principal_id: expect.any(String),
+    });
+
+    const controllers = await driver.pic.getControllers(
+      Principal.fromText(canister.principal_id),
+    );
+    const hasCorrectController = controllers.some(
+      c => c.compareTo(driver.canisterId) === 'eq',
+    );
+    expect(hasCorrectController).toBe(true);
+  }
+
+  beforeEach(async () => {
+    driver = await TestDriver.create();
+  });
+
+  afterEach(async () => {
+    await driver.tearDown();
+  });
+
+  describe('without canisters', () => {
+    it('should return an error for an anonymous user', async () => {
+      driver.actor.setIdentity(anonymousIdentity);
+
+      const res = await driver.actor.list_project_canisters({
+        project_id: crypto.randomUUID(),
+        limit: [],
+        page: [],
+      });
+      expect(res).toEqual(unauthenticatedError);
+    });
+
+    it('should return an error for a user without a profile', async () => {
+      const aliceIdentity = generateRandomIdentity();
+      driver.actor.setIdentity(aliceIdentity);
+
+      const res = await driver.actor.list_project_canisters({
+        project_id: crypto.randomUUID(),
+        limit: [],
+        page: [],
+      });
+      expect(res).toEqual(noProfileError(aliceIdentity.getPrincipal()));
+    });
+
+    it('should return an empty array when the user has no canisters', async () => {
+      const aliceIdentity = generateRandomIdentity();
+      driver.actor.setIdentity(aliceIdentity);
+      await driver.actor.create_my_user_profile();
+      const defaultProject = await driver.getDefaultProject();
+
+      const canisters = await driver.canisters.getAllProjectCanisters(
+        aliceIdentity,
+        defaultProject.id,
+      );
+      expect(canisters).toEqual([]);
+    });
+  });
+
+  describe('with canisters', () => {
+    let aliceIdentity: Identity;
+    let aliceProject: Project;
+
+    let bobIdentity: Identity;
+    let bobProject: Project;
+
+    const numAliceCanisters = 8;
+    const numBobCanisters = 5;
+
+    beforeEach(async () => {
+      aliceIdentity = generateRandomIdentity();
+      driver.actor.setIdentity(aliceIdentity);
+      await driver.actor.create_my_user_profile();
+      aliceProject = await driver.getDefaultProject();
+      for (let i = 0; i < numAliceCanisters; i++) {
+        await driver.proposals.createCanister(aliceIdentity, aliceProject.id);
+      }
+
+      bobIdentity = generateRandomIdentity();
+      driver.actor.setIdentity(bobIdentity);
+      await driver.actor.create_my_user_profile();
+      bobProject = await driver.getDefaultProject();
+      for (let i = 0; i < numBobCanisters; i++) {
+        await driver.proposals.createCanister(bobIdentity, bobProject.id);
+      }
+    });
+
+    it('should return all canisters owned by the user', async () => {
+      driver.actor.setIdentity(aliceIdentity);
+      const aliceCanisters = await driver.canisters.getAllProjectCanisters(
+        aliceIdentity,
+        aliceProject.id,
+      );
+
+      expect(aliceCanisters.length).toBe(numAliceCanisters);
+      for (const canister of aliceCanisters) {
+        await expectCanister(canister);
+      }
+
+      driver.actor.setIdentity(bobIdentity);
+      const bobCanisters = await driver.canisters.getAllProjectCanisters(
+        bobIdentity,
+        bobProject.id,
+      );
+
+      expect(bobCanisters.length).toBe(numBobCanisters);
+      for (const canister of bobCanisters) {
+        await expectCanister(canister);
+      }
+    });
+
+    it('should return one item per page', async () => {
+      driver.actor.setIdentity(aliceIdentity);
+      const res = await driver.actor.list_project_canisters({
+        project_id: aliceProject.id,
+        limit: [1n],
+        page: [1n],
+      });
+      const okRes = extractOkResponse(res);
+
+      expect(okRes.canisters).toHaveLength(1);
+      expect(okRes.meta.limit).toBe(1n);
+      expect(okRes.meta.page).toBe(1n);
+      expect(okRes.meta.total_items).toBe(8n);
+      expect(okRes.meta.total_pages).toBe(8n);
+    });
+
+    it('should return multiple items per page', async () => {
+      driver.actor.setIdentity(aliceIdentity);
+      const res = await driver.actor.list_project_canisters({
+        project_id: aliceProject.id,
+        limit: [3n],
+        page: [2n],
+      });
+      const okRes = extractOkResponse(res);
+      expect(okRes.canisters).toHaveLength(3);
+      expect(okRes.meta.limit).toBe(3n);
+      expect(okRes.meta.page).toBe(2n);
+      expect(okRes.meta.total_items).toBe(8n);
+      expect(okRes.meta.total_pages).toBe(3n);
+    });
+
+    it('return all items on a single page', async () => {
+      driver.actor.setIdentity(aliceIdentity);
+      const res = await driver.actor.list_project_canisters({
+        project_id: aliceProject.id,
+        limit: [10n],
+        page: [1n],
+      });
+      const okRes = extractOkResponse(res);
+      expect(okRes.canisters).toHaveLength(8);
+      expect(okRes.meta.limit).toBe(10n);
+      expect(okRes.meta.page).toBe(1n);
+      expect(okRes.meta.total_items).toBe(8n);
+      expect(okRes.meta.total_pages).toBe(1n);
+    });
+
+    it('should set a minimum page', async () => {
+      driver.actor.setIdentity(aliceIdentity);
+      const res = await driver.actor.list_project_canisters({
+        project_id: aliceProject.id,
+        limit: [1n],
+        page: [0n],
+      });
+      const okRes = extractOkResponse(res);
+      expect(okRes.meta.page).toBe(1n);
+    });
+
+    it('should set a maximum page', async () => {
+      driver.actor.setIdentity(aliceIdentity);
+      const res = await driver.actor.list_project_canisters({
+        project_id: aliceProject.id,
+        limit: [1n],
+        page: [10_000n],
+      });
+      const okRes = extractOkResponse(res);
+      expect(okRes.meta.page).toBe(8n);
+    });
+
+    it('should set a minimum limit', async () => {
+      driver.actor.setIdentity(aliceIdentity);
+      const res = await driver.actor.list_project_canisters({
+        project_id: aliceProject.id,
+        limit: [0n],
+        page: [1n],
+      });
+      const okRes = extractOkResponse(res);
+      expect(okRes.meta.limit).toBe(1n);
+    });
+
+    it('should set a maximum limit', async () => {
+      driver.actor.setIdentity(aliceIdentity);
+      const res = await driver.actor.list_project_canisters({
+        project_id: aliceProject.id,
+        limit: [10_000n],
+        page: [1n],
+      });
+      const okRes = extractOkResponse(res);
+      expect(okRes.meta.limit).toBe(50n);
+    });
+  });
+});

--- a/src/backend-tests/tsconfig.json
+++ b/src/backend-tests/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "types": ["bun", "vitest"]
   },
   "include": ["src/**/*.ts", "global-setup.ts", "types.d.ts"],

--- a/src/backend/src/controller/canister.rs
+++ b/src/backend/src/controller/canister.rs
@@ -1,26 +1,33 @@
 use crate::{
-    dto::{ListAllCanistersRequest, ListAllCanistersResponse, ListMyCanistersResponse},
+    dto::{
+        ListAllCanistersRequest, ListAllCanistersResponse, ListProjectCanistersRequest,
+        ListProjectCanistersResponse,
+    },
     service::canister_service,
 };
 use canister_utils::{assert_authenticated, assert_controller, ApiResultDto};
 use ic_cdk::{api::msg_caller, *};
 
 #[update]
-async fn list_my_canisters() -> ApiResultDto<ListMyCanistersResponse> {
+async fn list_project_canisters(
+    req: ListProjectCanistersRequest,
+) -> ApiResultDto<ListProjectCanistersResponse> {
     let caller = msg_caller();
     if let Err(err) = assert_authenticated(&caller) {
         return ApiResultDto::Err(err);
     }
 
-    canister_service::list_my_canisters(caller).await.into()
+    canister_service::list_project_canisters(&caller, &req.project_id, req.limit, req.page)
+        .await
+        .into()
 }
 
 #[query]
-fn list_all_canisters(request: ListAllCanistersRequest) -> ApiResultDto<ListAllCanistersResponse> {
+fn list_all_canisters(req: ListAllCanistersRequest) -> ApiResultDto<ListAllCanistersResponse> {
     let caller = msg_caller();
     if let Err(err) = assert_controller(&caller) {
         return ApiResultDto::Err(err);
     }
 
-    canister_service::list_all_canisters(request.limit, request.page).into()
+    canister_service::list_all_canisters(req.limit, req.page).into()
 }

--- a/src/backend/src/data/canister_repository.rs
+++ b/src/backend/src/data/canister_repository.rs
@@ -1,17 +1,24 @@
 use crate::data::{
     memory::{
-        init_canister_project_index, init_canisters, init_project_canister_index, CanisterMemory,
-        CanisterProjectIndexMemory, ProjectCanisterIndexMemory,
+        init_canister_project_index, init_canisters, init_project_canister_count,
+        init_project_canister_index, CanisterMemory, CanisterProjectIndexMemory,
+        ProjectCanisterCountMemory, ProjectCanisterIndexMemory,
     },
     Canister,
 };
 use canister_utils::Uuid;
-use std::cell::RefCell;
+use std::{cell::RefCell, collections::HashMap};
 
-pub fn list_canisters_by_project(project_id: Uuid) -> Vec<(Uuid, Canister)> {
+pub fn list_canisters_by_project(
+    project_id: Uuid,
+    limit: usize,
+    page: usize,
+) -> Vec<(Uuid, Canister)> {
     with_state(|s| {
         s.project_canister_index
             .range((project_id, Uuid::MIN)..=(project_id, Uuid::MAX))
+            .skip(limit * (page - 1))
+            .take(limit)
             .filter_map(|(_, canister_id)| {
                 s.canisters
                     .get(&canister_id)
@@ -44,6 +51,9 @@ pub fn create_canister(project_id: Uuid, canister: Canister) -> Uuid {
         s.canisters.insert(canister_id, canister);
         s.project_canister_index.insert((project_id, canister_id));
         s.canister_project_index.insert(canister_id, project_id);
+
+        let count = s.project_canister_count.get(&project_id).unwrap_or(0);
+        s.project_canister_count.insert(project_id, count + 1);
     });
 
     canister_id
@@ -53,10 +63,29 @@ pub fn get_canister_count() -> u64 {
     with_state(|s| s.canisters.len())
 }
 
+pub fn get_project_canister_count(project_id: Uuid) -> u64 {
+    with_state(|s| s.project_canister_count.get(&project_id).unwrap_or(0))
+}
+
+pub fn migrate_project_canister_count() {
+    mutate_state(|s| {
+        let mut counts = HashMap::new();
+
+        for (project_id, _) in s.project_canister_index.iter() {
+            *counts.entry(project_id).or_insert(0) += 1;
+        }
+
+        for (project_id, count) in counts {
+            s.project_canister_count.insert(project_id, count);
+        }
+    });
+}
+
 struct CanisterState {
     canisters: CanisterMemory,
     project_canister_index: ProjectCanisterIndexMemory,
     canister_project_index: CanisterProjectIndexMemory,
+    project_canister_count: ProjectCanisterCountMemory,
 }
 
 impl Default for CanisterState {
@@ -65,6 +94,7 @@ impl Default for CanisterState {
             canisters: init_canisters(),
             project_canister_index: init_project_canister_index(),
             canister_project_index: init_canister_project_index(),
+            project_canister_count: init_project_canister_count(),
         }
     }
 }

--- a/src/backend/src/data/memory/canister_memory.rs
+++ b/src/backend/src/data/memory/canister_memory.rs
@@ -1,7 +1,7 @@
 use crate::data::{
     memory::{
         get_memory, Memory, CANISTERS_MEMORY_ID, CANISTER_PROJECT_INDEX_MEMORY_ID,
-        PROJECT_CANISTER_INDEX_MEMORY_ID,
+        PROJECT_CANISTER_COUNT_MEMORY_ID, PROJECT_CANISTER_INDEX_MEMORY_ID,
     },
     Canister,
 };
@@ -11,6 +11,7 @@ use ic_stable_structures::{BTreeMap, BTreeSet};
 pub type CanisterMemory = BTreeMap<Uuid, Canister, Memory>;
 pub type ProjectCanisterIndexMemory = BTreeSet<(Uuid, Uuid), Memory>;
 pub type CanisterProjectIndexMemory = BTreeMap<Uuid, Uuid, Memory>;
+pub type ProjectCanisterCountMemory = BTreeMap<Uuid, u64, Memory>;
 
 pub fn init_canisters() -> CanisterMemory {
     CanisterMemory::init(get_canisters_memory())
@@ -24,6 +25,10 @@ pub fn init_canister_project_index() -> CanisterProjectIndexMemory {
     CanisterProjectIndexMemory::init(get_canister_project_index_memory())
 }
 
+pub fn init_project_canister_count() -> ProjectCanisterCountMemory {
+    ProjectCanisterCountMemory::init(get_project_canister_count_memory())
+}
+
 fn get_canisters_memory() -> Memory {
     get_memory(CANISTERS_MEMORY_ID)
 }
@@ -34,4 +39,8 @@ fn get_project_canister_index_memory() -> Memory {
 
 fn get_canister_project_index_memory() -> Memory {
     get_memory(CANISTER_PROJECT_INDEX_MEMORY_ID)
+}
+
+fn get_project_canister_count_memory() -> Memory {
+    get_memory(PROJECT_CANISTER_COUNT_MEMORY_ID)
 }

--- a/src/backend/src/data/memory/memory_manager.rs
+++ b/src/backend/src/data/memory/memory_manager.rs
@@ -53,3 +53,4 @@ pub(super) const PROPOSAL_MEMORY_ID: MemoryId = MemoryId::new(25);
 pub(super) const PROJECT_PROPOSAL_INDEX_MEMORY_ID: MemoryId = MemoryId::new(26);
 
 pub(super) const CANISTER_PROJECT_INDEX_MEMORY_ID: MemoryId = MemoryId::new(27);
+pub(super) const PROJECT_CANISTER_COUNT_MEMORY_ID: MemoryId = MemoryId::new(28);

--- a/src/backend/src/dto/canister.rs
+++ b/src/backend/src/dto/canister.rs
@@ -1,7 +1,18 @@
 use candid::{CandidType, Nat, Principal};
 use serde::Deserialize;
 
-pub type ListMyCanistersResponse = Vec<Canister>;
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct ListProjectCanistersRequest {
+    pub limit: Option<u64>,
+    pub page: Option<u64>,
+    pub project_id: String,
+}
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct ListProjectCanistersResponse {
+    pub canisters: Vec<Canister>,
+    pub meta: PaginationMetaResponse,
+}
 
 #[derive(Debug, Clone, CandidType, Deserialize)]
 pub struct ListAllCanistersRequest {

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -4,6 +4,8 @@ use dto::*;
 use ic_cdk::*;
 use ic_http_certification::{HttpRequest, HttpResponse};
 
+use crate::service::canister_service;
+
 mod constants;
 mod controller;
 mod data;
@@ -26,6 +28,7 @@ fn export_candid() -> String {
 #[ic_cdk::post_upgrade]
 fn post_upgrade() {
     controller::http::init();
+    canister_service::migrate_project_canister_count();
 }
 
 #[cfg(test)]

--- a/src/backend/src/service/canister_service.rs
+++ b/src/backend/src/service/canister_service.rs
@@ -7,11 +7,11 @@ use crate::{
         canister_repository, organization_repository, project_repository, team_repository,
         user_profile_repository, Canister,
     },
-    dto::{self, ListMyCanistersResponse},
+    dto::{self},
     mapping::map_canister_response,
 };
 use candid::Principal;
-use canister_utils::{ApiError, ApiResult, Uuid};
+use canister_utils::{ApiResult, Uuid};
 use futures::future::join_all;
 use ic_cdk::{
     api::canister_self,
@@ -20,26 +20,32 @@ use ic_cdk::{
     },
 };
 
-pub async fn list_my_canisters(caller: Principal) -> ApiResult<ListMyCanistersResponse> {
-    let user_id = user_profile_repository::assert_user_id_by_principal(&caller)?;
+pub fn migrate_project_canister_count() {
+    canister_repository::migrate_project_canister_count();
+}
 
-    let team_id = team_repository::list_user_team_ids(user_id)
-        .first()
-        .cloned()
-        .ok_or_else(|| {
-            ApiError::internal_error("User does not have a default team.".to_string())
-        })?;
+pub async fn list_project_canisters(
+    caller: &Principal,
+    project_id: &str,
+    limit: Option<u64>,
+    page: Option<u64>,
+) -> ApiResult<dto::ListProjectCanistersResponse> {
+    let limit = limit
+        .unwrap_or(DEFAULT_PAGINATION_LIMIT)
+        .clamp(MIN_PAGINATION_LIMIT, MAX_PAGINATION_LIMIT);
+    let page = page.unwrap_or(DEFAULT_PAGINATION_PAGE);
 
-    let project_id = project_repository::list_team_project_ids(team_id)
-        .first()
-        .cloned()
-        .ok_or_else(|| {
-            ApiError::internal_error(
-                "User's default team does not have a default project.".to_string(),
-            )
-        })?;
+    let project_id = Uuid::try_from(project_id)?;
+    let total_items = canister_repository::get_project_canister_count(project_id);
+    let total_pages = total_items.div_ceil(limit).max(MIN_PAGINATION_PAGE);
+    let page = page.clamp(MIN_PAGINATION_PAGE, total_pages);
 
-    let project_canisters = canister_repository::list_canisters_by_project(project_id);
+    let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
+    let team_ids = team_repository::list_user_team_ids(user_id);
+    project_repository::assert_any_team_has_project(&user_id, &team_ids, project_id)?;
+
+    let project_canisters =
+        canister_repository::list_canisters_by_project(project_id, limit as usize, page as usize);
     let mut canisters = vec![];
 
     for chunk in project_canisters.chunks(MAX_CALLS_PER_BATCH) {
@@ -57,7 +63,15 @@ pub async fn list_my_canisters(caller: Principal) -> ApiResult<ListMyCanistersRe
         canisters.extend(join_all(canister_futures).await);
     }
 
-    Ok(canisters)
+    Ok(dto::ListProjectCanistersResponse {
+        canisters,
+        meta: dto::PaginationMetaResponse {
+            limit,
+            page,
+            total_items,
+            total_pages,
+        },
+    })
 }
 
 pub fn list_all_canisters(

--- a/src/backend/src/service/canister_service.rs
+++ b/src/backend/src/service/canister_service.rs
@@ -30,19 +30,20 @@ pub async fn list_project_canisters(
     limit: Option<u64>,
     page: Option<u64>,
 ) -> ApiResult<dto::ListProjectCanistersResponse> {
+    let project_id = Uuid::try_from(project_id)?;
+
+    let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
+    let team_ids = team_repository::list_user_team_ids(user_id);
+    project_repository::assert_any_team_has_project(&user_id, &team_ids, project_id)?;
+
     let limit = limit
         .unwrap_or(DEFAULT_PAGINATION_LIMIT)
         .clamp(MIN_PAGINATION_LIMIT, MAX_PAGINATION_LIMIT);
     let page = page.unwrap_or(DEFAULT_PAGINATION_PAGE);
 
-    let project_id = Uuid::try_from(project_id)?;
     let total_items = canister_repository::get_project_canister_count(project_id);
     let total_pages = total_items.div_ceil(limit).max(MIN_PAGINATION_PAGE);
     let page = page.clamp(MIN_PAGINATION_PAGE, total_pages);
-
-    let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-    let team_ids = team_repository::list_user_team_ids(user_id);
-    project_repository::assert_any_team_has_project(&user_id, &team_ids, project_id)?;
 
     let project_canisters =
         canister_repository::list_canisters_by_project(project_id, limit as usize, page as usize);

--- a/src/canister-history-tests/tsconfig.json
+++ b/src/canister-history-tests/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "types": ["bun", "vitest"]
   },
   "include": ["src/**/*.ts", "global-setup.ts", "types.d.ts"],

--- a/src/cycles-monitor-tests/tsconfig.json
+++ b/src/cycles-monitor-tests/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "types": ["bun", "vitest"]
   },
   "include": ["src/**/*.ts", "global-setup.ts", "types.d.ts"],

--- a/src/frontend/src/lib/api-models/canister.ts
+++ b/src/frontend/src/lib/api-models/canister.ts
@@ -1,12 +1,19 @@
 import { mapOkResponse } from '@/lib/api-models/error';
+import {
+  mapPaginationMetaResponse,
+  type PaginationMetaResponse,
+} from '@/lib/api-models/pagination';
 import { isNotNil } from '@/lib/nil';
 import { fromCandidOpt } from '@/lib/utils';
 import type {
   Canister as ApiCanister,
-  ListMyCanistersResponse as ApiListMyCanistersResponse,
+  ListProjectCanistersResponse as ApiListProjectCanistersResponse,
 } from '@ssn/backend-api';
 
-export type ListMyCanistersResponse = Canister[];
+export type ListProjectCanistersResponse = {
+  canisters: Canister[];
+  meta: PaginationMetaResponse;
+};
 
 export type Canister = {
   id: string;
@@ -58,10 +65,15 @@ export enum CanisterStatus {
   Stopped = 'Stopped',
 }
 
-export function mapListMyCanistersResponse(
-  res: ApiListMyCanistersResponse,
-): ListMyCanistersResponse {
-  return mapOkResponse(res).map(mapCanisterResponse);
+export function mapListProjectCanistersResponse(
+  res: ApiListProjectCanistersResponse,
+): ListProjectCanistersResponse {
+  const okRes = mapOkResponse(res);
+
+  return {
+    canisters: okRes.canisters.map(mapCanisterResponse),
+    meta: mapPaginationMetaResponse(okRes.meta),
+  };
 }
 
 export function mapCanisterResponse(res: ApiCanister): Canister {

--- a/src/frontend/src/lib/api-models/index.ts
+++ b/src/frontend/src/lib/api-models/index.ts
@@ -3,6 +3,7 @@ export * from './canister-history';
 export * from './error';
 export * from './management-canister';
 export * from './organization';
+export * from './pagination';
 export * from './project';
 export * from './team';
 export * from './terms-and-conditions';

--- a/src/frontend/src/lib/api-models/pagination.ts
+++ b/src/frontend/src/lib/api-models/pagination.ts
@@ -1,0 +1,19 @@
+import type { PaginationMetaResponse as ApiPaginationMetaResponse } from '@ssn/backend-api';
+
+export type PaginationMetaResponse = {
+  limit: bigint;
+  page: bigint;
+  totalItems: bigint;
+  totalPages: bigint;
+};
+
+export function mapPaginationMetaResponse(
+  res: ApiPaginationMetaResponse,
+): PaginationMetaResponse {
+  return {
+    limit: res.limit,
+    page: res.page,
+    totalItems: res.total_items,
+    totalPages: res.total_pages,
+  };
+}

--- a/src/frontend/src/lib/api/canister.ts
+++ b/src/frontend/src/lib/api/canister.ts
@@ -1,7 +1,7 @@
 import {
-  mapListMyCanistersResponse,
+  mapListProjectCanistersResponse,
   mapOkResponse,
-  type ListMyCanistersResponse,
+  type ListProjectCanistersResponse,
 } from '@/lib/api-models';
 import { isNil } from '@/lib/nil';
 import type { ActorSubclass } from '@icp-sdk/core/agent';
@@ -24,10 +24,17 @@ function assertProposalExecuted(proposal: Proposal): void {
 export class CanisterApi {
   constructor(private readonly actor: ActorSubclass<_SERVICE>) {}
 
-  public async listMyCanisters(): Promise<ListMyCanistersResponse> {
-    const res = await this.actor.list_my_canisters();
+  public async listProjectCanisters(
+    projectId: string,
+  ): Promise<ListProjectCanistersResponse> {
+    const res = await this.actor.list_project_canisters({
+      project_id: projectId,
+      // [TODO]: add pagination in follow-up PR
+      limit: [50n],
+      page: [1n],
+    });
 
-    return mapListMyCanistersResponse(res);
+    return mapListProjectCanistersResponse(res);
   }
 
   public async createCanister(): Promise<void> {

--- a/src/frontend/src/lib/store/canister.ts
+++ b/src/frontend/src/lib/store/canister.ts
@@ -40,7 +40,7 @@ export const createCanistersSlice: AppStateCreator<CanistersSlice> = (
 
     set({ isCanistersLoading: true });
     try {
-      const canisters = await canisterApi.listMyCanisters();
+      const canisters = await canisterApi.listProjectCanisters(projectId);
       set(state => {
         const newCanisters = state.canisters
           ? new Map(state.canisters)

--- a/src/frontend/tsconfig.json
+++ b/src/frontend/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "lib": ["DOM", "ESNext"],
     "jsx": "react-jsx",
     "types": ["vite/client"],

--- a/src/offchain-service/tsconfig.json
+++ b/src/offchain-service/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "target": "ES2021",
     "module": "ES2022",
     "types": ["bun"]

--- a/src/scripts/tsconfig.json
+++ b/src/scripts/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "types": ["bun"],
     "baseUrl": "."
   },


### PR DESCRIPTION
This PR parameterises the canisters endpoint so it will return canisters for a specified project, rather than the "default" project. It also introduces pagination to that endpoint. This has not been added to the frontend yet, I will do that in a follow-up PR.