### PR TITLE
refactor: introduce OrgName and TeamName validation newtypes

### DIFF
--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -14,6 +14,7 @@ mod env;
 mod jwt;
 mod mapping;
 mod service;
+mod validation;
 
 #[macro_use]
 extern crate dotenv_codegen;

--- a/src/backend/src/service/organization_service.rs
+++ b/src/backend/src/service/organization_service.rs
@@ -9,27 +9,12 @@ use crate::{
         ListMyOrganizationsResponse, UpdateOrganizationRequest, UpdateOrganizationResponse,
     },
     mapping::{map_list_my_organizations_response, map_organization_to_response},
+    validation::OrgName,
 };
 use candid::Principal;
 use canister_utils::{ApiError, ApiResult, Uuid};
 
-const MAX_ORG_NAME_LENGTH: usize = 100;
 const MAX_ORGS_PER_USER: usize = 20;
-
-fn validate_and_trim_org_name(name: String) -> ApiResult<String> {
-    let trimmed = name.trim().to_string();
-    if trimmed.is_empty() {
-        return Err(ApiError::client_error(
-            "Organization name cannot be empty.".to_string(),
-        ));
-    }
-    if trimmed.len() > MAX_ORG_NAME_LENGTH {
-        return Err(ApiError::client_error(format!(
-            "Organization name cannot exceed {MAX_ORG_NAME_LENGTH} characters."
-        )));
-    }
-    Ok(trimmed)
-}
 
 pub fn list_my_organizations(caller: &Principal) -> ApiResult<ListMyOrganizationsResponse> {
     let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
@@ -43,7 +28,7 @@ pub fn create_organization(
     req: CreateOrganizationRequest,
 ) -> ApiResult<CreateOrganizationResponse> {
     let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-    let name = validate_and_trim_org_name(req.name)?;
+    let name = OrgName::try_from(req.name)?;
 
     if organization_repository::has_at_least_n_user_orgs(user_id, MAX_ORGS_PER_USER) {
         return Err(ApiError::client_error(format!(
@@ -51,7 +36,9 @@ pub fn create_organization(
         )));
     }
 
-    let org = Organization { name };
+    let org = Organization {
+        name: name.into_inner(),
+    };
     let org_id = organization_repository::create_org(user_id, org.clone());
     let team_id = team_repository::add_default_team(user_id, org_id);
     let project_id = project_repository::add_default_project(team_id, org_id);
@@ -95,9 +82,11 @@ pub fn update_organization(
     let org_id = Uuid::try_from(req.org_id.as_str())?;
     let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
     organization_repository::assert_user_in_org(user_id, org_id)?;
-    let name = validate_and_trim_org_name(req.name)?;
+    let name = OrgName::try_from(req.name)?;
 
-    let org = Organization { name };
+    let org = Organization {
+        name: name.into_inner(),
+    };
     organization_repository::update_org(org_id, org.clone())?;
 
     Ok(map_organization_to_response(org_id, org))

--- a/src/backend/src/service/team_service.rs
+++ b/src/backend/src/service/team_service.rs
@@ -8,27 +8,12 @@ use crate::{
         ListOrgTeamsRequest, ListTeamsResponse, UpdateTeamRequest, UpdateTeamResponse,
     },
     mapping::{map_list_teams_response, map_team_to_response},
+    validation::TeamName,
 };
 use candid::Principal;
 use canister_utils::{ApiError, ApiResult, Uuid};
 
-const MAX_TEAM_NAME_LENGTH: usize = 100;
 const MAX_TEAMS_PER_ORG: usize = 50;
-
-fn validate_and_trim_team_name(name: String) -> ApiResult<String> {
-    let trimmed = name.trim().to_string();
-    if trimmed.is_empty() {
-        return Err(ApiError::client_error(
-            "Team name cannot be empty.".to_string(),
-        ));
-    }
-    if trimmed.len() > MAX_TEAM_NAME_LENGTH {
-        return Err(ApiError::client_error(format!(
-            "Team name cannot exceed {MAX_TEAM_NAME_LENGTH} characters."
-        )));
-    }
-    Ok(trimmed)
-}
 
 pub fn list_my_teams(caller: Principal) -> ApiResult<ListTeamsResponse> {
     let user_id = user_profile_repository::assert_user_id_by_principal(&caller)?;
@@ -53,7 +38,7 @@ pub fn create_team(caller: &Principal, req: CreateTeamRequest) -> ApiResult<Crea
     let org_id = Uuid::try_from(req.org_id.as_str())?;
     let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
     organization_repository::assert_user_in_org(user_id, org_id)?;
-    let name = validate_and_trim_team_name(req.name)?;
+    let name = TeamName::try_from(req.name)?;
 
     if team_repository::has_at_least_n_org_teams(org_id, MAX_TEAMS_PER_ORG) {
         return Err(ApiError::client_error(format!(
@@ -61,7 +46,10 @@ pub fn create_team(caller: &Principal, req: CreateTeamRequest) -> ApiResult<Crea
         )));
     }
 
-    let team = Team { org_id, name };
+    let team = Team {
+        org_id,
+        name: name.into_inner(),
+    };
     let team_id = team_repository::create_team(user_id, org_id, team.clone());
 
     Ok(map_team_to_response(team_id, team))
@@ -83,11 +71,11 @@ pub fn update_team(caller: &Principal, req: UpdateTeamRequest) -> ApiResult<Upda
     let existing = team_repository::get_team(team_id)
         .ok_or_else(|| ApiError::client_error(format!("Team with id {team_id} does not exist.")))?;
     organization_repository::assert_user_in_org(user_id, existing.org_id)?;
-    let name = validate_and_trim_team_name(req.name)?;
+    let name = TeamName::try_from(req.name)?;
 
     let team = Team {
         org_id: existing.org_id,
-        name,
+        name: name.into_inner(),
     };
     team_repository::update_team(team_id, team.clone())?;
 

--- a/src/backend/src/validation/mod.rs
+++ b/src/backend/src/validation/mod.rs
@@ -1,0 +1,3 @@
+mod name;
+
+pub use name::{OrgName, TeamName};

--- a/src/backend/src/validation/name.rs
+++ b/src/backend/src/validation/name.rs
@@ -1,0 +1,109 @@
+use canister_utils::{ApiError, ApiResult};
+
+const MAX_ORG_NAME_LENGTH: usize = 100;
+const MAX_TEAM_NAME_LENGTH: usize = 100;
+
+fn validate_bounded_name(subject: &str, value: String, max: usize) -> ApiResult<String> {
+    let trimmed = value.trim().to_string();
+    if trimmed.is_empty() {
+        return Err(ApiError::client_error(format!(
+            "{subject} cannot be empty."
+        )));
+    }
+    if trimmed.len() > max {
+        return Err(ApiError::client_error(format!(
+            "{subject} cannot exceed {max} characters."
+        )));
+    }
+    Ok(trimmed)
+}
+
+#[derive(Debug, Clone)]
+pub struct OrgName(String);
+
+impl OrgName {
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl TryFrom<String> for OrgName {
+    type Error = ApiError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        validate_bounded_name("Organization name", value, MAX_ORG_NAME_LENGTH).map(OrgName)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TeamName(String);
+
+impl TeamName {
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl TryFrom<String> for TeamName {
+    type Error = ApiError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        validate_bounded_name("Team name", value, MAX_TEAM_NAME_LENGTH).map(TeamName)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn org_name_trims_whitespace() {
+        let name = OrgName::try_from("  Acme  ".to_string()).unwrap();
+        assert_eq!(name.into_inner(), "Acme");
+    }
+
+    #[test]
+    fn org_name_rejects_empty() {
+        let err = OrgName::try_from("".to_string()).unwrap_err();
+        assert!(err.message().contains("Organization name cannot be empty"));
+    }
+
+    #[test]
+    fn org_name_rejects_whitespace_only() {
+        let err = OrgName::try_from("   ".to_string()).unwrap_err();
+        assert!(err.message().contains("Organization name cannot be empty"));
+    }
+
+    #[test]
+    fn org_name_rejects_too_long() {
+        let long = "a".repeat(MAX_ORG_NAME_LENGTH + 1);
+        let err = OrgName::try_from(long).unwrap_err();
+        assert!(err.message().contains("cannot exceed"));
+    }
+
+    #[test]
+    fn org_name_accepts_max_length() {
+        let at_max = "a".repeat(MAX_ORG_NAME_LENGTH);
+        let name = OrgName::try_from(at_max.clone()).unwrap();
+        assert_eq!(name.into_inner(), at_max);
+    }
+
+    #[test]
+    fn team_name_trims_whitespace() {
+        let name = TeamName::try_from("  Platform  ".to_string()).unwrap();
+        assert_eq!(name.into_inner(), "Platform");
+    }
+
+    #[test]
+    fn team_name_rejects_empty() {
+        let err = TeamName::try_from("".to_string()).unwrap_err();
+        assert!(err.message().contains("Team name cannot be empty"));
+    }
+
+    #[test]
+    fn team_name_rejects_too_long() {
+        let long = "a".repeat(MAX_TEAM_NAME_LENGTH + 1);
+        let err = TeamName::try_from(long).unwrap_err();
+        assert!(err.message().contains("cannot exceed"));
+    }
+}


### PR DESCRIPTION
Extract org/team name validation rules into reusable newtype wrappers in a new `validation` module. Services construct OrgName/TeamName from request strings via TryFrom, so invalid names can no longer reach the domain layer. Error messages and limits are unchanged.

This establishes a pattern for validating future DTO fields without pulling in a dedicated validation crate.