### PR TITLE
feat: add invitation flow for organizations and teams

### DIFF
--- a/src/backend-api/backend.did
+++ b/src/backend-api/backend.did
@@ -2,6 +2,7 @@ import service "./candid/approval_policies.did";
 import service "./candid/canister.did";
 import service "./candid/cycles_ledger.did";
 import service "./candid/http.did";
+import service "./candid/invite.did";
 import service "./candid/organization.did";
 import service "./candid/project.did";
 import service "./candid/proposal.did";

--- a/src/backend-api/candid/invite.did
+++ b/src/backend-api/candid/invite.did
@@ -1,0 +1,87 @@
+import "../../canister-utils/error.did";
+
+type InviteTarget = variant {
+  Email : text;
+  UserId : text;
+  Principal : principal;
+};
+
+type InviteStatus = variant {
+  Pending;
+  Accepted;
+  Declined;
+  Revoked;
+};
+
+type OrgInvite = record {
+  id : text;
+  org_id : text;
+  org_name : text;
+  created_by : text;
+  created_at_ns : nat64;
+  expires_at_ns : nat64;
+  target : InviteTarget;
+  status : InviteStatus;
+};
+
+type CreateOrgInviteRequest = record {
+  org_id : text;
+  target : InviteTarget;
+};
+
+type CreateOrgInviteResponse = variant {
+  Ok : record {
+    invite : OrgInvite;
+  };
+  Err : ApiError;
+};
+
+type ListOrgInvitesRequest = record {
+  org_id : text;
+};
+
+type ListOrgInvitesResponse = variant {
+  Ok : vec OrgInvite;
+  Err : ApiError;
+};
+
+type ListMyInvitesResponse = variant {
+  Ok : vec OrgInvite;
+  Err : ApiError;
+};
+
+type RevokeOrgInviteRequest = record {
+  invite_id : text;
+};
+
+type RevokeOrgInviteResponse = variant {
+  Ok : record {};
+  Err : ApiError;
+};
+
+type AcceptOrgInviteRequest = record {
+  invite_id : text;
+};
+
+type AcceptOrgInviteResponse = variant {
+  Ok : record {};
+  Err : ApiError;
+};
+
+type DeclineOrgInviteRequest = record {
+  invite_id : text;
+};
+
+type DeclineOrgInviteResponse = variant {
+  Ok : record {};
+  Err : ApiError;
+};
+
+service : {
+  create_org_invite : (CreateOrgInviteRequest) -> (CreateOrgInviteResponse);
+  list_org_invites : (ListOrgInvitesRequest) -> (ListOrgInvitesResponse) query;
+  revoke_org_invite : (RevokeOrgInviteRequest) -> (RevokeOrgInviteResponse);
+  list_my_invites : () -> (ListMyInvitesResponse) query;
+  accept_org_invite : (AcceptOrgInviteRequest) -> (AcceptOrgInviteResponse);
+  decline_org_invite : (DeclineOrgInviteRequest) -> (DeclineOrgInviteResponse);
+};

--- a/src/backend-api/candid/organization.did
+++ b/src/backend-api/candid/organization.did
@@ -48,6 +48,21 @@ type DeleteOrganizationResponse = variant {
   Err : ApiError;
 };
 
+type ListOrgUsersRequest = record {
+  org_id : text;
+};
+
+type OrgUser = record {
+  id : text;
+  email : opt text;
+  email_verified : bool;
+};
+
+type ListOrgUsersResponse = variant {
+  Ok : vec OrgUser;
+  Err : ApiError;
+};
+
 type Organization = record {
   id : text;
   name : text;
@@ -59,4 +74,5 @@ service : {
   get_organization : (GetOrganizationRequest) -> (GetOrganizationResponse) query;
   update_organization : (UpdateOrganizationRequest) -> (UpdateOrganizationResponse);
   delete_organization : (DeleteOrganizationRequest) -> (DeleteOrganizationResponse);
+  list_org_users : (ListOrgUsersRequest) -> (ListOrgUsersResponse) query;
 };

--- a/src/backend-api/candid/team.did
+++ b/src/backend-api/candid/team.did
@@ -63,6 +63,21 @@ type AddUserToTeamResponse = variant {
   Err : ApiError;
 };
 
+type ListTeamUsersRequest = record {
+  team_id : text;
+};
+
+type TeamUser = record {
+  id : text;
+  email : opt text;
+  email_verified : bool;
+};
+
+type ListTeamUsersResponse = variant {
+  Ok : vec TeamUser;
+  Err : ApiError;
+};
+
 type Team = record {
   id : text;
   name : text;
@@ -76,4 +91,5 @@ service : {
   update_team : (UpdateTeamRequest) -> (UpdateTeamResponse);
   delete_team : (DeleteTeamRequest) -> (DeleteTeamResponse);
   add_user_to_team : (AddUserToTeamRequest) -> (AddUserToTeamResponse);
+  list_team_users : (ListTeamUsersRequest) -> (ListTeamUsersResponse) query;
 };

--- a/src/backend-tests/src/tests/invite.spec.ts
+++ b/src/backend-tests/src/tests/invite.spec.ts
@@ -1,0 +1,540 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  anonymousIdentity,
+  createTestJwt,
+  extractOkResponse,
+  noOrgError,
+  noProfileError,
+  PRIVATE_KEY,
+  TestDriver,
+  unauthenticatedError,
+} from '../support';
+import { generateRandomIdentity } from '@dfinity/pic';
+
+describe('Org Invites', () => {
+  let driver: TestDriver;
+  const fakeOrgId = '939ede22-1f0d-4e63-ba18-bed4b09212b5';
+  const fakeInviteId = '839ede22-1f0d-4e63-ba18-bed4b09212b5';
+  const fakeUserId = '11111111-1111-1111-1111-111111111111';
+  const DAY_MS = 24 * 60 * 60 * 1000;
+  const TTL_MS = 7 * DAY_MS;
+
+  beforeEach(async () => {
+    driver = await TestDriver.create();
+  });
+
+  afterEach(async () => {
+    await driver.tearDown();
+  });
+
+  async function setupUser() {
+    const identity = generateRandomIdentity();
+    driver.actor.setIdentity(identity);
+    const profileRes = await driver.actor.create_my_user_profile();
+    const profile = extractOkResponse(profileRes);
+    const orgsRes = await driver.actor.list_my_organizations();
+    const [org] = extractOkResponse(orgsRes);
+    return { identity, profile, org };
+  }
+
+  async function setVerifiedEmail(email: string): Promise<void> {
+    await driver.actor.update_my_user_profile({ email: [email] });
+    const token = await createTestJwt(email, PRIVATE_KEY);
+    const res = await driver.actor.verify_my_email({ token });
+    extractOkResponse(res);
+  }
+
+  describe('create_org_invite', () => {
+    it('should return an error for an anonymous user', async () => {
+      driver.actor.setIdentity(anonymousIdentity);
+      const res = await driver.actor.create_org_invite({
+        org_id: fakeOrgId,
+        target: { Email: 'bob@example.com' },
+      });
+      expect(res).toEqual(unauthenticatedError);
+    });
+
+    it('should return an error if the user has no profile', async () => {
+      const identity = generateRandomIdentity();
+      driver.actor.setIdentity(identity);
+      const res = await driver.actor.create_org_invite({
+        org_id: fakeOrgId,
+        target: { Email: 'bob@example.com' },
+      });
+      expect(res).toEqual(noProfileError(identity.getPrincipal()));
+    });
+
+    it('should return an error if the caller is not in the org', async () => {
+      const alice = await setupUser();
+
+      const bob = await setupUser();
+      const res = await driver.actor.create_org_invite({
+        org_id: alice.org.id,
+        target: { Email: 'carol@example.com' },
+      });
+      expect(res).toEqual(noOrgError(bob.profile.id, alice.org.id));
+    });
+
+    it('should return an error for an invalid email', async () => {
+      const { org } = await setupUser();
+      const res = await driver.actor.create_org_invite({
+        org_id: org.id,
+        target: { Email: 'not-an-email' },
+      });
+      expect(res).toEqual({
+        Err: {
+          code: [{ ClientError: {} }],
+          message: "Email must contain an '@' symbol.",
+        },
+      });
+    });
+
+    it('should create an invite targeting an email', async () => {
+      const { org, profile } = await setupUser();
+      const res = await driver.actor.create_org_invite({
+        org_id: org.id,
+        target: { Email: 'bob@example.com' },
+      });
+      const { invite } = extractOkResponse(res);
+      expect(invite.org_id).toBe(org.id);
+      expect(invite.org_name).toBe(org.name);
+      expect(invite.created_by).toBe(profile.id);
+      expect(invite.target).toEqual({ Email: 'bob@example.com' });
+      expect(invite.status).toEqual({ Pending: null });
+      expect(invite.expires_at_ns).toBeGreaterThan(invite.created_at_ns);
+    });
+
+    it('should create an invite targeting a user id', async () => {
+      const { org } = await setupUser();
+      const res = await driver.actor.create_org_invite({
+        org_id: org.id,
+        target: { UserId: fakeUserId },
+      });
+      const { invite } = extractOkResponse(res);
+      expect(invite.target).toEqual({ UserId: fakeUserId });
+    });
+
+    it('should create an invite targeting a principal', async () => {
+      const { org } = await setupUser();
+      const target = generateRandomIdentity().getPrincipal();
+      const res = await driver.actor.create_org_invite({
+        org_id: org.id,
+        target: { Principal: target },
+      });
+      const { invite } = extractOkResponse(res);
+      expect(invite.target).toEqual({ Principal: target });
+    });
+
+    it('should reject the 11th pending invite in an org', async () => {
+      const { org } = await setupUser();
+      for (let i = 0; i < 10; i++) {
+        const r = await driver.actor.create_org_invite({
+          org_id: org.id,
+          target: { Email: `invitee${i}@example.com` },
+        });
+        extractOkResponse(r);
+      }
+      const res = await driver.actor.create_org_invite({
+        org_id: org.id,
+        target: { Email: 'one-too-many@example.com' },
+      });
+      expect(res).toEqual({
+        Err: {
+          code: [{ ClientError: {} }],
+          message:
+            'Cannot have more than 10 pending invites per organization.',
+        },
+      });
+    });
+
+    it('should sweep expired invites before enforcing the pending cap', async () => {
+      const { org } = await setupUser();
+      for (let i = 0; i < 10; i++) {
+        const r = await driver.actor.create_org_invite({
+          org_id: org.id,
+          target: { Email: `invitee${i}@example.com` },
+        });
+        extractOkResponse(r);
+      }
+
+      await driver.pic.advanceTime(TTL_MS + 1000);
+      await driver.pic.tick();
+
+      // Previous 10 are expired; the sweep on create should let an 11th through.
+      const res = await driver.actor.create_org_invite({
+        org_id: org.id,
+        target: { Email: 'fresh@example.com' },
+      });
+      extractOkResponse(res);
+    });
+  });
+
+  describe('list_org_invites', () => {
+    it('should return an error for an anonymous user', async () => {
+      driver.actor.setIdentity(anonymousIdentity);
+      const res = await driver.actor.list_org_invites({ org_id: fakeOrgId });
+      expect(res).toEqual(unauthenticatedError);
+    });
+
+    it('should return an error if the caller is not in the org', async () => {
+      const alice = await setupUser();
+      const bob = await setupUser();
+      const res = await driver.actor.list_org_invites({ org_id: alice.org.id });
+      expect(res).toEqual(noOrgError(bob.profile.id, alice.org.id));
+    });
+
+    it('should list pending invites and omit expired ones', async () => {
+      const { org } = await setupUser();
+      await driver.actor.create_org_invite({
+        org_id: org.id,
+        target: { Email: 'bob@example.com' },
+      });
+      const beforeRes = await driver.actor.list_org_invites({ org_id: org.id });
+      expect(extractOkResponse(beforeRes)).toHaveLength(1);
+
+      await driver.pic.advanceTime(TTL_MS + 1000);
+      await driver.pic.tick();
+
+      const afterRes = await driver.actor.list_org_invites({ org_id: org.id });
+      expect(extractOkResponse(afterRes)).toHaveLength(0);
+    });
+  });
+
+  describe('revoke_org_invite', () => {
+    it('should return an error for an anonymous user', async () => {
+      driver.actor.setIdentity(anonymousIdentity);
+      const res = await driver.actor.revoke_org_invite({
+        invite_id: fakeInviteId,
+      });
+      expect(res).toEqual(unauthenticatedError);
+    });
+
+    it('should return an error for a non-existent invite', async () => {
+      await setupUser();
+      const res = await driver.actor.revoke_org_invite({
+        invite_id: fakeInviteId,
+      });
+      expect(res).toEqual({
+        Err: {
+          code: [{ ClientError: {} }],
+          message: `Invite with id ${fakeInviteId} does not exist.`,
+        },
+      });
+    });
+
+    it('should return an error if the caller is not in the inviting org', async () => {
+      const alice = await setupUser();
+      driver.actor.setIdentity(alice.identity);
+      const createRes = await driver.actor.create_org_invite({
+        org_id: alice.org.id,
+        target: { Email: 'bob@example.com' },
+      });
+      const { invite } = extractOkResponse(createRes);
+
+      const bob = await setupUser();
+      const res = await driver.actor.revoke_org_invite({
+        invite_id: invite.id,
+      });
+      expect(res).toEqual(noOrgError(bob.profile.id, alice.org.id));
+    });
+
+    it('should mark the invite as Revoked', async () => {
+      const { org } = await setupUser();
+      const createRes = await driver.actor.create_org_invite({
+        org_id: org.id,
+        target: { Email: 'bob@example.com' },
+      });
+      const { invite } = extractOkResponse(createRes);
+
+      const revokeRes = await driver.actor.revoke_org_invite({
+        invite_id: invite.id,
+      });
+      expect(revokeRes).toEqual({ Ok: {} });
+
+      const listRes = await driver.actor.list_org_invites({ org_id: org.id });
+      const invites = extractOkResponse(listRes);
+      expect(invites).toHaveLength(1);
+      expect(invites[0].status).toEqual({ Revoked: null });
+    });
+
+    it('should error when revoking a non-pending invite', async () => {
+      const { org } = await setupUser();
+      const createRes = await driver.actor.create_org_invite({
+        org_id: org.id,
+        target: { Email: 'bob@example.com' },
+      });
+      const { invite } = extractOkResponse(createRes);
+      await driver.actor.revoke_org_invite({ invite_id: invite.id });
+
+      const res = await driver.actor.revoke_org_invite({
+        invite_id: invite.id,
+      });
+      expect(res).toEqual({
+        Err: {
+          code: [{ ClientError: {} }],
+          message: 'Only pending invites can be revoked.',
+        },
+      });
+    });
+  });
+
+  describe('list_my_invites', () => {
+    it('should return an error for an anonymous user', async () => {
+      driver.actor.setIdentity(anonymousIdentity);
+      const res = await driver.actor.list_my_invites();
+      expect(res).toEqual(unauthenticatedError);
+    });
+
+    it('should return an empty list when no invites exist', async () => {
+      await setupUser();
+      const res = await driver.actor.list_my_invites();
+      expect(extractOkResponse(res)).toEqual([]);
+    });
+
+    it('should match an invite targeted at the user id', async () => {
+      const alice = await setupUser();
+      const bob = await setupUser();
+
+      driver.actor.setIdentity(alice.identity);
+      await driver.actor.create_org_invite({
+        org_id: alice.org.id,
+        target: { UserId: bob.profile.id },
+      });
+
+      driver.actor.setIdentity(bob.identity);
+      const res = await driver.actor.list_my_invites();
+      const invites = extractOkResponse(res);
+      expect(invites).toHaveLength(1);
+      expect(invites[0].org_id).toBe(alice.org.id);
+    });
+
+    it('should match an invite targeted at a principal the user owns', async () => {
+      const alice = await setupUser();
+      const bob = await setupUser();
+
+      driver.actor.setIdentity(alice.identity);
+      await driver.actor.create_org_invite({
+        org_id: alice.org.id,
+        target: { Principal: bob.identity.getPrincipal() },
+      });
+
+      driver.actor.setIdentity(bob.identity);
+      const res = await driver.actor.list_my_invites();
+      expect(extractOkResponse(res)).toHaveLength(1);
+    });
+
+    it('should NOT match an email invite when the email is unverified', async () => {
+      const alice = await setupUser();
+      const bob = await setupUser();
+
+      driver.actor.setIdentity(bob.identity);
+      await driver.actor.update_my_user_profile({
+        email: ['bob@example.com'],
+      });
+
+      driver.actor.setIdentity(alice.identity);
+      await driver.actor.create_org_invite({
+        org_id: alice.org.id,
+        target: { Email: 'bob@example.com' },
+      });
+
+      driver.actor.setIdentity(bob.identity);
+      const res = await driver.actor.list_my_invites();
+      expect(extractOkResponse(res)).toEqual([]);
+    });
+
+    it('should match an email invite once the email is verified', async () => {
+      const alice = await setupUser();
+      const bob = await setupUser();
+
+      driver.actor.setIdentity(bob.identity);
+      await setVerifiedEmail('bob@example.com');
+
+      driver.actor.setIdentity(alice.identity);
+      await driver.actor.create_org_invite({
+        org_id: alice.org.id,
+        target: { Email: 'bob@example.com' },
+      });
+
+      driver.actor.setIdentity(bob.identity);
+      const res = await driver.actor.list_my_invites();
+      expect(extractOkResponse(res)).toHaveLength(1);
+    });
+
+    it('should omit expired invites', async () => {
+      const alice = await setupUser();
+      const bob = await setupUser();
+
+      driver.actor.setIdentity(alice.identity);
+      await driver.actor.create_org_invite({
+        org_id: alice.org.id,
+        target: { UserId: bob.profile.id },
+      });
+
+      await driver.pic.advanceTime(TTL_MS + 1000);
+      await driver.pic.tick();
+
+      driver.actor.setIdentity(bob.identity);
+      const res = await driver.actor.list_my_invites();
+      expect(extractOkResponse(res)).toEqual([]);
+    });
+  });
+
+  describe('accept_org_invite', () => {
+    it('should return an error for an anonymous user', async () => {
+      driver.actor.setIdentity(anonymousIdentity);
+      const res = await driver.actor.accept_org_invite({
+        invite_id: fakeInviteId,
+      });
+      expect(res).toEqual(unauthenticatedError);
+    });
+
+    it('should return an error for a non-existent invite', async () => {
+      await setupUser();
+      const res = await driver.actor.accept_org_invite({
+        invite_id: fakeInviteId,
+      });
+      expect(res).toEqual({
+        Err: {
+          code: [{ ClientError: {} }],
+          message: `Invite with id ${fakeInviteId} does not exist.`,
+        },
+      });
+    });
+
+    it('should reject acceptance by a non-target user', async () => {
+      const alice = await setupUser();
+      const bob = await setupUser();
+      const carol = await setupUser();
+
+      driver.actor.setIdentity(alice.identity);
+      const createRes = await driver.actor.create_org_invite({
+        org_id: alice.org.id,
+        target: { UserId: bob.profile.id },
+      });
+      const { invite } = extractOkResponse(createRes);
+
+      driver.actor.setIdentity(carol.identity);
+      const res = await driver.actor.accept_org_invite({
+        invite_id: invite.id,
+      });
+      expect(res).toEqual({
+        Err: {
+          code: [{ Unauthorized: {} }],
+          message: 'Invite is not addressed to the caller.',
+        },
+      });
+    });
+
+    it('should reject acceptance of an expired invite', async () => {
+      const alice = await setupUser();
+      const bob = await setupUser();
+
+      driver.actor.setIdentity(alice.identity);
+      const createRes = await driver.actor.create_org_invite({
+        org_id: alice.org.id,
+        target: { UserId: bob.profile.id },
+      });
+      const { invite } = extractOkResponse(createRes);
+
+      await driver.pic.advanceTime(TTL_MS + 1000);
+      await driver.pic.tick();
+
+      driver.actor.setIdentity(bob.identity);
+      const res = await driver.actor.accept_org_invite({
+        invite_id: invite.id,
+      });
+      expect(res).toEqual({
+        Err: {
+          code: [{ ClientError: {} }],
+          message: 'Invite has expired.',
+        },
+      });
+    });
+
+    it('should add the user to the org on accept and mark the invite Accepted', async () => {
+      const alice = await setupUser();
+      const bob = await setupUser();
+
+      driver.actor.setIdentity(alice.identity);
+      const createRes = await driver.actor.create_org_invite({
+        org_id: alice.org.id,
+        target: { UserId: bob.profile.id },
+      });
+      const { invite } = extractOkResponse(createRes);
+
+      driver.actor.setIdentity(bob.identity);
+      const acceptRes = await driver.actor.accept_org_invite({
+        invite_id: invite.id,
+      });
+      expect(acceptRes).toEqual({ Ok: {} });
+
+      const orgsRes = await driver.actor.list_my_organizations();
+      const orgs = extractOkResponse(orgsRes);
+      expect(orgs.map(o => o.id)).toContain(alice.org.id);
+
+      driver.actor.setIdentity(alice.identity);
+      const listRes = await driver.actor.list_org_invites({
+        org_id: alice.org.id,
+      });
+      const invites = extractOkResponse(listRes);
+      expect(invites[0].status).toEqual({ Accepted: null });
+    });
+
+    it('should reject a second acceptance of the same invite', async () => {
+      const alice = await setupUser();
+      const bob = await setupUser();
+
+      driver.actor.setIdentity(alice.identity);
+      const createRes = await driver.actor.create_org_invite({
+        org_id: alice.org.id,
+        target: { UserId: bob.profile.id },
+      });
+      const { invite } = extractOkResponse(createRes);
+
+      driver.actor.setIdentity(bob.identity);
+      await driver.actor.accept_org_invite({ invite_id: invite.id });
+
+      const res = await driver.actor.accept_org_invite({
+        invite_id: invite.id,
+      });
+      expect(res).toEqual({
+        Err: {
+          code: [{ ClientError: {} }],
+          message: 'Invite is no longer pending.',
+        },
+      });
+    });
+  });
+
+  describe('decline_org_invite', () => {
+    it('should mark the invite Declined without adding the user to the org', async () => {
+      const alice = await setupUser();
+      const bob = await setupUser();
+
+      driver.actor.setIdentity(alice.identity);
+      const createRes = await driver.actor.create_org_invite({
+        org_id: alice.org.id,
+        target: { UserId: bob.profile.id },
+      });
+      const { invite } = extractOkResponse(createRes);
+
+      driver.actor.setIdentity(bob.identity);
+      const declineRes = await driver.actor.decline_org_invite({
+        invite_id: invite.id,
+      });
+      expect(declineRes).toEqual({ Ok: {} });
+
+      const orgsRes = await driver.actor.list_my_organizations();
+      const orgs = extractOkResponse(orgsRes);
+      expect(orgs.map(o => o.id)).not.toContain(alice.org.id);
+
+      driver.actor.setIdentity(alice.identity);
+      const listRes = await driver.actor.list_org_invites({
+        org_id: alice.org.id,
+      });
+      const invites = extractOkResponse(listRes);
+      expect(invites[0].status).toEqual({ Declined: null });
+    });
+  });
+});

--- a/src/backend-tests/src/tests/invite.spec.ts
+++ b/src/backend-tests/src/tests/invite.spec.ts
@@ -141,8 +141,7 @@ describe('Org Invites', () => {
       expect(res).toEqual({
         Err: {
           code: [{ ClientError: {} }],
-          message:
-            'Cannot have more than 10 pending invites per organization.',
+          message: 'Cannot have more than 10 pending invites per organization.',
         },
       });
     });
@@ -181,6 +180,34 @@ describe('Org Invites', () => {
       const bob = await setupUser();
       const res = await driver.actor.list_org_invites({ org_id: alice.org.id });
       expect(res).toEqual(noOrgError(bob.profile.id, alice.org.id));
+    });
+
+    it('should not show invites created by other org members', async () => {
+      const alice = await setupUser();
+      const bob = await setupUser();
+
+      // Bob joins alice's org.
+      driver.actor.setIdentity(alice.identity);
+      const joinRes = await driver.actor.create_org_invite({
+        org_id: alice.org.id,
+        target: { UserId: bob.profile.id },
+      });
+      const { invite: joinInvite } = extractOkResponse(joinRes);
+      driver.actor.setIdentity(bob.identity);
+      extractOkResponse(
+        await driver.actor.accept_org_invite({ invite_id: joinInvite.id }),
+      );
+
+      // Alice invites carol; bob (same org, not the creator) must not see it.
+      driver.actor.setIdentity(alice.identity);
+      await driver.actor.create_org_invite({
+        org_id: alice.org.id,
+        target: { Email: 'carol@example.com' },
+      });
+
+      driver.actor.setIdentity(bob.identity);
+      const res = await driver.actor.list_org_invites({ org_id: alice.org.id });
+      expect(extractOkResponse(res)).toEqual([]);
     });
 
     it('should list pending invites and omit expired ones', async () => {
@@ -255,6 +282,42 @@ describe('Org Invites', () => {
       const invites = extractOkResponse(listRes);
       expect(invites).toHaveLength(1);
       expect(invites[0].status).toEqual({ Revoked: null });
+    });
+
+    it('should reject revocation by an org member who did not create the invite', async () => {
+      const alice = await setupUser();
+      const bob = await setupUser();
+
+      // Bob joins alice's org via an invite he accepts.
+      driver.actor.setIdentity(alice.identity);
+      const joinRes = await driver.actor.create_org_invite({
+        org_id: alice.org.id,
+        target: { UserId: bob.profile.id },
+      });
+      const { invite: joinInvite } = extractOkResponse(joinRes);
+      driver.actor.setIdentity(bob.identity);
+      extractOkResponse(
+        await driver.actor.accept_org_invite({ invite_id: joinInvite.id }),
+      );
+
+      // Alice creates an invite for carol; bob (same org) must not revoke it.
+      driver.actor.setIdentity(alice.identity);
+      const createRes = await driver.actor.create_org_invite({
+        org_id: alice.org.id,
+        target: { Email: 'carol@example.com' },
+      });
+      const { invite } = extractOkResponse(createRes);
+
+      driver.actor.setIdentity(bob.identity);
+      const res = await driver.actor.revoke_org_invite({
+        invite_id: invite.id,
+      });
+      expect(res).toEqual({
+        Err: {
+          code: [{ Unauthorized: {} }],
+          message: 'Only the inviter can revoke this invite.',
+        },
+      });
     });
 
     it('should error when revoking a non-pending invite', async () => {

--- a/src/backend-tests/src/tests/invite.spec.ts
+++ b/src/backend-tests/src/tests/invite.spec.ts
@@ -34,6 +34,7 @@ describe('Org Invites', () => {
     const profile = extractOkResponse(profileRes);
     const orgsRes = await driver.actor.list_my_organizations();
     const [org] = extractOkResponse(orgsRes);
+    if (!org) throw new Error('expected default org');
     return { identity, profile, org };
   }
 
@@ -123,6 +124,64 @@ describe('Org Invites', () => {
       });
       const { invite } = extractOkResponse(res);
       expect(invite.target).toEqual({ Principal: target });
+    });
+
+    it('should reject inviting a user id who is already an org member', async () => {
+      const alice = await setupUser();
+      const bob = await setupUser();
+
+      // Bob joins alice's org via an accepted invite.
+      driver.actor.setIdentity(alice.identity);
+      const joinRes = await driver.actor.create_org_invite({
+        org_id: alice.org.id,
+        target: { UserId: bob.profile.id },
+      });
+      const { invite: joinInvite } = extractOkResponse(joinRes);
+      driver.actor.setIdentity(bob.identity);
+      extractOkResponse(
+        await driver.actor.accept_org_invite({ invite_id: joinInvite.id }),
+      );
+
+      // A second invite targeting bob (already a member) must be rejected.
+      driver.actor.setIdentity(alice.identity);
+      const res = await driver.actor.create_org_invite({
+        org_id: alice.org.id,
+        target: { UserId: bob.profile.id },
+      });
+      expect(res).toEqual({
+        Err: {
+          code: [{ ClientError: {} }],
+          message: 'User is already a member of this organization.',
+        },
+      });
+    });
+
+    it('should reject inviting a principal who is already an org member', async () => {
+      const alice = await setupUser();
+      const bob = await setupUser();
+
+      driver.actor.setIdentity(alice.identity);
+      const joinRes = await driver.actor.create_org_invite({
+        org_id: alice.org.id,
+        target: { UserId: bob.profile.id },
+      });
+      const { invite: joinInvite } = extractOkResponse(joinRes);
+      driver.actor.setIdentity(bob.identity);
+      extractOkResponse(
+        await driver.actor.accept_org_invite({ invite_id: joinInvite.id }),
+      );
+
+      driver.actor.setIdentity(alice.identity);
+      const res = await driver.actor.create_org_invite({
+        org_id: alice.org.id,
+        target: { Principal: bob.identity.getPrincipal() },
+      });
+      expect(res).toEqual({
+        Err: {
+          code: [{ ClientError: {} }],
+          message: 'User is already a member of this organization.',
+        },
+      });
     });
 
     it('should reject the 11th pending invite in an org', async () => {
@@ -281,7 +340,7 @@ describe('Org Invites', () => {
       const listRes = await driver.actor.list_org_invites({ org_id: org.id });
       const invites = extractOkResponse(listRes);
       expect(invites).toHaveLength(1);
-      expect(invites[0].status).toEqual({ Revoked: null });
+      expect(invites[0]!.status).toEqual({ Revoked: null });
     });
 
     it('should reject revocation by an org member who did not create the invite', async () => {
@@ -368,7 +427,7 @@ describe('Org Invites', () => {
       const res = await driver.actor.list_my_invites();
       const invites = extractOkResponse(res);
       expect(invites).toHaveLength(1);
-      expect(invites[0].org_id).toBe(alice.org.id);
+      expect(invites[0]!.org_id).toBe(alice.org.id);
     });
 
     it('should match an invite targeted at a principal the user owns', async () => {
@@ -541,7 +600,7 @@ describe('Org Invites', () => {
         org_id: alice.org.id,
       });
       const invites = extractOkResponse(listRes);
-      expect(invites[0].status).toEqual({ Accepted: null });
+      expect(invites[0]!.status).toEqual({ Accepted: null });
     });
 
     it('should reject a second acceptance of the same invite', async () => {
@@ -597,7 +656,7 @@ describe('Org Invites', () => {
         org_id: alice.org.id,
       });
       const invites = extractOkResponse(listRes);
-      expect(invites[0].status).toEqual({ Declined: null });
+      expect(invites[0]!.status).toEqual({ Declined: null });
     });
   });
 });

--- a/src/backend-tests/src/tests/organization.spec.ts
+++ b/src/backend-tests/src/tests/organization.spec.ts
@@ -343,17 +343,17 @@ describe('Organizations', () => {
     it('should return an error if the caller is not in the org', async () => {
       const alice = await setupUser();
       const bob = await setupUser();
-      const res = await driver.actor.list_org_users({ org_id: alice.org.id });
-      expect(res).toEqual(noOrgError(bob.profile.id, alice.org.id));
+      const res = await driver.actor.list_org_users({ org_id: alice.org!.id });
+      expect(res).toEqual(noOrgError(bob.profile.id, alice.org!.id));
     });
 
     it('should list the sole member of a fresh org', async () => {
       const { org, profile } = await setupUser();
-      const res = await driver.actor.list_org_users({ org_id: org.id });
+      const res = await driver.actor.list_org_users({ org_id: org!.id });
       const users = extractOkResponse(res);
       expect(users).toHaveLength(1);
-      expect(users[0].id).toBe(profile.id);
-      expect(users[0].email_verified).toBe(false);
+      expect(users[0]!.id).toBe(profile.id);
+      expect(users[0]!.email_verified).toBe(false);
     });
 
     it('should include a user who joined via invite acceptance', async () => {
@@ -362,7 +362,7 @@ describe('Organizations', () => {
 
       driver.actor.setIdentity(alice.identity);
       const inviteRes = await driver.actor.create_org_invite({
-        org_id: alice.org.id,
+        org_id: alice.org!.id,
         target: { UserId: bob.profile.id },
       });
       const { invite } = extractOkResponse(inviteRes);
@@ -371,7 +371,7 @@ describe('Organizations', () => {
       await driver.actor.accept_org_invite({ invite_id: invite.id });
 
       driver.actor.setIdentity(alice.identity);
-      const res = await driver.actor.list_org_users({ org_id: alice.org.id });
+      const res = await driver.actor.list_org_users({ org_id: alice.org!.id });
       const users = extractOkResponse(res);
       expect(users.map(u => u.id).sort()).toEqual(
         [alice.profile.id, bob.profile.id].sort(),

--- a/src/backend-tests/src/tests/organization.spec.ts
+++ b/src/backend-tests/src/tests/organization.spec.ts
@@ -332,4 +332,50 @@ describe('Organizations', () => {
       expect(orgs.map(o => o.id)).not.toContain(newOrg.id);
     });
   });
+
+  describe('list_org_users', () => {
+    it('should return an error for an anonymous user', async () => {
+      driver.actor.setIdentity(anonymousIdentity);
+      const res = await driver.actor.list_org_users({ org_id: fakeOrgId });
+      expect(res).toEqual(unauthenticatedError);
+    });
+
+    it('should return an error if the caller is not in the org', async () => {
+      const alice = await setupUser();
+      const bob = await setupUser();
+      const res = await driver.actor.list_org_users({ org_id: alice.org.id });
+      expect(res).toEqual(noOrgError(bob.profile.id, alice.org.id));
+    });
+
+    it('should list the sole member of a fresh org', async () => {
+      const { org, profile } = await setupUser();
+      const res = await driver.actor.list_org_users({ org_id: org.id });
+      const users = extractOkResponse(res);
+      expect(users).toHaveLength(1);
+      expect(users[0].id).toBe(profile.id);
+      expect(users[0].email_verified).toBe(false);
+    });
+
+    it('should include a user who joined via invite acceptance', async () => {
+      const alice = await setupUser();
+      const bob = await setupUser();
+
+      driver.actor.setIdentity(alice.identity);
+      const inviteRes = await driver.actor.create_org_invite({
+        org_id: alice.org.id,
+        target: { UserId: bob.profile.id },
+      });
+      const { invite } = extractOkResponse(inviteRes);
+
+      driver.actor.setIdentity(bob.identity);
+      await driver.actor.accept_org_invite({ invite_id: invite.id });
+
+      driver.actor.setIdentity(alice.identity);
+      const res = await driver.actor.list_org_users({ org_id: alice.org.id });
+      const users = extractOkResponse(res);
+      expect(users.map(u => u.id).sort()).toEqual(
+        [alice.profile.id, bob.profile.id].sort(),
+      );
+    });
+  });
 });

--- a/src/backend-tests/src/tests/team.spec.ts
+++ b/src/backend-tests/src/tests/team.spec.ts
@@ -499,7 +499,7 @@ describe('Teams', () => {
       // Alice invites Bob to her org, Bob accepts.
       driver.actor.setIdentity(alice.identity);
       const inviteRes = await driver.actor.create_org_invite({
-        org_id: alice.org.id,
+        org_id: alice.org!.id,
         target: { UserId: bob.profile.id },
       });
       const { invite } = extractOkResponse(inviteRes);
@@ -524,14 +524,14 @@ describe('Teams', () => {
     it('should list team members', async () => {
       const alice = await setupUser();
       const teamsRes = await driver.actor.list_org_teams({
-        org_id: alice.org.id,
+        org_id: alice.org!.id,
       });
       const [defaultTeam] = extractOkResponse(teamsRes);
 
       const bob = await setupUser();
       driver.actor.setIdentity(alice.identity);
       const inviteRes = await driver.actor.create_org_invite({
-        org_id: alice.org.id,
+        org_id: alice.org!.id,
         target: { UserId: bob.profile.id },
       });
       const { invite } = extractOkResponse(inviteRes);
@@ -540,12 +540,12 @@ describe('Teams', () => {
 
       driver.actor.setIdentity(alice.identity);
       await driver.actor.add_user_to_team({
-        team_id: defaultTeam.id,
+        team_id: defaultTeam!.id,
         user_id: bob.profile.id,
       });
 
       const listRes = await driver.actor.list_team_users({
-        team_id: defaultTeam.id,
+        team_id: defaultTeam!.id,
       });
       const members = extractOkResponse(listRes);
       expect(members.map(m => m.id).sort()).toEqual(
@@ -556,15 +556,15 @@ describe('Teams', () => {
     it('should reject list_team_users for a non-member', async () => {
       const alice = await setupUser();
       const teamsRes = await driver.actor.list_org_teams({
-        org_id: alice.org.id,
+        org_id: alice.org!.id,
       });
       const [defaultTeam] = extractOkResponse(teamsRes);
 
       const bob = await setupUser();
       const res = await driver.actor.list_team_users({
-        team_id: defaultTeam.id,
+        team_id: defaultTeam!.id,
       });
-      expect(res).toEqual(noOrgError(bob.profile.id, alice.org.id));
+      expect(res).toEqual(noOrgError(bob.profile.id, alice.org!.id));
     });
 
     it('should be idempotent when adding an existing member', async () => {

--- a/src/backend-tests/src/tests/team.spec.ts
+++ b/src/backend-tests/src/tests/team.spec.ts
@@ -486,9 +486,7 @@ describe('Teams', () => {
       expect(res).toEqual(noOrgError(bob.profile.id, alice.org!.id));
     });
 
-    // Blocked: no "add user to org" API exists yet, so we cannot
-    // get Bob into Alice's org to test the happy path.
-    it.skip('should add a user to the team', async () => {
+    it('should add a user to the team after they accept an org invite', async () => {
       const alice = await setupUser();
       const createRes = await driver.actor.create_team({
         org_id: alice.org!.id,
@@ -497,7 +495,18 @@ describe('Teams', () => {
       const { team } = extractOkResponse(createRes);
 
       const bob = await setupUser();
-      // TODO: add Bob to Alice's org here once the API exists.
+
+      // Alice invites Bob to her org, Bob accepts.
+      driver.actor.setIdentity(alice.identity);
+      const inviteRes = await driver.actor.create_org_invite({
+        org_id: alice.org.id,
+        target: { UserId: bob.profile.id },
+      });
+      const { invite } = extractOkResponse(inviteRes);
+      driver.actor.setIdentity(bob.identity);
+      await driver.actor.accept_org_invite({ invite_id: invite.id });
+
+      // Alice can now add Bob to the team.
       driver.actor.setIdentity(alice.identity);
       const addRes = await driver.actor.add_user_to_team({
         team_id: team.id,
@@ -510,6 +519,52 @@ describe('Teams', () => {
       const teamsRes = await driver.actor.list_my_teams();
       const teams = extractOkResponse(teamsRes);
       expect(teams.map(t => t.id)).toContain(team.id);
+    });
+
+    it('should list team members', async () => {
+      const alice = await setupUser();
+      const teamsRes = await driver.actor.list_org_teams({
+        org_id: alice.org.id,
+      });
+      const [defaultTeam] = extractOkResponse(teamsRes);
+
+      const bob = await setupUser();
+      driver.actor.setIdentity(alice.identity);
+      const inviteRes = await driver.actor.create_org_invite({
+        org_id: alice.org.id,
+        target: { UserId: bob.profile.id },
+      });
+      const { invite } = extractOkResponse(inviteRes);
+      driver.actor.setIdentity(bob.identity);
+      await driver.actor.accept_org_invite({ invite_id: invite.id });
+
+      driver.actor.setIdentity(alice.identity);
+      await driver.actor.add_user_to_team({
+        team_id: defaultTeam.id,
+        user_id: bob.profile.id,
+      });
+
+      const listRes = await driver.actor.list_team_users({
+        team_id: defaultTeam.id,
+      });
+      const members = extractOkResponse(listRes);
+      expect(members.map(m => m.id).sort()).toEqual(
+        [alice.profile.id, bob.profile.id].sort(),
+      );
+    });
+
+    it('should reject list_team_users for a non-member', async () => {
+      const alice = await setupUser();
+      const teamsRes = await driver.actor.list_org_teams({
+        org_id: alice.org.id,
+      });
+      const [defaultTeam] = extractOkResponse(teamsRes);
+
+      const bob = await setupUser();
+      const res = await driver.actor.list_team_users({
+        team_id: defaultTeam.id,
+      });
+      expect(res).toEqual(noOrgError(bob.profile.id, alice.org.id));
     });
 
     it('should be idempotent when adding an existing member', async () => {

--- a/src/backend/src/constants.rs
+++ b/src/backend/src/constants.rs
@@ -16,3 +16,12 @@ pub const DEFAULT_PAGINATION_PAGE: u64 = 1;
 /// This number should not exceed the length of the canister output queue, which
 /// is currently 500.
 pub const MAX_CALLS_PER_BATCH: usize = 490;
+
+// Organization invites expire 7 days after creation. Expired invites are
+// filtered on read and swept lazily when a new invite is created on the
+// same org.
+pub const INVITE_TTL_NS: u64 = 7 * 24 * 60 * 60 * 1_000_000_000;
+
+// Maximum number of pending (non-expired) invites a single org may have.
+// Bounds per-org storage and prevents invite spam.
+pub const MAX_PENDING_INVITES_PER_ORG: usize = 10;

--- a/src/backend/src/controller/invite.rs
+++ b/src/backend/src/controller/invite.rs
@@ -1,0 +1,74 @@
+use crate::{
+    dto::{
+        AcceptOrgInviteRequest, AcceptOrgInviteResponse, CreateOrgInviteRequest,
+        CreateOrgInviteResponse, DeclineOrgInviteRequest, DeclineOrgInviteResponse,
+        ListMyInvitesResponse, ListOrgInvitesRequest, ListOrgInvitesResponse,
+        RevokeOrgInviteRequest, RevokeOrgInviteResponse,
+    },
+    service::invite_service,
+};
+use canister_utils::{assert_authenticated, ApiResultDto};
+use ic_cdk::{
+    api::{msg_caller, time},
+    *,
+};
+
+#[update]
+fn create_org_invite(req: CreateOrgInviteRequest) -> ApiResultDto<CreateOrgInviteResponse> {
+    let caller = msg_caller();
+    if let Err(err) = assert_authenticated(&caller) {
+        return ApiResultDto::Err(err);
+    }
+
+    invite_service::create_org_invite(&caller, req, time()).into()
+}
+
+#[query]
+fn list_org_invites(req: ListOrgInvitesRequest) -> ApiResultDto<ListOrgInvitesResponse> {
+    let caller = msg_caller();
+    if let Err(err) = assert_authenticated(&caller) {
+        return ApiResultDto::Err(err);
+    }
+
+    invite_service::list_org_invites(&caller, req, time()).into()
+}
+
+#[update]
+fn revoke_org_invite(req: RevokeOrgInviteRequest) -> ApiResultDto<RevokeOrgInviteResponse> {
+    let caller = msg_caller();
+    if let Err(err) = assert_authenticated(&caller) {
+        return ApiResultDto::Err(err);
+    }
+
+    invite_service::revoke_org_invite(&caller, req).into()
+}
+
+#[query]
+fn list_my_invites() -> ApiResultDto<ListMyInvitesResponse> {
+    let caller = msg_caller();
+    if let Err(err) = assert_authenticated(&caller) {
+        return ApiResultDto::Err(err);
+    }
+
+    invite_service::list_my_invites(&caller, time()).into()
+}
+
+#[update]
+fn accept_org_invite(req: AcceptOrgInviteRequest) -> ApiResultDto<AcceptOrgInviteResponse> {
+    let caller = msg_caller();
+    if let Err(err) = assert_authenticated(&caller) {
+        return ApiResultDto::Err(err);
+    }
+
+    invite_service::accept_org_invite(&caller, req, time()).into()
+}
+
+#[update]
+fn decline_org_invite(req: DeclineOrgInviteRequest) -> ApiResultDto<DeclineOrgInviteResponse> {
+    let caller = msg_caller();
+    if let Err(err) = assert_authenticated(&caller) {
+        return ApiResultDto::Err(err);
+    }
+
+    invite_service::decline_org_invite(&caller, req, time()).into()
+}

--- a/src/backend/src/controller/mod.rs
+++ b/src/backend/src/controller/mod.rs
@@ -2,6 +2,7 @@ mod approval_policy;
 mod canister;
 mod cycles_ledger;
 pub mod http;
+mod invite;
 mod organization;
 mod project;
 mod proposal;

--- a/src/backend/src/controller/organization.rs
+++ b/src/backend/src/controller/organization.rs
@@ -2,7 +2,8 @@ use crate::{
     dto::{
         CreateOrganizationRequest, CreateOrganizationResponse, DeleteOrganizationRequest,
         DeleteOrganizationResponse, GetOrganizationRequest, GetOrganizationResponse,
-        ListMyOrganizationsResponse, UpdateOrganizationRequest, UpdateOrganizationResponse,
+        ListMyOrganizationsResponse, ListOrgUsersRequest, ListOrgUsersResponse,
+        UpdateOrganizationRequest, UpdateOrganizationResponse,
     },
     service::organization_service,
 };
@@ -57,4 +58,14 @@ fn delete_organization(req: DeleteOrganizationRequest) -> ApiResultDto<DeleteOrg
     }
 
     organization_service::delete_organization(&caller, req).into()
+}
+
+#[query]
+fn list_org_users(req: ListOrgUsersRequest) -> ApiResultDto<ListOrgUsersResponse> {
+    let caller = msg_caller();
+    if let Err(err) = assert_authenticated(&caller) {
+        return ApiResultDto::Err(err);
+    }
+
+    organization_service::list_org_users(&caller, req).into()
 }

--- a/src/backend/src/controller/team.rs
+++ b/src/backend/src/controller/team.rs
@@ -2,7 +2,8 @@ use crate::{
     dto::{
         AddUserToTeamRequest, AddUserToTeamResponse, CreateTeamRequest, CreateTeamResponse,
         DeleteTeamRequest, DeleteTeamResponse, GetTeamRequest, GetTeamResponse,
-        ListOrgTeamsRequest, ListTeamsResponse, UpdateTeamRequest, UpdateTeamResponse,
+        ListOrgTeamsRequest, ListTeamUsersRequest, ListTeamUsersResponse, ListTeamsResponse,
+        UpdateTeamRequest, UpdateTeamResponse,
     },
     service::team_service,
 };
@@ -77,4 +78,14 @@ fn add_user_to_team(req: AddUserToTeamRequest) -> ApiResultDto<AddUserToTeamResp
     }
 
     team_service::add_user_to_team(&caller, req).into()
+}
+
+#[query]
+fn list_team_users(req: ListTeamUsersRequest) -> ApiResultDto<ListTeamUsersResponse> {
+    let caller = msg_caller();
+    if let Err(err) = assert_authenticated(&caller) {
+        return ApiResultDto::Err(err);
+    }
+
+    team_service::list_team_users(&caller, req).into()
 }

--- a/src/backend/src/data/invite_repository.rs
+++ b/src/backend/src/data/invite_repository.rs
@@ -1,7 +1,7 @@
 use super::{
     memory::{
-        init_org_invites, init_organization_invite_index, OrgInviteMemory,
-        OrganizationInviteIndexMemory,
+        init_invite_status_index, init_org_invites, init_organization_invite_index,
+        InviteStatusIndexMemory, OrgInviteMemory, OrganizationInviteIndexMemory,
     },
     InviteStatus, OrgInvite,
 };
@@ -13,6 +13,8 @@ pub fn create_invite(invite: OrgInvite) -> Uuid {
     mutate_state(|s| {
         s.organization_invite_index
             .insert((invite.org_id, invite_id));
+        s.invite_status_index
+            .insert((invite.status.as_u8(), invite_id));
         s.invites.insert(invite_id, invite);
     });
     invite_id
@@ -24,40 +26,44 @@ pub fn get_invite(invite_id: Uuid) -> Option<OrgInvite> {
 
 pub fn update_invite(invite_id: Uuid, invite: OrgInvite) -> ApiResult {
     mutate_state(|s| {
-        if !s.invites.contains_key(&invite_id) {
-            return Err(ApiError::client_error(format!(
-                "Invite with id {invite_id} does not exist."
-            )));
-        }
+        let old = s.invites.get(&invite_id).ok_or_else(|| {
+            ApiError::client_error(format!("Invite with id {invite_id} does not exist."))
+        })?;
+        s.invite_status_index
+            .remove(&(old.status.as_u8(), invite_id));
+        s.invite_status_index
+            .insert((invite.status.as_u8(), invite_id));
         s.invites.insert(invite_id, invite);
         Ok(())
     })
 }
 
-#[allow(dead_code)]
-pub fn list_org_invite_ids(org_id: Uuid) -> Vec<Uuid> {
-    with_state(|s| {
-        s.organization_invite_index
-            .range((org_id, Uuid::MIN)..=(org_id, Uuid::MAX))
-            .map(|(_, invite_id)| invite_id)
-            .collect()
-    })
-}
-
-pub fn list_org_invites(org_id: Uuid) -> Vec<(Uuid, OrgInvite)> {
+pub fn list_org_invites_by_creator(
+    org_id: Uuid,
+    created_by: Uuid,
+    now_ns: u64,
+) -> Vec<(Uuid, OrgInvite)> {
     with_state(|s| {
         s.organization_invite_index
             .range((org_id, Uuid::MIN)..=(org_id, Uuid::MAX))
             .filter_map(|(_, invite_id)| s.invites.get(&invite_id).map(|inv| (invite_id, inv)))
+            .filter(|(_, inv)| inv.created_by == created_by)
+            .filter(|(_, inv)| {
+                !(inv.status == InviteStatus::Pending && inv.expires_at_ns <= now_ns)
+            })
             .collect()
     })
 }
 
-// Scans all invites. The number of invites is bounded by
-// MAX_PENDING_INVITES_PER_ORG * number_of_orgs, plus expired invites
-// that have not yet been swept. Acceptable for the size of this system.
-pub fn iter_invites() -> Vec<(Uuid, OrgInvite)> {
-    with_state(|s| s.invites.iter().map(|e| e.into_pair()).collect())
+pub fn list_pending_invites(now_ns: u64) -> Vec<(Uuid, OrgInvite)> {
+    let pending_status = InviteStatus::Pending.as_u8();
+    with_state(|s| {
+        s.invite_status_index
+            .range((pending_status, Uuid::MIN)..=(pending_status, Uuid::MAX))
+            .filter_map(|(_, invite_id)| s.invites.get(&invite_id).map(|inv| (invite_id, inv)))
+            .filter(|(_, inv)| inv.expires_at_ns > now_ns)
+            .collect()
+    })
 }
 
 pub fn count_pending_invites_for_org(org_id: Uuid, now_ns: u64) -> usize {
@@ -72,8 +78,6 @@ pub fn count_pending_invites_for_org(org_id: Uuid, now_ns: u64) -> usize {
     })
 }
 
-// Removes all invites for an org that are expired at now_ns. Used
-// before creating a new invite to bound stale storage.
 pub fn sweep_expired_org_invites(org_id: Uuid, now_ns: u64) {
     mutate_state(|s| {
         while let Some(invite_id) = s
@@ -89,29 +93,19 @@ pub fn sweep_expired_org_invites(org_id: Uuid, now_ns: u64) {
                 })
             })
         {
-            s.invites.remove(&invite_id);
+            if let Some(inv) = s.invites.remove(&invite_id) {
+                s.invite_status_index
+                    .remove(&(inv.status.as_u8(), invite_id));
+            }
             s.organization_invite_index.remove(&(org_id, invite_id));
         }
     });
 }
 
-#[allow(dead_code)]
-pub fn delete_invite(invite_id: Uuid) -> ApiResult {
-    mutate_state(|s| {
-        let Some(invite) = s.invites.remove(&invite_id) else {
-            return Err(ApiError::client_error(format!(
-                "Invite with id {invite_id} does not exist."
-            )));
-        };
-        s.organization_invite_index
-            .remove(&(invite.org_id, invite_id));
-        Ok(())
-    })
-}
-
 struct InviteState {
     invites: OrgInviteMemory,
     organization_invite_index: OrganizationInviteIndexMemory,
+    invite_status_index: InviteStatusIndexMemory,
 }
 
 impl Default for InviteState {
@@ -119,6 +113,7 @@ impl Default for InviteState {
         Self {
             invites: init_org_invites(),
             organization_invite_index: init_organization_invite_index(),
+            invite_status_index: init_invite_status_index(),
         }
     }
 }

--- a/src/backend/src/data/invite_repository.rs
+++ b/src/backend/src/data/invite_repository.rs
@@ -8,13 +8,21 @@ use super::{
 use canister_utils::{ApiError, ApiResult, Uuid};
 use std::cell::RefCell;
 
+fn org_index_key(inv: &OrgInvite, invite_id: Uuid) -> (Uuid, (u8, u64), Uuid) {
+    (inv.org_id, (inv.status.as_u8(), inv.expires_at_ns), invite_id)
+}
+
+fn status_index_key(inv: &OrgInvite, invite_id: Uuid) -> ((u8, u64), Uuid) {
+    ((inv.status.as_u8(), inv.expires_at_ns), invite_id)
+}
+
 pub fn create_invite(invite: OrgInvite) -> Uuid {
     let invite_id = Uuid::new();
     mutate_state(|s| {
         s.organization_invite_index
-            .insert((invite.org_id, invite_id));
+            .insert(org_index_key(&invite, invite_id));
         s.invite_status_index
-            .insert((invite.status.as_u8(), invite_id));
+            .insert(status_index_key(&invite, invite_id));
         s.invites.insert(invite_id, invite);
     });
     invite_id
@@ -29,10 +37,14 @@ pub fn update_invite(invite_id: Uuid, invite: OrgInvite) -> ApiResult {
         let old = s.invites.get(&invite_id).ok_or_else(|| {
             ApiError::client_error(format!("Invite with id {invite_id} does not exist."))
         })?;
+        s.organization_invite_index
+            .remove(&org_index_key(&old, invite_id));
         s.invite_status_index
-            .remove(&(old.status.as_u8(), invite_id));
+            .remove(&status_index_key(&old, invite_id));
+        s.organization_invite_index
+            .insert(org_index_key(&invite, invite_id));
         s.invite_status_index
-            .insert((invite.status.as_u8(), invite_id));
+            .insert(status_index_key(&invite, invite_id));
         s.invites.insert(invite_id, invite);
         Ok(())
     })
@@ -45,8 +57,13 @@ pub fn list_org_invites_by_creator(
 ) -> Vec<(Uuid, OrgInvite)> {
     with_state(|s| {
         s.organization_invite_index
-            .range((org_id, Uuid::MIN)..=(org_id, Uuid::MAX))
-            .filter_map(|(_, invite_id)| s.invites.get(&invite_id).map(|inv| (invite_id, inv)))
+            .range(
+                (org_id, (u8::MIN, u64::MIN), Uuid::MIN)
+                    ..=(org_id, (u8::MAX, u64::MAX), Uuid::MAX),
+            )
+            .filter_map(|(_, _, invite_id)| {
+                s.invites.get(&invite_id).map(|inv| (invite_id, inv))
+            })
             .filter(|(_, inv)| inv.created_by == created_by)
             .filter(|(_, inv)| {
                 !(inv.status == InviteStatus::Pending && inv.expires_at_ns <= now_ns)
@@ -56,48 +73,44 @@ pub fn list_org_invites_by_creator(
 }
 
 pub fn list_pending_invites(now_ns: u64) -> Vec<(Uuid, OrgInvite)> {
-    let pending_status = InviteStatus::Pending.as_u8();
+    let pending = InviteStatus::Pending.as_u8();
     with_state(|s| {
         s.invite_status_index
-            .range((pending_status, Uuid::MIN)..=(pending_status, Uuid::MAX))
-            .filter_map(|(_, invite_id)| s.invites.get(&invite_id).map(|inv| (invite_id, inv)))
-            .filter(|(_, inv)| inv.expires_at_ns > now_ns)
+            .range(((pending, now_ns), Uuid::MIN)..=((pending, u64::MAX), Uuid::MAX))
+            .filter_map(|(_, invite_id)| {
+                s.invites.get(&invite_id).map(|inv| (invite_id, inv))
+            })
             .collect()
     })
 }
 
 pub fn count_pending_invites_for_org(org_id: Uuid, now_ns: u64) -> usize {
+    let pending = InviteStatus::Pending.as_u8();
     with_state(|s| {
         s.organization_invite_index
-            .range((org_id, Uuid::MIN)..=(org_id, Uuid::MAX))
-            .filter(|(_, invite_id)| match s.invites.get(invite_id) {
-                Some(inv) => inv.status == InviteStatus::Pending && inv.expires_at_ns > now_ns,
-                None => false,
-            })
+            .range(
+                (org_id, (pending, now_ns), Uuid::MIN)
+                    ..=(org_id, (pending, u64::MAX), Uuid::MAX),
+            )
             .count()
     })
 }
 
 pub fn sweep_expired_org_invites(org_id: Uuid, now_ns: u64) {
+    let pending = InviteStatus::Pending.as_u8();
     mutate_state(|s| {
-        while let Some(invite_id) = s
+        let expired: Vec<_> = s
             .organization_invite_index
-            .range((org_id, Uuid::MIN)..=(org_id, Uuid::MAX))
-            .find_map(|(_, invite_id)| {
-                s.invites.get(&invite_id).and_then(|inv| {
-                    if inv.status == InviteStatus::Pending && inv.expires_at_ns <= now_ns {
-                        Some(invite_id)
-                    } else {
-                        None
-                    }
-                })
-            })
-        {
-            if let Some(inv) = s.invites.remove(&invite_id) {
-                s.invite_status_index
-                    .remove(&(inv.status.as_u8(), invite_id));
-            }
-            s.organization_invite_index.remove(&(org_id, invite_id));
+            .range(
+                (org_id, (pending, u64::MIN), Uuid::MIN)
+                    ..=(org_id, (pending, now_ns), Uuid::MAX),
+            )
+            .collect();
+        for key @ (_, (status, expires_at_ns), invite_id) in expired {
+            s.invites.remove(&invite_id);
+            s.organization_invite_index.remove(&key);
+            s.invite_status_index
+                .remove(&((status, expires_at_ns), invite_id));
         }
     });
 }

--- a/src/backend/src/data/invite_repository.rs
+++ b/src/backend/src/data/invite_repository.rs
@@ -76,10 +76,10 @@ pub fn count_pending_invites_for_org(org_id: Uuid, now_ns: u64) -> usize {
 // before creating a new invite to bound stale storage.
 pub fn sweep_expired_org_invites(org_id: Uuid, now_ns: u64) {
     mutate_state(|s| {
-        let expired: Vec<Uuid> = s
+        while let Some(invite_id) = s
             .organization_invite_index
             .range((org_id, Uuid::MIN)..=(org_id, Uuid::MAX))
-            .filter_map(|(_, invite_id)| {
+            .find_map(|(_, invite_id)| {
                 s.invites.get(&invite_id).and_then(|inv| {
                     if inv.status == InviteStatus::Pending && inv.expires_at_ns <= now_ns {
                         Some(invite_id)
@@ -88,9 +88,7 @@ pub fn sweep_expired_org_invites(org_id: Uuid, now_ns: u64) {
                     }
                 })
             })
-            .collect();
-
-        for invite_id in expired {
+        {
             s.invites.remove(&invite_id);
             s.organization_invite_index.remove(&(org_id, invite_id));
         }

--- a/src/backend/src/data/invite_repository.rs
+++ b/src/backend/src/data/invite_repository.rs
@@ -9,7 +9,11 @@ use canister_utils::{ApiError, ApiResult, Uuid};
 use std::cell::RefCell;
 
 fn org_index_key(inv: &OrgInvite, invite_id: Uuid) -> (Uuid, (u8, u64), Uuid) {
-    (inv.org_id, (inv.status.as_u8(), inv.expires_at_ns), invite_id)
+    (
+        inv.org_id,
+        (inv.status.as_u8(), inv.expires_at_ns),
+        invite_id,
+    )
 }
 
 fn status_index_key(inv: &OrgInvite, invite_id: Uuid) -> ((u8, u64), Uuid) {
@@ -58,12 +62,9 @@ pub fn list_org_invites_by_creator(
     with_state(|s| {
         s.organization_invite_index
             .range(
-                (org_id, (u8::MIN, u64::MIN), Uuid::MIN)
-                    ..=(org_id, (u8::MAX, u64::MAX), Uuid::MAX),
+                (org_id, (u8::MIN, u64::MIN), Uuid::MIN)..=(org_id, (u8::MAX, u64::MAX), Uuid::MAX),
             )
-            .filter_map(|(_, _, invite_id)| {
-                s.invites.get(&invite_id).map(|inv| (invite_id, inv))
-            })
+            .filter_map(|(_, _, invite_id)| s.invites.get(&invite_id).map(|inv| (invite_id, inv)))
             .filter(|(_, inv)| inv.created_by == created_by)
             .filter(|(_, inv)| {
                 !(inv.status == InviteStatus::Pending && inv.expires_at_ns <= now_ns)
@@ -77,9 +78,7 @@ pub fn list_pending_invites(now_ns: u64) -> Vec<(Uuid, OrgInvite)> {
     with_state(|s| {
         s.invite_status_index
             .range(((pending, now_ns), Uuid::MIN)..=((pending, u64::MAX), Uuid::MAX))
-            .filter_map(|(_, invite_id)| {
-                s.invites.get(&invite_id).map(|inv| (invite_id, inv))
-            })
+            .filter_map(|(_, invite_id)| s.invites.get(&invite_id).map(|inv| (invite_id, inv)))
             .collect()
     })
 }
@@ -89,8 +88,7 @@ pub fn count_pending_invites_for_org(org_id: Uuid, now_ns: u64) -> usize {
     with_state(|s| {
         s.organization_invite_index
             .range(
-                (org_id, (pending, now_ns), Uuid::MIN)
-                    ..=(org_id, (pending, u64::MAX), Uuid::MAX),
+                (org_id, (pending, now_ns), Uuid::MIN)..=(org_id, (pending, u64::MAX), Uuid::MAX),
             )
             .count()
     })
@@ -102,8 +100,7 @@ pub fn sweep_expired_org_invites(org_id: Uuid, now_ns: u64) {
         let expired: Vec<_> = s
             .organization_invite_index
             .range(
-                (org_id, (pending, u64::MIN), Uuid::MIN)
-                    ..=(org_id, (pending, now_ns), Uuid::MAX),
+                (org_id, (pending, u64::MIN), Uuid::MIN)..=(org_id, (pending, now_ns), Uuid::MAX),
             )
             .collect();
         for key @ (_, (status, expires_at_ns), invite_id) in expired {

--- a/src/backend/src/data/invite_repository.rs
+++ b/src/backend/src/data/invite_repository.rs
@@ -1,0 +1,138 @@
+use super::{
+    memory::{
+        init_org_invites, init_organization_invite_index, OrgInviteMemory,
+        OrganizationInviteIndexMemory,
+    },
+    InviteStatus, OrgInvite,
+};
+use canister_utils::{ApiError, ApiResult, Uuid};
+use std::cell::RefCell;
+
+pub fn create_invite(invite: OrgInvite) -> Uuid {
+    let invite_id = Uuid::new();
+    mutate_state(|s| {
+        s.organization_invite_index
+            .insert((invite.org_id, invite_id));
+        s.invites.insert(invite_id, invite);
+    });
+    invite_id
+}
+
+pub fn get_invite(invite_id: Uuid) -> Option<OrgInvite> {
+    with_state(|s| s.invites.get(&invite_id))
+}
+
+pub fn update_invite(invite_id: Uuid, invite: OrgInvite) -> ApiResult {
+    mutate_state(|s| {
+        if !s.invites.contains_key(&invite_id) {
+            return Err(ApiError::client_error(format!(
+                "Invite with id {invite_id} does not exist."
+            )));
+        }
+        s.invites.insert(invite_id, invite);
+        Ok(())
+    })
+}
+
+#[allow(dead_code)]
+pub fn list_org_invite_ids(org_id: Uuid) -> Vec<Uuid> {
+    with_state(|s| {
+        s.organization_invite_index
+            .range((org_id, Uuid::MIN)..=(org_id, Uuid::MAX))
+            .map(|(_, invite_id)| invite_id)
+            .collect()
+    })
+}
+
+pub fn list_org_invites(org_id: Uuid) -> Vec<(Uuid, OrgInvite)> {
+    with_state(|s| {
+        s.organization_invite_index
+            .range((org_id, Uuid::MIN)..=(org_id, Uuid::MAX))
+            .filter_map(|(_, invite_id)| s.invites.get(&invite_id).map(|inv| (invite_id, inv)))
+            .collect()
+    })
+}
+
+// Scans all invites. The number of invites is bounded by
+// MAX_PENDING_INVITES_PER_ORG * number_of_orgs, plus expired invites
+// that have not yet been swept. Acceptable for the size of this system.
+pub fn iter_invites() -> Vec<(Uuid, OrgInvite)> {
+    with_state(|s| s.invites.iter().map(|e| e.into_pair()).collect())
+}
+
+pub fn count_pending_invites_for_org(org_id: Uuid, now_ns: u64) -> usize {
+    with_state(|s| {
+        s.organization_invite_index
+            .range((org_id, Uuid::MIN)..=(org_id, Uuid::MAX))
+            .filter(|(_, invite_id)| match s.invites.get(invite_id) {
+                Some(inv) => inv.status == InviteStatus::Pending && inv.expires_at_ns > now_ns,
+                None => false,
+            })
+            .count()
+    })
+}
+
+// Removes all invites for an org that are expired at now_ns. Used
+// before creating a new invite to bound stale storage.
+pub fn sweep_expired_org_invites(org_id: Uuid, now_ns: u64) {
+    mutate_state(|s| {
+        let expired: Vec<Uuid> = s
+            .organization_invite_index
+            .range((org_id, Uuid::MIN)..=(org_id, Uuid::MAX))
+            .filter_map(|(_, invite_id)| {
+                s.invites.get(&invite_id).and_then(|inv| {
+                    if inv.status == InviteStatus::Pending && inv.expires_at_ns <= now_ns {
+                        Some(invite_id)
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect();
+
+        for invite_id in expired {
+            s.invites.remove(&invite_id);
+            s.organization_invite_index.remove(&(org_id, invite_id));
+        }
+    });
+}
+
+#[allow(dead_code)]
+pub fn delete_invite(invite_id: Uuid) -> ApiResult {
+    mutate_state(|s| {
+        let Some(invite) = s.invites.remove(&invite_id) else {
+            return Err(ApiError::client_error(format!(
+                "Invite with id {invite_id} does not exist."
+            )));
+        };
+        s.organization_invite_index
+            .remove(&(invite.org_id, invite_id));
+        Ok(())
+    })
+}
+
+struct InviteState {
+    invites: OrgInviteMemory,
+    organization_invite_index: OrganizationInviteIndexMemory,
+}
+
+impl Default for InviteState {
+    fn default() -> Self {
+        Self {
+            invites: init_org_invites(),
+            organization_invite_index: init_organization_invite_index(),
+        }
+    }
+}
+
+thread_local! {
+    static STATE: RefCell<InviteState> = RefCell::new(InviteState::default());
+}
+
+fn with_state<R>(f: impl FnOnce(&InviteState) -> R) -> R {
+    STATE.with(|s| f(&s.borrow()))
+}
+
+fn mutate_state<R>(f: impl FnOnce(&mut InviteState) -> R) -> R {
+    STATE.with(|s| f(&mut s.borrow_mut()))
+}

--- a/src/backend/src/data/memory/invite_memory.rs
+++ b/src/backend/src/data/memory/invite_memory.rs
@@ -1,0 +1,23 @@
+use super::{Memory, ORGANIZATION_INVITE_INDEX_MEMORY_ID, ORG_INVITE_MEMORY_ID};
+use crate::data::{memory::get_memory, OrgInvite};
+use canister_utils::Uuid;
+use ic_stable_structures::{BTreeMap, BTreeSet};
+
+pub type OrgInviteMemory = BTreeMap<Uuid, OrgInvite, Memory>;
+pub type OrganizationInviteIndexMemory = BTreeSet<(Uuid, Uuid), Memory>;
+
+pub fn init_org_invites() -> OrgInviteMemory {
+    OrgInviteMemory::init(get_org_invite_memory())
+}
+
+pub fn init_organization_invite_index() -> OrganizationInviteIndexMemory {
+    OrganizationInviteIndexMemory::init(get_organization_invite_index_memory())
+}
+
+fn get_org_invite_memory() -> Memory {
+    get_memory(ORG_INVITE_MEMORY_ID)
+}
+
+fn get_organization_invite_index_memory() -> Memory {
+    get_memory(ORGANIZATION_INVITE_INDEX_MEMORY_ID)
+}

--- a/src/backend/src/data/memory/invite_memory.rs
+++ b/src/backend/src/data/memory/invite_memory.rs
@@ -1,10 +1,14 @@
-use super::{Memory, ORGANIZATION_INVITE_INDEX_MEMORY_ID, ORG_INVITE_MEMORY_ID};
+use super::{
+    Memory, INVITE_STATUS_INDEX_MEMORY_ID, ORGANIZATION_INVITE_INDEX_MEMORY_ID,
+    ORG_INVITE_MEMORY_ID,
+};
 use crate::data::{memory::get_memory, OrgInvite};
 use canister_utils::Uuid;
 use ic_stable_structures::{BTreeMap, BTreeSet};
 
 pub type OrgInviteMemory = BTreeMap<Uuid, OrgInvite, Memory>;
 pub type OrganizationInviteIndexMemory = BTreeSet<(Uuid, Uuid), Memory>;
+pub type InviteStatusIndexMemory = BTreeSet<(u8, Uuid), Memory>;
 
 pub fn init_org_invites() -> OrgInviteMemory {
     OrgInviteMemory::init(get_org_invite_memory())
@@ -14,10 +18,18 @@ pub fn init_organization_invite_index() -> OrganizationInviteIndexMemory {
     OrganizationInviteIndexMemory::init(get_organization_invite_index_memory())
 }
 
+pub fn init_invite_status_index() -> InviteStatusIndexMemory {
+    InviteStatusIndexMemory::init(get_invite_status_index_memory())
+}
+
 fn get_org_invite_memory() -> Memory {
     get_memory(ORG_INVITE_MEMORY_ID)
 }
 
 fn get_organization_invite_index_memory() -> Memory {
     get_memory(ORGANIZATION_INVITE_INDEX_MEMORY_ID)
+}
+
+fn get_invite_status_index_memory() -> Memory {
+    get_memory(INVITE_STATUS_INDEX_MEMORY_ID)
 }

--- a/src/backend/src/data/memory/invite_memory.rs
+++ b/src/backend/src/data/memory/invite_memory.rs
@@ -7,8 +7,8 @@ use canister_utils::Uuid;
 use ic_stable_structures::{BTreeMap, BTreeSet};
 
 pub type OrgInviteMemory = BTreeMap<Uuid, OrgInvite, Memory>;
-pub type OrganizationInviteIndexMemory = BTreeSet<(Uuid, Uuid), Memory>;
-pub type InviteStatusIndexMemory = BTreeSet<(u8, Uuid), Memory>;
+pub type OrganizationInviteIndexMemory = BTreeSet<(Uuid, (u8, u64), Uuid), Memory>;
+pub type InviteStatusIndexMemory = BTreeSet<((u8, u64), Uuid), Memory>;
 
 pub fn init_org_invites() -> OrgInviteMemory {
     OrgInviteMemory::init(get_org_invite_memory())
@@ -18,16 +18,16 @@ pub fn init_organization_invite_index() -> OrganizationInviteIndexMemory {
     OrganizationInviteIndexMemory::init(get_organization_invite_index_memory())
 }
 
-pub fn init_invite_status_index() -> InviteStatusIndexMemory {
-    InviteStatusIndexMemory::init(get_invite_status_index_memory())
-}
-
 fn get_org_invite_memory() -> Memory {
     get_memory(ORG_INVITE_MEMORY_ID)
 }
 
 fn get_organization_invite_index_memory() -> Memory {
     get_memory(ORGANIZATION_INVITE_INDEX_MEMORY_ID)
+}
+
+pub fn init_invite_status_index() -> InviteStatusIndexMemory {
+    InviteStatusIndexMemory::init(get_invite_status_index_memory())
 }
 
 fn get_invite_status_index_memory() -> Memory {

--- a/src/backend/src/data/memory/memory_manager.rs
+++ b/src/backend/src/data/memory/memory_manager.rs
@@ -56,3 +56,4 @@ pub(super) const CANISTER_PROJECT_INDEX_MEMORY_ID: MemoryId = MemoryId::new(27);
 
 pub(super) const ORG_INVITE_MEMORY_ID: MemoryId = MemoryId::new(28);
 pub(super) const ORGANIZATION_INVITE_INDEX_MEMORY_ID: MemoryId = MemoryId::new(29);
+pub(super) const INVITE_STATUS_INDEX_MEMORY_ID: MemoryId = MemoryId::new(30);

--- a/src/backend/src/data/memory/memory_manager.rs
+++ b/src/backend/src/data/memory/memory_manager.rs
@@ -53,3 +53,6 @@ pub(super) const PROPOSAL_MEMORY_ID: MemoryId = MemoryId::new(25);
 pub(super) const PROJECT_PROPOSAL_INDEX_MEMORY_ID: MemoryId = MemoryId::new(26);
 
 pub(super) const CANISTER_PROJECT_INDEX_MEMORY_ID: MemoryId = MemoryId::new(27);
+
+pub(super) const ORG_INVITE_MEMORY_ID: MemoryId = MemoryId::new(28);
+pub(super) const ORGANIZATION_INVITE_INDEX_MEMORY_ID: MemoryId = MemoryId::new(29);

--- a/src/backend/src/data/memory/mod.rs
+++ b/src/backend/src/data/memory/mod.rs
@@ -3,6 +3,7 @@ use memory_manager::*;
 
 mod approval_policy_memory;
 mod canister_memory;
+mod invite_memory;
 mod organization_memory;
 mod project_memory;
 mod proposal_memory;
@@ -14,6 +15,7 @@ mod user_profile_memory;
 
 pub(super) use approval_policy_memory::*;
 pub(super) use canister_memory::*;
+pub(super) use invite_memory::*;
 pub(super) use organization_memory::*;
 pub(super) use project_memory::*;
 pub(super) use proposal_memory::*;

--- a/src/backend/src/data/mod.rs
+++ b/src/backend/src/data/mod.rs
@@ -4,6 +4,7 @@ pub use model::*;
 
 pub mod approval_policy_repository;
 pub mod canister_repository;
+pub mod invite_repository;
 pub mod organization_repository;
 pub mod project_repository;
 pub mod proposal_repository;

--- a/src/backend/src/data/model/invite.rs
+++ b/src/backend/src/data/model/invite.rs
@@ -1,0 +1,46 @@
+use candid::Principal;
+use canister_utils::{deserialize_cbor, serialize_cbor, Uuid};
+use ic_stable_structures::{storable::Bound, Storable};
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum InviteTarget {
+    Email(String),
+    UserId(Uuid),
+    Principal(Principal),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum InviteStatus {
+    Pending,
+    Accepted,
+    Declined,
+    Revoked,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrgInvite {
+    pub org_id: Uuid,
+    pub created_by: Uuid,
+    pub created_at_ns: u64,
+    pub expires_at_ns: u64,
+    pub target: InviteTarget,
+    pub status: InviteStatus,
+}
+
+impl Storable for OrgInvite {
+    fn into_bytes(self) -> Vec<u8> {
+        serialize_cbor(&self)
+    }
+
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
+        Cow::Owned(serialize_cbor(self))
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        deserialize_cbor(&bytes)
+    }
+
+    const BOUND: Bound = Bound::Unbounded;
+}

--- a/src/backend/src/data/model/invite.rs
+++ b/src/backend/src/data/model/invite.rs
@@ -19,6 +19,17 @@ pub enum InviteStatus {
     Revoked,
 }
 
+impl InviteStatus {
+    pub fn as_u8(&self) -> u8 {
+        match self {
+            InviteStatus::Pending => 0,
+            InviteStatus::Accepted => 1,
+            InviteStatus::Declined => 2,
+            InviteStatus::Revoked => 3,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OrgInvite {
     pub org_id: Uuid,

--- a/src/backend/src/data/model/mod.rs
+++ b/src/backend/src/data/model/mod.rs
@@ -1,5 +1,6 @@
 mod approval_policy;
 mod canister;
+mod invite;
 mod organization;
 mod project;
 mod proposal;
@@ -12,6 +13,7 @@ mod user_stats;
 
 pub use approval_policy::*;
 pub use canister::*;
+pub use invite::*;
 pub use organization::*;
 pub use project::*;
 pub use proposal::*;

--- a/src/backend/src/data/organization_repository.rs
+++ b/src/backend/src/data/organization_repository.rs
@@ -96,6 +96,13 @@ pub fn list_org_users(org_id: Uuid) -> Vec<Uuid> {
     })
 }
 
+pub fn add_user_to_org(user_id: Uuid, org_id: Uuid) {
+    mutate_state(|s| {
+        s.organization_user_index.insert((org_id, user_id));
+        s.user_organization_index.insert((user_id, org_id));
+    });
+}
+
 pub fn assert_user_in_org(user_id: Uuid, org_id: Uuid) -> ApiResult {
     with_state(|s| {
         if !s.organization_user_index.contains(&(org_id, user_id)) {

--- a/src/backend/src/data/team_repository.rs
+++ b/src/backend/src/data/team_repository.rs
@@ -124,6 +124,15 @@ pub fn has_at_least_n_org_teams(org_id: Uuid, n: usize) -> bool {
     })
 }
 
+pub fn list_team_user_ids(team_id: Uuid) -> Vec<Uuid> {
+    with_state(|s| {
+        s.team_user_index
+            .range((team_id, Uuid::MIN)..=(team_id, Uuid::MAX))
+            .map(|(_, user_id)| user_id)
+            .collect()
+    })
+}
+
 pub fn list_user_team_ids(user_id: Uuid) -> Vec<Uuid> {
     with_state(|s| {
         s.user_team_index

--- a/src/backend/src/dto/invite.rs
+++ b/src/backend/src/dto/invite.rs
@@ -1,0 +1,73 @@
+use candid::{CandidType, Principal};
+use serde::Deserialize;
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub enum InviteTarget {
+    Email(String),
+    UserId(String),
+    Principal(Principal),
+}
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub enum InviteStatus {
+    Pending,
+    Accepted,
+    Declined,
+    Revoked,
+}
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct OrgInvite {
+    pub id: String,
+    pub org_id: String,
+    pub org_name: String,
+    pub created_by: String,
+    pub created_at_ns: u64,
+    pub expires_at_ns: u64,
+    pub target: InviteTarget,
+    pub status: InviteStatus,
+}
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct CreateOrgInviteRequest {
+    pub org_id: String,
+    pub target: InviteTarget,
+}
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct CreateOrgInviteResponse {
+    pub invite: OrgInvite,
+}
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct ListOrgInvitesRequest {
+    pub org_id: String,
+}
+
+pub type ListOrgInvitesResponse = Vec<OrgInvite>;
+
+pub type ListMyInvitesResponse = Vec<OrgInvite>;
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct RevokeOrgInviteRequest {
+    pub invite_id: String,
+}
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct RevokeOrgInviteResponse {}
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct AcceptOrgInviteRequest {
+    pub invite_id: String,
+}
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct AcceptOrgInviteResponse {}
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct DeclineOrgInviteRequest {
+    pub invite_id: String,
+}
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct DeclineOrgInviteResponse {}

--- a/src/backend/src/dto/mod.rs
+++ b/src/backend/src/dto/mod.rs
@@ -1,6 +1,7 @@
 mod approval_policy;
 mod canister;
 mod cycles_ledger;
+mod invite;
 mod organization;
 mod project;
 mod proposal;
@@ -12,6 +13,7 @@ mod user_profile;
 pub use approval_policy::*;
 pub use canister::*;
 pub use cycles_ledger::*;
+pub use invite::*;
 pub use organization::*;
 pub use project::*;
 pub use proposal::*;

--- a/src/backend/src/dto/organization.rs
+++ b/src/backend/src/dto/organization.rs
@@ -41,3 +41,17 @@ pub struct DeleteOrganizationRequest {
 
 #[derive(Debug, Clone, CandidType, Deserialize)]
 pub struct DeleteOrganizationResponse {}
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct ListOrgUsersRequest {
+    pub org_id: String,
+}
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct OrgUser {
+    pub id: String,
+    pub email: Option<String>,
+    pub email_verified: bool,
+}
+
+pub type ListOrgUsersResponse = Vec<OrgUser>;

--- a/src/backend/src/dto/team.rs
+++ b/src/backend/src/dto/team.rs
@@ -56,3 +56,17 @@ pub struct AddUserToTeamRequest {
 
 #[derive(Debug, Clone, CandidType, Deserialize)]
 pub struct AddUserToTeamResponse {}
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct ListTeamUsersRequest {
+    pub team_id: String,
+}
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct TeamUser {
+    pub id: String,
+    pub email: Option<String>,
+    pub email_verified: bool,
+}
+
+pub type ListTeamUsersResponse = Vec<TeamUser>;

--- a/src/backend/src/mapping/invite.rs
+++ b/src/backend/src/mapping/invite.rs
@@ -1,0 +1,50 @@
+use crate::{
+    data::{self},
+    dto::{self},
+};
+use canister_utils::Uuid;
+
+pub fn map_invite_target_to_data(target: dto::InviteTarget) -> Result<data::InviteTarget, String> {
+    match target {
+        dto::InviteTarget::Email(email) => Ok(data::InviteTarget::Email(email)),
+        dto::InviteTarget::UserId(id) => {
+            let uuid = Uuid::try_from(id.as_str()).map_err(|e| e.message().to_string())?;
+            Ok(data::InviteTarget::UserId(uuid))
+        }
+        dto::InviteTarget::Principal(p) => Ok(data::InviteTarget::Principal(p)),
+    }
+}
+
+pub fn map_invite_target_to_dto(target: data::InviteTarget) -> dto::InviteTarget {
+    match target {
+        data::InviteTarget::Email(email) => dto::InviteTarget::Email(email),
+        data::InviteTarget::UserId(uuid) => dto::InviteTarget::UserId(uuid.to_string()),
+        data::InviteTarget::Principal(p) => dto::InviteTarget::Principal(p),
+    }
+}
+
+pub fn map_invite_status_to_dto(status: data::InviteStatus) -> dto::InviteStatus {
+    match status {
+        data::InviteStatus::Pending => dto::InviteStatus::Pending,
+        data::InviteStatus::Accepted => dto::InviteStatus::Accepted,
+        data::InviteStatus::Declined => dto::InviteStatus::Declined,
+        data::InviteStatus::Revoked => dto::InviteStatus::Revoked,
+    }
+}
+
+pub fn map_invite_to_dto(
+    invite_id: Uuid,
+    invite: data::OrgInvite,
+    org_name: String,
+) -> dto::OrgInvite {
+    dto::OrgInvite {
+        id: invite_id.to_string(),
+        org_id: invite.org_id.to_string(),
+        org_name,
+        created_by: invite.created_by.to_string(),
+        created_at_ns: invite.created_at_ns,
+        expires_at_ns: invite.expires_at_ns,
+        target: map_invite_target_to_dto(invite.target),
+        status: map_invite_status_to_dto(invite.status),
+    }
+}

--- a/src/backend/src/mapping/mod.rs
+++ b/src/backend/src/mapping/mod.rs
@@ -1,5 +1,6 @@
 mod approval_policy;
 mod canister;
+mod invite;
 mod organization;
 mod project;
 mod proposal;
@@ -10,6 +11,7 @@ mod user_profile;
 
 pub use approval_policy::*;
 pub use canister::*;
+pub use invite::*;
 pub use organization::*;
 pub use project::*;
 pub use proposal::*;

--- a/src/backend/src/mapping/organization.rs
+++ b/src/backend/src/mapping/organization.rs
@@ -1,6 +1,9 @@
 use crate::{
     data::{self},
-    dto::{ListMyOrganizationsResponse, Organization, OrganizationResponse},
+    dto::{
+        ListMyOrganizationsResponse, ListOrgUsersResponse, OrgUser, Organization,
+        OrganizationResponse,
+    },
 };
 use canister_utils::Uuid;
 
@@ -24,4 +27,15 @@ pub fn map_organization_to_response(id: Uuid, org: data::Organization) -> Organi
     OrganizationResponse {
         organization: map_organization_response((id, org)),
     }
+}
+
+pub fn map_list_org_users_response(users: Vec<(Uuid, data::UserProfile)>) -> ListOrgUsersResponse {
+    users
+        .into_iter()
+        .map(|(id, profile)| OrgUser {
+            id: id.to_string(),
+            email: profile.email,
+            email_verified: profile.email_verified,
+        })
+        .collect()
 }

--- a/src/backend/src/mapping/team.rs
+++ b/src/backend/src/mapping/team.rs
@@ -1,6 +1,6 @@
 use crate::{
     data::{self},
-    dto::{ListTeamsResponse, Team, TeamResponse},
+    dto::{ListTeamUsersResponse, ListTeamsResponse, Team, TeamResponse, TeamUser},
 };
 use canister_utils::Uuid;
 
@@ -22,4 +22,17 @@ pub fn map_team_to_response(team_id: Uuid, team: data::Team) -> TeamResponse {
     TeamResponse {
         team: map_team(team_id, team),
     }
+}
+
+pub fn map_list_team_users_response(
+    users: Vec<(Uuid, data::UserProfile)>,
+) -> ListTeamUsersResponse {
+    users
+        .into_iter()
+        .map(|(id, profile)| TeamUser {
+            id: id.to_string(),
+            email: profile.email,
+            email_verified: profile.email_verified,
+        })
+        .collect()
 }

--- a/src/backend/src/service/invite_service.rs
+++ b/src/backend/src/service/invite_service.rs
@@ -75,9 +75,14 @@ pub fn list_org_invites(
         .map(|o| o.name)
         .unwrap_or_default();
 
+    // Only show invites the caller created, to avoid leaking invitee
+    // emails/principals to other org members. Once an org permission
+    // model exists, this should gate on an "invite manage" permission
+    // so admins can see all org invites.
     let invites = invite_repository::list_org_invites(org_id)
         .into_iter()
         .filter(|(_, inv)| !is_expired_pending(inv, now_ns))
+        .filter(|(_, inv)| inv.created_by == caller_user_id)
         .map(|(id, inv)| map_invite_to_dto(id, inv, org_name.clone()))
         .collect();
 
@@ -95,6 +100,14 @@ pub fn revoke_org_invite(
         ApiError::client_error(format!("Invite with id {invite_id} does not exist."))
     })?;
     organization_repository::assert_user_in_org(caller_user_id, invite.org_id)?;
+
+    // Only the inviter can revoke. Once org admin roles exist, admins
+    // should be allowed too.
+    if invite.created_by != caller_user_id {
+        return Err(ApiError::unauthorized(
+            "Only the inviter can revoke this invite.".to_string(),
+        ));
+    }
 
     if invite.status != InviteStatus::Pending {
         return Err(ApiError::client_error(

--- a/src/backend/src/service/invite_service.rs
+++ b/src/backend/src/service/invite_service.rs
@@ -35,6 +35,25 @@ pub fn create_org_invite(
         .map_err(ApiError::client_error)
         .and_then(normalize_target)?;
 
+    // For UserId/Principal targets, reject if the user is already a member.
+    // Email targets are intentionally not resolved here, to preserve the
+    // anti-enumeration property described above; accept-time idempotency
+    // covers the duplicate case.
+    let already_member_user_id = match &target {
+        data::InviteTarget::UserId(target_user_id) => Some(*target_user_id),
+        data::InviteTarget::Principal(target_principal) => {
+            user_profile_repository::get_user_id_by_principal(target_principal)
+        }
+        data::InviteTarget::Email(_) => None,
+    };
+    if let Some(target_user_id) = already_member_user_id {
+        if organization_repository::assert_user_in_org(target_user_id, org_id).is_ok() {
+            return Err(ApiError::client_error(
+                "User is already a member of this organization.".to_string(),
+            ));
+        }
+    }
+
     invite_repository::sweep_expired_org_invites(org_id, now_ns);
     if invite_repository::count_pending_invites_for_org(org_id, now_ns)
         >= MAX_PENDING_INVITES_PER_ORG

--- a/src/backend/src/service/invite_service.rs
+++ b/src/backend/src/service/invite_service.rs
@@ -1,0 +1,278 @@
+use crate::{
+    constants::{INVITE_TTL_NS, MAX_PENDING_INVITES_PER_ORG},
+    data::{
+        self, invite_repository, organization_repository, user_profile_repository, InviteStatus,
+        OrgInvite,
+    },
+    dto::{
+        AcceptOrgInviteRequest, AcceptOrgInviteResponse, CreateOrgInviteRequest,
+        CreateOrgInviteResponse, DeclineOrgInviteRequest, DeclineOrgInviteResponse,
+        ListMyInvitesResponse, ListOrgInvitesRequest, ListOrgInvitesResponse,
+        RevokeOrgInviteRequest, RevokeOrgInviteResponse,
+    },
+    mapping::{map_invite_target_to_data, map_invite_to_dto},
+    validation::Email,
+};
+use candid::Principal;
+use canister_utils::{ApiError, ApiResult, Uuid};
+
+// Creates an org invite. Intentionally does not leak whether the target
+// (email / user_id / principal) refers to an existing user, so that
+// sending an invite cannot be used to enumerate app accounts.
+//
+// TODO: any org member can invite. Restrict to org owner/admin once
+// roles exist.
+pub fn create_org_invite(
+    caller: &Principal,
+    req: CreateOrgInviteRequest,
+    now_ns: u64,
+) -> ApiResult<CreateOrgInviteResponse> {
+    let org_id = Uuid::try_from(req.org_id.as_str())?;
+    let caller_user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
+    organization_repository::assert_user_in_org(caller_user_id, org_id)?;
+
+    let target = map_invite_target_to_data(req.target)
+        .map_err(ApiError::client_error)
+        .and_then(normalize_target)?;
+
+    invite_repository::sweep_expired_org_invites(org_id, now_ns);
+    if invite_repository::count_pending_invites_for_org(org_id, now_ns)
+        >= MAX_PENDING_INVITES_PER_ORG
+    {
+        return Err(ApiError::client_error(format!(
+            "Cannot have more than {MAX_PENDING_INVITES_PER_ORG} pending invites per organization."
+        )));
+    }
+
+    let invite = OrgInvite {
+        org_id,
+        created_by: caller_user_id,
+        created_at_ns: now_ns,
+        expires_at_ns: now_ns + INVITE_TTL_NS,
+        target,
+        status: InviteStatus::Pending,
+    };
+    let invite_id = invite_repository::create_invite(invite.clone());
+    let org_name = organization_repository::get_org(org_id)
+        .map(|o| o.name)
+        .unwrap_or_default();
+
+    Ok(CreateOrgInviteResponse {
+        invite: map_invite_to_dto(invite_id, invite, org_name),
+    })
+}
+
+pub fn list_org_invites(
+    caller: &Principal,
+    req: ListOrgInvitesRequest,
+    now_ns: u64,
+) -> ApiResult<ListOrgInvitesResponse> {
+    let org_id = Uuid::try_from(req.org_id.as_str())?;
+    let caller_user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
+    organization_repository::assert_user_in_org(caller_user_id, org_id)?;
+
+    let org_name = organization_repository::get_org(org_id)
+        .map(|o| o.name)
+        .unwrap_or_default();
+
+    let invites = invite_repository::list_org_invites(org_id)
+        .into_iter()
+        .filter(|(_, inv)| !is_expired_pending(inv, now_ns))
+        .map(|(id, inv)| map_invite_to_dto(id, inv, org_name.clone()))
+        .collect();
+
+    Ok(invites)
+}
+
+pub fn revoke_org_invite(
+    caller: &Principal,
+    req: RevokeOrgInviteRequest,
+) -> ApiResult<RevokeOrgInviteResponse> {
+    let invite_id = Uuid::try_from(req.invite_id.as_str())?;
+    let caller_user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
+
+    let mut invite = invite_repository::get_invite(invite_id).ok_or_else(|| {
+        ApiError::client_error(format!("Invite with id {invite_id} does not exist."))
+    })?;
+    organization_repository::assert_user_in_org(caller_user_id, invite.org_id)?;
+
+    if invite.status != InviteStatus::Pending {
+        return Err(ApiError::client_error(
+            "Only pending invites can be revoked.".to_string(),
+        ));
+    }
+
+    invite.status = InviteStatus::Revoked;
+    invite_repository::update_invite(invite_id, invite)?;
+
+    Ok(RevokeOrgInviteResponse {})
+}
+
+pub fn list_my_invites(caller: &Principal, now_ns: u64) -> ApiResult<ListMyInvitesResponse> {
+    let caller_user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
+    let caller_profile = user_profile_repository::get_user_profile_by_user_id(&caller_user_id)
+        .ok_or_else(|| {
+            ApiError::client_error(format!(
+                "User profile for user with id {caller_user_id} does not exist."
+            ))
+        })?;
+    let caller_principals = user_profile_repository::get_principals_by_user_id(caller_user_id);
+
+    let invites = invite_repository::iter_invites()
+        .into_iter()
+        .filter(|(_, inv)| inv.status == InviteStatus::Pending && inv.expires_at_ns > now_ns)
+        .filter(|(_, inv)| {
+            invite_matches_user(
+                &inv.target,
+                caller_user_id,
+                &caller_principals,
+                caller_profile.email.as_deref(),
+                caller_profile.email_verified,
+            )
+        })
+        .map(|(id, inv)| {
+            let org_name = organization_repository::get_org(inv.org_id)
+                .map(|o| o.name)
+                .unwrap_or_default();
+            map_invite_to_dto(id, inv, org_name)
+        })
+        .collect();
+
+    Ok(invites)
+}
+
+pub fn accept_org_invite(
+    caller: &Principal,
+    req: AcceptOrgInviteRequest,
+    now_ns: u64,
+) -> ApiResult<AcceptOrgInviteResponse> {
+    let invite_id = Uuid::try_from(req.invite_id.as_str())?;
+    let caller_user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
+    let caller_profile = user_profile_repository::get_user_profile_by_user_id(&caller_user_id)
+        .ok_or_else(|| {
+            ApiError::client_error(format!(
+                "User profile for user with id {caller_user_id} does not exist."
+            ))
+        })?;
+    let caller_principals = user_profile_repository::get_principals_by_user_id(caller_user_id);
+
+    let mut invite = invite_repository::get_invite(invite_id).ok_or_else(|| {
+        ApiError::client_error(format!("Invite with id {invite_id} does not exist."))
+    })?;
+
+    assert_invite_is_actionable_by(
+        &invite,
+        caller_user_id,
+        &caller_principals,
+        caller_profile.email.as_deref(),
+        caller_profile.email_verified,
+        now_ns,
+    )?;
+
+    // Adding the user to the org is idempotent: if they are already a
+    // member (e.g. double-accept race), we still mark the invite as
+    // Accepted.
+    if organization_repository::assert_user_in_org(caller_user_id, invite.org_id).is_err() {
+        organization_repository::add_user_to_org(caller_user_id, invite.org_id);
+    }
+
+    invite.status = InviteStatus::Accepted;
+    invite_repository::update_invite(invite_id, invite)?;
+
+    Ok(AcceptOrgInviteResponse {})
+}
+
+pub fn decline_org_invite(
+    caller: &Principal,
+    req: DeclineOrgInviteRequest,
+    now_ns: u64,
+) -> ApiResult<DeclineOrgInviteResponse> {
+    let invite_id = Uuid::try_from(req.invite_id.as_str())?;
+    let caller_user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
+    let caller_profile = user_profile_repository::get_user_profile_by_user_id(&caller_user_id)
+        .ok_or_else(|| {
+            ApiError::client_error(format!(
+                "User profile for user with id {caller_user_id} does not exist."
+            ))
+        })?;
+    let caller_principals = user_profile_repository::get_principals_by_user_id(caller_user_id);
+
+    let mut invite = invite_repository::get_invite(invite_id).ok_or_else(|| {
+        ApiError::client_error(format!("Invite with id {invite_id} does not exist."))
+    })?;
+
+    assert_invite_is_actionable_by(
+        &invite,
+        caller_user_id,
+        &caller_principals,
+        caller_profile.email.as_deref(),
+        caller_profile.email_verified,
+        now_ns,
+    )?;
+
+    invite.status = InviteStatus::Declined;
+    invite_repository::update_invite(invite_id, invite)?;
+
+    Ok(DeclineOrgInviteResponse {})
+}
+
+fn normalize_target(target: data::InviteTarget) -> ApiResult<data::InviteTarget> {
+    match target {
+        data::InviteTarget::Email(email) => {
+            let normalized = Email::try_from(email)?;
+            Ok(data::InviteTarget::Email(normalized.into_inner()))
+        }
+        other => Ok(other),
+    }
+}
+
+fn is_expired_pending(invite: &OrgInvite, now_ns: u64) -> bool {
+    invite.status == InviteStatus::Pending && invite.expires_at_ns <= now_ns
+}
+
+fn invite_matches_user(
+    target: &data::InviteTarget,
+    user_id: Uuid,
+    principals: &[Principal],
+    verified_email: Option<&str>,
+    email_verified: bool,
+) -> bool {
+    match target {
+        data::InviteTarget::UserId(target_user_id) => *target_user_id == user_id,
+        data::InviteTarget::Principal(target_principal) => principals.contains(target_principal),
+        data::InviteTarget::Email(target_email) => match (email_verified, verified_email) {
+            (true, Some(email)) => email.eq_ignore_ascii_case(target_email),
+            _ => false,
+        },
+    }
+}
+
+fn assert_invite_is_actionable_by(
+    invite: &OrgInvite,
+    user_id: Uuid,
+    principals: &[Principal],
+    verified_email: Option<&str>,
+    email_verified: bool,
+    now_ns: u64,
+) -> ApiResult {
+    if invite.status != InviteStatus::Pending {
+        return Err(ApiError::client_error(
+            "Invite is no longer pending.".to_string(),
+        ));
+    }
+    if invite.expires_at_ns <= now_ns {
+        return Err(ApiError::client_error("Invite has expired.".to_string()));
+    }
+    if !invite_matches_user(
+        &invite.target,
+        user_id,
+        principals,
+        verified_email,
+        email_verified,
+    ) {
+        return Err(ApiError::unauthorized(
+            "Invite is not addressed to the caller.".to_string(),
+        ));
+    }
+    Ok(())
+}

--- a/src/backend/src/service/invite_service.rs
+++ b/src/backend/src/service/invite_service.rs
@@ -98,10 +98,8 @@ pub fn list_org_invites(
     // emails/principals to other org members. Once an org permission
     // model exists, this should gate on an "invite manage" permission
     // so admins can see all org invites.
-    let invites = invite_repository::list_org_invites(org_id)
+    let invites = invite_repository::list_org_invites_by_creator(org_id, caller_user_id, now_ns)
         .into_iter()
-        .filter(|(_, inv)| !is_expired_pending(inv, now_ns))
-        .filter(|(_, inv)| inv.created_by == caller_user_id)
         .map(|(id, inv)| map_invite_to_dto(id, inv, org_name.clone()))
         .collect();
 
@@ -150,9 +148,8 @@ pub fn list_my_invites(caller: &Principal, now_ns: u64) -> ApiResult<ListMyInvit
         })?;
     let caller_principals = user_profile_repository::get_principals_by_user_id(caller_user_id);
 
-    let invites = invite_repository::iter_invites()
+    let invites = invite_repository::list_pending_invites(now_ns)
         .into_iter()
-        .filter(|(_, inv)| inv.status == InviteStatus::Pending && inv.expires_at_ns > now_ns)
         .filter(|(_, inv)| {
             invite_matches_user(
                 &inv.target,
@@ -256,10 +253,6 @@ fn normalize_target(target: data::InviteTarget) -> ApiResult<data::InviteTarget>
         }
         other => Ok(other),
     }
-}
-
-fn is_expired_pending(invite: &OrgInvite, now_ns: u64) -> bool {
-    invite.status == InviteStatus::Pending && invite.expires_at_ns <= now_ns
 }
 
 fn invite_matches_user(

--- a/src/backend/src/service/mod.rs
+++ b/src/backend/src/service/mod.rs
@@ -2,6 +2,7 @@ pub mod access_control_service;
 pub mod approval_policy_service;
 pub mod canister_service;
 pub mod cycles_ledger_service;
+pub mod invite_service;
 pub mod organization_service;
 pub mod project_service;
 pub mod proposal_service;

--- a/src/backend/src/service/organization_service.rs
+++ b/src/backend/src/service/organization_service.rs
@@ -6,9 +6,13 @@ use crate::{
     dto::{
         CreateOrganizationRequest, CreateOrganizationResponse, DeleteOrganizationRequest,
         DeleteOrganizationResponse, GetOrganizationRequest, GetOrganizationResponse,
-        ListMyOrganizationsResponse, UpdateOrganizationRequest, UpdateOrganizationResponse,
+        ListMyOrganizationsResponse, ListOrgUsersRequest, ListOrgUsersResponse,
+        UpdateOrganizationRequest, UpdateOrganizationResponse,
     },
-    mapping::{map_list_my_organizations_response, map_organization_to_response},
+    mapping::{
+        map_list_my_organizations_response, map_list_org_users_response,
+        map_organization_to_response,
+    },
     validation::OrgName,
 };
 use candid::Principal;
@@ -21,6 +25,22 @@ pub fn list_my_organizations(caller: &Principal) -> ApiResult<ListMyOrganization
 
     let organizations = organization_repository::list_user_orgs(user_id);
     Ok(map_list_my_organizations_response(organizations))
+}
+
+pub fn list_org_users(
+    caller: &Principal,
+    req: ListOrgUsersRequest,
+) -> ApiResult<ListOrgUsersResponse> {
+    let org_id = Uuid::try_from(req.org_id.as_str())?;
+    let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
+    organization_repository::assert_user_in_org(user_id, org_id)?;
+
+    let users = organization_repository::list_org_users(org_id)
+        .into_iter()
+        .filter_map(|id| user_profile_repository::get_user_profile_by_user_id(&id).map(|p| (id, p)))
+        .collect::<Vec<_>>();
+
+    Ok(map_list_org_users_response(users))
 }
 
 pub fn create_organization(

--- a/src/backend/src/service/team_service.rs
+++ b/src/backend/src/service/team_service.rs
@@ -5,9 +5,10 @@ use crate::{
     dto::{
         AddUserToTeamRequest, AddUserToTeamResponse, CreateTeamRequest, CreateTeamResponse,
         DeleteTeamRequest, DeleteTeamResponse, GetTeamRequest, GetTeamResponse,
-        ListOrgTeamsRequest, ListTeamsResponse, UpdateTeamRequest, UpdateTeamResponse,
+        ListOrgTeamsRequest, ListTeamUsersRequest, ListTeamUsersResponse, ListTeamsResponse,
+        UpdateTeamRequest, UpdateTeamResponse,
     },
-    mapping::{map_list_teams_response, map_team_to_response},
+    mapping::{map_list_team_users_response, map_list_teams_response, map_team_to_response},
     validation::TeamName,
 };
 use candid::Principal;
@@ -105,6 +106,24 @@ pub fn delete_team(caller: &Principal, req: DeleteTeamRequest) -> ApiResult<Dele
     team_repository::delete_team(team_id, team.org_id)?;
 
     Ok(DeleteTeamResponse {})
+}
+
+pub fn list_team_users(
+    caller: &Principal,
+    req: ListTeamUsersRequest,
+) -> ApiResult<ListTeamUsersResponse> {
+    let team_id = Uuid::try_from(req.team_id.as_str())?;
+    let caller_user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
+    let team = team_repository::get_team(team_id)
+        .ok_or_else(|| ApiError::client_error(format!("Team with id {team_id} does not exist.")))?;
+    organization_repository::assert_user_in_org(caller_user_id, team.org_id)?;
+
+    let users = team_repository::list_team_user_ids(team_id)
+        .into_iter()
+        .filter_map(|id| user_profile_repository::get_user_profile_by_user_id(&id).map(|p| (id, p)))
+        .collect::<Vec<_>>();
+
+    Ok(map_list_team_users_response(users))
 }
 
 pub fn add_user_to_team(

--- a/src/backend/src/validation/email.rs
+++ b/src/backend/src/validation/email.rs
@@ -1,0 +1,111 @@
+use canister_utils::{ApiError, ApiResult};
+
+const MAX_EMAIL_LENGTH: usize = 254;
+
+// Basic shape check: non-empty local and domain parts separated by '@',
+// domain must contain a '.', no whitespace. This is intentionally loose:
+// full RFC 5322 validation is not the goal. Verified-email gating is
+// enforced elsewhere (invite matching) where it actually matters.
+fn validate_email_shape(value: &str) -> ApiResult<()> {
+    if value.is_empty() {
+        return Err(ApiError::client_error("Email cannot be empty.".to_string()));
+    }
+    if value.len() > MAX_EMAIL_LENGTH {
+        return Err(ApiError::client_error(format!(
+            "Email cannot exceed {MAX_EMAIL_LENGTH} characters."
+        )));
+    }
+    if value.chars().any(char::is_whitespace) {
+        return Err(ApiError::client_error(
+            "Email cannot contain whitespace.".to_string(),
+        ));
+    }
+    let Some((local, domain)) = value.split_once('@') else {
+        return Err(ApiError::client_error(
+            "Email must contain an '@' symbol.".to_string(),
+        ));
+    };
+    if local.is_empty() || domain.is_empty() {
+        return Err(ApiError::client_error(
+            "Email must have a local and a domain part.".to_string(),
+        ));
+    }
+    if !domain.contains('.') {
+        return Err(ApiError::client_error(
+            "Email domain must contain a '.'.".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+pub struct Email(String);
+
+impl Email {
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+
+    #[allow(dead_code)]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for Email {
+    type Error = ApiError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        let normalized = value.trim().to_lowercase();
+        validate_email_shape(&normalized)?;
+        Ok(Email(normalized))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_basic_email() {
+        let email = Email::try_from("alice@example.com".to_string()).unwrap();
+        assert_eq!(email.into_inner(), "alice@example.com");
+    }
+
+    #[test]
+    fn normalizes_to_lowercase_and_trims() {
+        let email = Email::try_from("  Alice@Example.COM  ".to_string()).unwrap();
+        assert_eq!(email.into_inner(), "alice@example.com");
+    }
+
+    #[test]
+    fn rejects_empty() {
+        let err = Email::try_from("".to_string()).unwrap_err();
+        assert!(err.message().contains("Email cannot be empty"));
+    }
+
+    #[test]
+    fn rejects_missing_at() {
+        let err = Email::try_from("aliceexample.com".to_string()).unwrap_err();
+        assert!(err.message().contains("'@'"));
+    }
+
+    #[test]
+    fn rejects_missing_domain_dot() {
+        let err = Email::try_from("alice@example".to_string()).unwrap_err();
+        assert!(err.message().contains("domain must contain"));
+    }
+
+    #[test]
+    fn rejects_whitespace_inside() {
+        let err = Email::try_from("al ice@example.com".to_string()).unwrap_err();
+        assert!(err.message().contains("whitespace"));
+    }
+
+    #[test]
+    fn rejects_too_long() {
+        let long = format!("{}@example.com", "a".repeat(MAX_EMAIL_LENGTH));
+        let err = Email::try_from(long).unwrap_err();
+        assert!(err.message().contains("cannot exceed"));
+    }
+}

--- a/src/backend/src/validation/email.rs
+++ b/src/backend/src/validation/email.rs
@@ -35,6 +35,11 @@ fn validate_email_shape(value: &str) -> ApiResult<()> {
             "Email domain must contain a '.'.".to_string(),
         ));
     }
+    if domain.split('.').any(|part| part.is_empty()) {
+        return Err(ApiError::client_error(
+            "Email domain labels must not be empty.".to_string(),
+        ));
+    }
     Ok(())
 }
 
@@ -100,6 +105,24 @@ mod tests {
     fn rejects_whitespace_inside() {
         let err = Email::try_from("al ice@example.com".to_string()).unwrap_err();
         assert!(err.message().contains("whitespace"));
+    }
+
+    #[test]
+    fn rejects_leading_dot_in_domain() {
+        let err = Email::try_from("alice@.example.com".to_string()).unwrap_err();
+        assert!(err.message().contains("domain labels"));
+    }
+
+    #[test]
+    fn rejects_trailing_dot_in_domain() {
+        let err = Email::try_from("alice@example.".to_string()).unwrap_err();
+        assert!(err.message().contains("domain labels"));
+    }
+
+    #[test]
+    fn rejects_consecutive_dots_in_domain() {
+        let err = Email::try_from("alice@example..com".to_string()).unwrap_err();
+        assert!(err.message().contains("domain labels"));
     }
 
     #[test]

--- a/src/backend/src/validation/mod.rs
+++ b/src/backend/src/validation/mod.rs
@@ -1,3 +1,5 @@
+mod email;
 mod name;
 
+pub use email::Email;
 pub use name::{OrgName, TeamName};

--- a/src/frontend/src/components/layout/header-menu.tsx
+++ b/src/frontend/src/components/layout/header-menu.tsx
@@ -16,6 +16,7 @@ import {
   ClipboardIcon,
   CogIcon,
   LogOutIcon,
+  MailIcon,
   ScrollTextIcon,
   ServerIcon,
 } from 'lucide-react';
@@ -23,9 +24,10 @@ import { useMemo, type FC } from 'react';
 import { NavLink } from 'react-router';
 
 export const HeaderMenu: FC = () => {
-  const { identity, logout, termsAndConditions } = useAppStore();
+  const { identity, logout, termsAndConditions, myInvites } = useAppStore();
   const isActive = useAppStore(selectIsActive);
   const isAdmin = useAppStore(selectIsAdmin);
+  const pendingInviteCount = myInvites.length;
 
   const principal = useMemo(
     () => identity?.getPrincipal().toString(),
@@ -86,6 +88,22 @@ export const HeaderMenu: FC = () => {
             >
               Canisters
               <ServerIcon />
+            </DropdownMenuItem>
+          )}
+
+          {isActive && (
+            <DropdownMenuItem
+              className="justify-between"
+              render={<NavLink to="/invitations" />}
+            >
+              Invitations
+              {pendingInviteCount > 0 ? (
+                <span className="bg-primary text-primary-foreground ml-auto rounded-full px-1.5 text-xs">
+                  {pendingInviteCount}
+                </span>
+              ) : (
+                <MailIcon />
+              )}
             </DropdownMenuItem>
           )}
 

--- a/src/frontend/src/lib/api-models/index.ts
+++ b/src/frontend/src/lib/api-models/index.ts
@@ -1,6 +1,7 @@
 export * from './canister';
 export * from './canister-history';
 export * from './error';
+export * from './invite';
 export * from './management-canister';
 export * from './organization';
 export * from './project';

--- a/src/frontend/src/lib/api-models/invite.ts
+++ b/src/frontend/src/lib/api-models/invite.ts
@@ -1,0 +1,170 @@
+import type { Principal } from '@icp-sdk/core/principal';
+import { mapOkResponse } from '@/lib/api-models/error';
+import type {
+  CreateOrgInviteRequest as ApiCreateOrgInviteRequest,
+  CreateOrgInviteResponse as ApiCreateOrgInviteResponse,
+  ListOrgInvitesRequest as ApiListOrgInvitesRequest,
+  ListOrgInvitesResponse as ApiListOrgInvitesResponse,
+  ListMyInvitesResponse as ApiListMyInvitesResponse,
+  RevokeOrgInviteRequest as ApiRevokeOrgInviteRequest,
+  RevokeOrgInviteResponse as ApiRevokeOrgInviteResponse,
+  AcceptOrgInviteRequest as ApiAcceptOrgInviteRequest,
+  AcceptOrgInviteResponse as ApiAcceptOrgInviteResponse,
+  DeclineOrgInviteRequest as ApiDeclineOrgInviteRequest,
+  DeclineOrgInviteResponse as ApiDeclineOrgInviteResponse,
+  OrgInvite as ApiOrgInvite,
+  InviteTarget as ApiInviteTarget,
+  InviteStatus as ApiInviteStatus,
+} from '@ssn/backend-api';
+
+export type InviteTargetKind = 'email' | 'userId' | 'principal';
+
+export type InviteTarget =
+  | { kind: 'email'; email: string }
+  | { kind: 'userId'; userId: string }
+  | { kind: 'principal'; principal: Principal };
+
+export type InviteStatus = 'pending' | 'accepted' | 'declined' | 'revoked';
+
+export type OrgInvite = {
+  id: string;
+  orgId: string;
+  orgName: string;
+  createdBy: string;
+  createdAtNs: bigint;
+  expiresAtNs: bigint;
+  target: InviteTarget;
+  status: InviteStatus;
+};
+
+export type CreateOrgInviteRequest = {
+  orgId: string;
+  target: InviteTarget;
+};
+
+export type ListOrgInvitesRequest = {
+  orgId: string;
+};
+
+export type RevokeOrgInviteRequest = {
+  inviteId: string;
+};
+
+export type AcceptOrgInviteRequest = {
+  inviteId: string;
+};
+
+export type DeclineOrgInviteRequest = {
+  inviteId: string;
+};
+
+function mapInviteTargetRequest(target: InviteTarget): ApiInviteTarget {
+  switch (target.kind) {
+    case 'email':
+      return { Email: target.email };
+    case 'userId':
+      return { UserId: target.userId };
+    case 'principal':
+      return { Principal: target.principal };
+  }
+}
+
+function mapInviteTargetResponse(target: ApiInviteTarget): InviteTarget {
+  if ('Email' in target) {
+    return { kind: 'email', email: target.Email };
+  }
+  if ('UserId' in target) {
+    return { kind: 'userId', userId: target.UserId };
+  }
+  return { kind: 'principal', principal: target.Principal };
+}
+
+function mapInviteStatus(status: ApiInviteStatus): InviteStatus {
+  if ('Pending' in status) return 'pending';
+  if ('Accepted' in status) return 'accepted';
+  if ('Declined' in status) return 'declined';
+  return 'revoked';
+}
+
+function mapInvite(inv: ApiOrgInvite): OrgInvite {
+  return {
+    id: inv.id,
+    orgId: inv.org_id,
+    orgName: inv.org_name,
+    createdBy: inv.created_by,
+    createdAtNs: inv.created_at_ns,
+    expiresAtNs: inv.expires_at_ns,
+    target: mapInviteTargetResponse(inv.target),
+    status: mapInviteStatus(inv.status),
+  };
+}
+
+export function mapCreateOrgInviteRequest(
+  req: CreateOrgInviteRequest,
+): ApiCreateOrgInviteRequest {
+  return {
+    org_id: req.orgId,
+    target: mapInviteTargetRequest(req.target),
+  };
+}
+
+export function mapCreateOrgInviteResponse(
+  res: ApiCreateOrgInviteResponse,
+): OrgInvite {
+  const okRes = mapOkResponse(res);
+  return mapInvite(okRes.invite);
+}
+
+export function mapListOrgInvitesRequest(
+  req: ListOrgInvitesRequest,
+): ApiListOrgInvitesRequest {
+  return { org_id: req.orgId };
+}
+
+export function mapListOrgInvitesResponse(
+  res: ApiListOrgInvitesResponse,
+): OrgInvite[] {
+  return mapOkResponse(res).map(mapInvite);
+}
+
+export function mapListMyInvitesResponse(
+  res: ApiListMyInvitesResponse,
+): OrgInvite[] {
+  return mapOkResponse(res).map(mapInvite);
+}
+
+export function mapRevokeOrgInviteRequest(
+  req: RevokeOrgInviteRequest,
+): ApiRevokeOrgInviteRequest {
+  return { invite_id: req.inviteId };
+}
+
+export function mapRevokeOrgInviteResponse(
+  res: ApiRevokeOrgInviteResponse,
+): void {
+  mapOkResponse(res);
+}
+
+export function mapAcceptOrgInviteRequest(
+  req: AcceptOrgInviteRequest,
+): ApiAcceptOrgInviteRequest {
+  return { invite_id: req.inviteId };
+}
+
+export function mapAcceptOrgInviteResponse(
+  res: ApiAcceptOrgInviteResponse,
+): void {
+  mapOkResponse(res);
+}
+
+export function mapDeclineOrgInviteRequest(
+  req: DeclineOrgInviteRequest,
+): ApiDeclineOrgInviteRequest {
+  return { invite_id: req.inviteId };
+}
+
+export function mapDeclineOrgInviteResponse(
+  res: ApiDeclineOrgInviteResponse,
+): void {
+  mapOkResponse(res);
+}

--- a/src/frontend/src/lib/api-models/organization.ts
+++ b/src/frontend/src/lib/api-models/organization.ts
@@ -9,7 +9,10 @@ import type {
   UpdateOrganizationResponse as ApiUpdateOrganizationResponse,
   DeleteOrganizationRequest as ApiDeleteOrganizationRequest,
   DeleteOrganizationResponse as ApiDeleteOrganizationResponse,
+  ListOrgUsersRequest as ApiListOrgUsersRequest,
+  ListOrgUsersResponse as ApiListOrgUsersResponse,
   Organization as ApiOrganization,
+  OrgUser as ApiOrgUser,
 } from '@ssn/backend-api';
 
 export type Organization = {
@@ -108,4 +111,34 @@ export function mapDeleteOrganizationResponse(
   res: ApiDeleteOrganizationResponse,
 ): void {
   mapOkResponse(res);
+}
+
+export type OrgUser = {
+  id: string;
+  email: string | null;
+  emailVerified: boolean;
+};
+
+export type ListOrgUsersRequest = {
+  orgId: string;
+};
+
+function mapOrgUserResponse(user: ApiOrgUser): OrgUser {
+  return {
+    id: user.id,
+    email: user.email[0] ?? null,
+    emailVerified: user.email_verified,
+  };
+}
+
+export function mapListOrgUsersRequest(
+  req: ListOrgUsersRequest,
+): ApiListOrgUsersRequest {
+  return { org_id: req.orgId };
+}
+
+export function mapListOrgUsersResponse(
+  res: ApiListOrgUsersResponse,
+): OrgUser[] {
+  return mapOkResponse(res).map(mapOrgUserResponse);
 }

--- a/src/frontend/src/lib/api-models/team.ts
+++ b/src/frontend/src/lib/api-models/team.ts
@@ -12,7 +12,10 @@ import type {
   DeleteTeamResponse as ApiDeleteTeamResponse,
   AddUserToTeamRequest as ApiAddUserToTeamRequest,
   AddUserToTeamResponse as ApiAddUserToTeamResponse,
+  ListTeamUsersRequest as ApiListTeamUsersRequest,
+  ListTeamUsersResponse as ApiListTeamUsersResponse,
   Team as ApiTeam,
+  TeamUser as ApiTeamUser,
 } from '@ssn/backend-api';
 
 export type Team = {
@@ -130,4 +133,34 @@ export function mapAddUserToTeamRequest(
 
 export function mapAddUserToTeamResponse(res: ApiAddUserToTeamResponse): void {
   mapOkResponse(res);
+}
+
+export type TeamUser = {
+  id: string;
+  email: string | null;
+  emailVerified: boolean;
+};
+
+export type ListTeamUsersRequest = {
+  teamId: string;
+};
+
+function mapTeamUser(user: ApiTeamUser): TeamUser {
+  return {
+    id: user.id,
+    email: user.email[0] ?? null,
+    emailVerified: user.email_verified,
+  };
+}
+
+export function mapListTeamUsersRequest(
+  req: ListTeamUsersRequest,
+): ApiListTeamUsersRequest {
+  return { team_id: req.teamId };
+}
+
+export function mapListTeamUsersResponse(
+  res: ApiListTeamUsersResponse,
+): TeamUser[] {
+  return mapOkResponse(res).map(mapTeamUser);
 }

--- a/src/frontend/src/lib/api/index.ts
+++ b/src/frontend/src/lib/api/index.ts
@@ -1,5 +1,6 @@
 export * from './canister';
 export * from './canister-history';
+export * from './invite';
 export * from './management-canister';
 export * from './organization';
 export * from './project';

--- a/src/frontend/src/lib/api/invite.ts
+++ b/src/frontend/src/lib/api/invite.ts
@@ -1,0 +1,67 @@
+import {
+  mapAcceptOrgInviteRequest,
+  mapAcceptOrgInviteResponse,
+  mapCreateOrgInviteRequest,
+  mapCreateOrgInviteResponse,
+  mapDeclineOrgInviteRequest,
+  mapDeclineOrgInviteResponse,
+  mapListMyInvitesResponse,
+  mapListOrgInvitesRequest,
+  mapListOrgInvitesResponse,
+  mapRevokeOrgInviteRequest,
+  mapRevokeOrgInviteResponse,
+  type AcceptOrgInviteRequest,
+  type CreateOrgInviteRequest,
+  type DeclineOrgInviteRequest,
+  type ListOrgInvitesRequest,
+  type OrgInvite,
+  type RevokeOrgInviteRequest,
+} from '@/lib/api-models';
+import type { ActorSubclass } from '@icp-sdk/core/agent';
+import type { _SERVICE } from '@ssn/backend-api';
+
+export class InviteApi {
+  constructor(private readonly actor: ActorSubclass<_SERVICE>) {}
+
+  public async createOrgInvite(
+    req: CreateOrgInviteRequest,
+  ): Promise<OrgInvite> {
+    const res = await this.actor.create_org_invite(
+      mapCreateOrgInviteRequest(req),
+    );
+    return mapCreateOrgInviteResponse(res);
+  }
+
+  public async listOrgInvites(
+    req: ListOrgInvitesRequest,
+  ): Promise<OrgInvite[]> {
+    const res = await this.actor.list_org_invites(mapListOrgInvitesRequest(req));
+    return mapListOrgInvitesResponse(res);
+  }
+
+  public async revokeOrgInvite(req: RevokeOrgInviteRequest): Promise<void> {
+    const res = await this.actor.revoke_org_invite(
+      mapRevokeOrgInviteRequest(req),
+    );
+    mapRevokeOrgInviteResponse(res);
+  }
+
+  public async listMyInvites(): Promise<OrgInvite[]> {
+    const res = await this.actor.list_my_invites();
+    return mapListMyInvitesResponse(res);
+  }
+
+  public async acceptOrgInvite(req: AcceptOrgInviteRequest): Promise<void> {
+    const res = await this.actor.accept_org_invite(
+      mapAcceptOrgInviteRequest(req),
+    );
+    mapAcceptOrgInviteResponse(res);
+  }
+
+  public async declineOrgInvite(req: DeclineOrgInviteRequest): Promise<void> {
+    const res = await this.actor.decline_org_invite(
+      mapDeclineOrgInviteRequest(req),
+    );
+    mapDeclineOrgInviteResponse(res);
+  }
+}

--- a/src/frontend/src/lib/api/invite.ts
+++ b/src/frontend/src/lib/api/invite.ts
@@ -35,7 +35,9 @@ export class InviteApi {
   public async listOrgInvites(
     req: ListOrgInvitesRequest,
   ): Promise<OrgInvite[]> {
-    const res = await this.actor.list_org_invites(mapListOrgInvitesRequest(req));
+    const res = await this.actor.list_org_invites(
+      mapListOrgInvitesRequest(req),
+    );
     return mapListOrgInvitesResponse(res);
   }
 

--- a/src/frontend/src/lib/api/organization.ts
+++ b/src/frontend/src/lib/api/organization.ts
@@ -8,12 +8,16 @@ import {
   mapUpdateOrganizationResponse,
   mapDeleteOrganizationRequest,
   mapDeleteOrganizationResponse,
+  mapListOrgUsersRequest,
+  mapListOrgUsersResponse,
   type ListMyOrganizationsResponse,
   type CreateOrganizationRequest,
   type OrganizationResponse,
   type GetOrganizationRequest,
   type UpdateOrganizationRequest,
   type DeleteOrganizationRequest,
+  type ListOrgUsersRequest,
+  type OrgUser,
 } from '@/lib/api-models';
 import type { ActorSubclass } from '@icp-sdk/core/agent';
 import type { _SERVICE } from '@ssn/backend-api';
@@ -60,5 +64,10 @@ export class OrganizationApi {
       mapDeleteOrganizationRequest(req),
     );
     mapDeleteOrganizationResponse(res);
+  }
+
+  public async listOrgUsers(req: ListOrgUsersRequest): Promise<OrgUser[]> {
+    const res = await this.actor.list_org_users(mapListOrgUsersRequest(req));
+    return mapListOrgUsersResponse(res);
   }
 }

--- a/src/frontend/src/lib/api/team.ts
+++ b/src/frontend/src/lib/api/team.ts
@@ -11,6 +11,8 @@ import {
   mapDeleteTeamResponse,
   mapAddUserToTeamRequest,
   mapAddUserToTeamResponse,
+  mapListTeamUsersRequest,
+  mapListTeamUsersResponse,
   type ListTeamsResponse,
   type ListOrgTeamsRequest,
   type CreateTeamRequest,
@@ -19,6 +21,8 @@ import {
   type UpdateTeamRequest,
   type DeleteTeamRequest,
   type AddUserToTeamRequest,
+  type ListTeamUsersRequest,
+  type TeamUser,
 } from '@/lib/api-models';
 import type { ActorSubclass } from '@icp-sdk/core/agent';
 import type { _SERVICE } from '@ssn/backend-api';
@@ -61,5 +65,10 @@ export class TeamApi {
   public async addUserToTeam(req: AddUserToTeamRequest): Promise<void> {
     const res = await this.actor.add_user_to_team(mapAddUserToTeamRequest(req));
     mapAddUserToTeamResponse(res);
+  }
+
+  public async listTeamUsers(req: ListTeamUsersRequest): Promise<TeamUser[]> {
+    const res = await this.actor.list_team_users(mapListTeamUsersRequest(req));
+    return mapListTeamUsersResponse(res);
   }
 }

--- a/src/frontend/src/lib/store/api.ts
+++ b/src/frontend/src/lib/store/api.ts
@@ -13,6 +13,7 @@ import {
   ProjectApi,
   OrganizationApi,
   TeamApi,
+  InviteApi,
   AuthApi,
 } from '@/lib/api';
 import { OFFCHAIN_SERVICE_URL } from '@/env';
@@ -65,6 +66,7 @@ const termsAndConditionsApi = new TermsAndConditionsApi(actor);
 const projectApi = new ProjectApi(actor);
 const organizationApi = new OrganizationApi(actor);
 const teamApi = new TeamApi(actor);
+const inviteApi = new InviteApi(actor);
 const canisterHistoryApi = new CanisterHistoryApi(canisterHistoryActor);
 const authApi = new AuthApi(OFFCHAIN_SERVICE_URL);
 
@@ -80,6 +82,7 @@ export const createApiSlice: AppStateCreator<ApiSlice> = (_set, get) => ({
   projectApi,
   organizationApi,
   teamApi,
+  inviteApi,
   authApi,
 
   setAgentIdentity: identity => {

--- a/src/frontend/src/lib/store/app.ts
+++ b/src/frontend/src/lib/store/app.ts
@@ -1,6 +1,7 @@
 import { createApiSlice } from '@/lib/store/api';
 import { createAuthSlice } from '@/lib/store/auth';
 import { createCanistersSlice } from '@/lib/store/canister';
+import { createInvitesSlice } from '@/lib/store/invite';
 import type { AppSlice } from '@/lib/store/model';
 import { createOrganizationsSlice } from '@/lib/store/organization';
 import { createProjectsSlice } from '@/lib/store/project';
@@ -22,4 +23,5 @@ export const useAppStore = create<AppSlice>()((...a) => ({
   ...createProjectsSlice(...a),
   ...createOrganizationsSlice(...a),
   ...createTeamsSlice(...a),
+  ...createInvitesSlice(...a),
 }));

--- a/src/frontend/src/lib/store/auth.ts
+++ b/src/frontend/src/lib/store/auth.ts
@@ -26,6 +26,7 @@ export const createAuthSlice: AppStateCreator<AuthSlice> = (set, get) => ({
       initializeProjects,
       initializeOrganizations,
       initializeTeams,
+      initializeMyInvites,
     } = get();
 
     await initializeUserProfile();
@@ -36,6 +37,7 @@ export const createAuthSlice: AppStateCreator<AuthSlice> = (set, get) => ({
       initializeProjects(),
       initializeOrganizations(),
       initializeTeams(),
+      initializeMyInvites(),
     ]);
   },
 
@@ -117,6 +119,7 @@ export const createAuthSlice: AppStateCreator<AuthSlice> = (set, get) => ({
       clearProjects,
       clearOrganizations,
       clearTeams,
+      clearMyInvites,
       setAgentIdentity,
     } = get();
     if (isNil(authClient)) {
@@ -141,6 +144,7 @@ export const createAuthSlice: AppStateCreator<AuthSlice> = (set, get) => ({
       clearProjects();
       clearOrganizations();
       clearTeams();
+      clearMyInvites();
     }
   },
 });

--- a/src/frontend/src/lib/store/index.ts
+++ b/src/frontend/src/lib/store/index.ts
@@ -1,6 +1,7 @@
 export * from './api';
 export * from './app';
 export * from './auth';
+export * from './invite';
 export * from './model';
 export * from './organization';
 export * from './project';

--- a/src/frontend/src/lib/store/invite.ts
+++ b/src/frontend/src/lib/store/invite.ts
@@ -9,14 +9,14 @@ export const createInvitesSlice: AppStateCreator<InvitesSlice> = (
   myInvites: [],
 
   async initializeMyInvites() {
-    const { getInviteApi, isAuthenticated } = get();
+    const { inviteApi, isAuthenticated } = get();
     if (!isAuthenticated) {
       set({ isMyInvitesInitialized: true });
       return;
     }
 
     try {
-      const invites = await getInviteApi().listMyInvites();
+      const invites = await inviteApi.listMyInvites();
       set({ myInvites: invites });
     } finally {
       set({ isMyInvitesInitialized: true });
@@ -28,24 +28,24 @@ export const createInvitesSlice: AppStateCreator<InvitesSlice> = (
   },
 
   async refreshMyInvites() {
-    const invites = await get().getInviteApi().listMyInvites();
+    const invites = await get().inviteApi.listMyInvites();
     set({ myInvites: invites });
   },
 
   async createOrgInvite(req: CreateOrgInviteRequest): Promise<OrgInvite> {
-    return get().getInviteApi().createOrgInvite(req);
+    return get().inviteApi.createOrgInvite(req);
   },
 
   async listOrgInvites(orgId: string): Promise<OrgInvite[]> {
-    return get().getInviteApi().listOrgInvites({ orgId });
+    return get().inviteApi.listOrgInvites({ orgId });
   },
 
   async revokeOrgInvite(inviteId: string): Promise<void> {
-    await get().getInviteApi().revokeOrgInvite({ inviteId });
+    await get().inviteApi.revokeOrgInvite({ inviteId });
   },
 
   async acceptOrgInvite(inviteId: string): Promise<void> {
-    await get().getInviteApi().acceptOrgInvite({ inviteId });
+    await get().inviteApi.acceptOrgInvite({ inviteId });
     set(state => ({
       myInvites: state.myInvites.filter(i => i.id !== inviteId),
     }));
@@ -53,7 +53,7 @@ export const createInvitesSlice: AppStateCreator<InvitesSlice> = (
   },
 
   async declineOrgInvite(inviteId: string): Promise<void> {
-    await get().getInviteApi().declineOrgInvite({ inviteId });
+    await get().inviteApi.declineOrgInvite({ inviteId });
     set(state => ({
       myInvites: state.myInvites.filter(i => i.id !== inviteId),
     }));

--- a/src/frontend/src/lib/store/invite.ts
+++ b/src/frontend/src/lib/store/invite.ts
@@ -1,0 +1,64 @@
+import type {
+  CreateOrgInviteRequest,
+  OrgInvite,
+} from '@/lib/api-models';
+import type { AppStateCreator, InvitesSlice } from '@/lib/store/model';
+
+export const createInvitesSlice: AppStateCreator<InvitesSlice> = (
+  set,
+  get,
+) => ({
+  isMyInvitesInitialized: false,
+  myInvites: [],
+
+  async initializeMyInvites() {
+    const { getInviteApi, isAuthenticated } = get();
+    if (!isAuthenticated) {
+      set({ isMyInvitesInitialized: true });
+      return;
+    }
+
+    try {
+      const invites = await getInviteApi().listMyInvites();
+      set({ myInvites: invites });
+    } finally {
+      set({ isMyInvitesInitialized: true });
+    }
+  },
+
+  clearMyInvites() {
+    set({ myInvites: [], isMyInvitesInitialized: false });
+  },
+
+  async refreshMyInvites() {
+    const invites = await get().getInviteApi().listMyInvites();
+    set({ myInvites: invites });
+  },
+
+  async createOrgInvite(req: CreateOrgInviteRequest): Promise<OrgInvite> {
+    return get().getInviteApi().createOrgInvite(req);
+  },
+
+  async listOrgInvites(orgId: string): Promise<OrgInvite[]> {
+    return get().getInviteApi().listOrgInvites({ orgId });
+  },
+
+  async revokeOrgInvite(inviteId: string): Promise<void> {
+    await get().getInviteApi().revokeOrgInvite({ inviteId });
+  },
+
+  async acceptOrgInvite(inviteId: string): Promise<void> {
+    await get().getInviteApi().acceptOrgInvite({ inviteId });
+    set(state => ({
+      myInvites: state.myInvites.filter(i => i.id !== inviteId),
+    }));
+    await get().initializeOrganizations();
+  },
+
+  async declineOrgInvite(inviteId: string): Promise<void> {
+    await get().getInviteApi().declineOrgInvite({ inviteId });
+    set(state => ({
+      myInvites: state.myInvites.filter(i => i.id !== inviteId),
+    }));
+  },
+});

--- a/src/frontend/src/lib/store/invite.ts
+++ b/src/frontend/src/lib/store/invite.ts
@@ -1,7 +1,4 @@
-import type {
-  CreateOrgInviteRequest,
-  OrgInvite,
-} from '@/lib/api-models';
+import type { CreateOrgInviteRequest, OrgInvite } from '@/lib/api-models';
 import type { AppStateCreator, InvitesSlice } from '@/lib/store/model';
 
 export const createInvitesSlice: AppStateCreator<InvitesSlice> = (

--- a/src/frontend/src/lib/store/model.ts
+++ b/src/frontend/src/lib/store/model.ts
@@ -1,6 +1,8 @@
 import type {
   Canister,
   CreateTrustedPartnerRequest,
+  CreateOrgInviteRequest,
+  OrgInvite,
   TrustedPartner,
   UserProfile,
   UserStatus,
@@ -22,6 +24,7 @@ import type {
   ProjectApi,
   OrganizationApi,
   TeamApi,
+  InviteApi,
   AuthApi,
 } from '@/lib/api';
 import type { ActorSubclass, HttpAgent, Identity } from '@icp-sdk/core/agent';
@@ -55,6 +58,7 @@ export type ApiSlice = {
   projectApi: ProjectApi;
   organizationApi: OrganizationApi;
   teamApi: TeamApi;
+  inviteApi: InviteApi;
 
   setAgentIdentity: (identity: Identity) => void;
 };
@@ -144,6 +148,21 @@ export type OrganizationsSlice = {
   createOrganization: (name: string) => Promise<Organization>;
   updateOrganization: (orgId: string, name: string) => Promise<Organization>;
   deleteOrganization: (orgId: string) => Promise<void>;
+  loadOrgUsers: (orgId: string) => Promise<import('@/lib/api-models').OrgUser[]>;
+};
+
+export type InvitesSlice = {
+  isMyInvitesInitialized: boolean;
+  myInvites: OrgInvite[];
+
+  initializeMyInvites: () => Promise<void>;
+  clearMyInvites: () => void;
+  refreshMyInvites: () => Promise<void>;
+  createOrgInvite: (req: CreateOrgInviteRequest) => Promise<OrgInvite>;
+  listOrgInvites: (orgId: string) => Promise<OrgInvite[]>;
+  revokeOrgInvite: (inviteId: string) => Promise<void>;
+  acceptOrgInvite: (inviteId: string) => Promise<void>;
+  declineOrgInvite: (inviteId: string) => Promise<void>;
 };
 
 export type TeamsSlice = {
@@ -157,6 +176,9 @@ export type TeamsSlice = {
   updateTeam: (teamId: string, name: string) => Promise<Team>;
   deleteTeam: (teamId: string) => Promise<void>;
   addUserToTeam: (teamId: string, userId: string) => Promise<void>;
+  loadTeamUsers: (
+    teamId: string,
+  ) => Promise<import('@/lib/api-models').TeamUser[]>;
 };
 
 export type AppSlice = AuthSlice &
@@ -168,6 +190,7 @@ export type AppSlice = AuthSlice &
   TermsAndConditionsSlice &
   ProjectsSlice &
   OrganizationsSlice &
-  TeamsSlice;
+  TeamsSlice &
+  InvitesSlice;
 
 export type AppStateCreator<T> = StateCreator<AppSlice, [], [], T>;

--- a/src/frontend/src/lib/store/model.ts
+++ b/src/frontend/src/lib/store/model.ts
@@ -148,7 +148,9 @@ export type OrganizationsSlice = {
   createOrganization: (name: string) => Promise<Organization>;
   updateOrganization: (orgId: string, name: string) => Promise<Organization>;
   deleteOrganization: (orgId: string) => Promise<void>;
-  loadOrgUsers: (orgId: string) => Promise<import('@/lib/api-models').OrgUser[]>;
+  loadOrgUsers: (
+    orgId: string,
+  ) => Promise<import('@/lib/api-models').OrgUser[]>;
 };
 
 export type InvitesSlice = {

--- a/src/frontend/src/lib/store/organization.ts
+++ b/src/frontend/src/lib/store/organization.ts
@@ -61,6 +61,10 @@ export const createOrganizationsSlice: AppStateCreator<OrganizationsSlice> = (
       organizations: state.organizations.filter(org => org.id !== orgId),
     }));
   },
+
+  async loadOrgUsers(orgId: string) {
+    return get().getOrganizationApi().listOrgUsers({ orgId });
+  },
 });
 
 function selectOrgs(state: AppSlice): Organization[] {

--- a/src/frontend/src/lib/store/organization.ts
+++ b/src/frontend/src/lib/store/organization.ts
@@ -63,7 +63,7 @@ export const createOrganizationsSlice: AppStateCreator<OrganizationsSlice> = (
   },
 
   async loadOrgUsers(orgId: string) {
-    return get().getOrganizationApi().listOrgUsers({ orgId });
+    return get().organizationApi.listOrgUsers({ orgId });
   },
 });
 

--- a/src/frontend/src/lib/store/team.ts
+++ b/src/frontend/src/lib/store/team.ts
@@ -62,6 +62,10 @@ export const createTeamsSlice: AppStateCreator<TeamsSlice> = (set, get) => ({
     const teamApi = get().teamApi;
     await teamApi.addUserToTeam({ teamId, userId });
   },
+
+  async loadTeamUsers(teamId: string) {
+    return get().getTeamApi().listTeamUsers({ teamId });
+  },
 });
 
 function selectTeams(state: AppSlice): Team[] {

--- a/src/frontend/src/lib/store/team.ts
+++ b/src/frontend/src/lib/store/team.ts
@@ -64,7 +64,7 @@ export const createTeamsSlice: AppStateCreator<TeamsSlice> = (set, get) => ({
   },
 
   async loadTeamUsers(teamId: string) {
-    return get().getTeamApi().listTeamUsers({ teamId });
+    return get().teamApi.listTeamUsers({ teamId });
   },
 });
 

--- a/src/frontend/src/router.tsx
+++ b/src/frontend/src/router.tsx
@@ -33,6 +33,9 @@ const TeamSettings = lazy(
   () => import('@/routes/organizations/teams/team-settings'),
 );
 const UserCanisters = lazy(() => import('@/routes/admin/user-canisters'));
+const MyInvitations = lazy(
+  () => import('@/routes/invitations/my-invitations'),
+);
 
 export const Router: FC = () => (
   <BrowserRouter>
@@ -60,6 +63,7 @@ export const Router: FC = () => (
             path="organizations/:orgId/teams/:teamId/settings"
             element={<TeamSettings />}
           />
+          <Route path="invitations" element={<MyInvitations />} />
 
           <Route path="projects/:projectId" element={<ProjectLayout />}>
             <Route path="canisters" element={<Canisters />} />

--- a/src/frontend/src/router.tsx
+++ b/src/frontend/src/router.tsx
@@ -33,9 +33,7 @@ const TeamSettings = lazy(
   () => import('@/routes/organizations/teams/team-settings'),
 );
 const UserCanisters = lazy(() => import('@/routes/admin/user-canisters'));
-const MyInvitations = lazy(
-  () => import('@/routes/invitations/my-invitations'),
-);
+const MyInvitations = lazy(() => import('@/routes/invitations/my-invitations'));
 
 export const Router: FC = () => (
   <BrowserRouter>

--- a/src/frontend/src/routes/invitations/my-invitations.tsx
+++ b/src/frontend/src/routes/invitations/my-invitations.tsx
@@ -1,15 +1,11 @@
 import { Container } from '@/components/layout/container';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
 import { LoadingButton } from '@/components/loading-button';
 import { useAppStore } from '@/lib/store';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
-import { ArrowLeft } from 'lucide-react';
 import { useState, type FC } from 'react';
-import { useNavigate } from 'react-router';
 
 const MyInvitations: FC = () => {
-  const navigate = useNavigate();
   const { myInvites, acceptOrgInvite, declineOrgInvite } = useAppStore();
   const [busyId, setBusyId] = useState<string | null>(null);
 
@@ -40,17 +36,6 @@ const MyInvitations: FC = () => {
   return (
     <Container>
       <div className="space-y-6">
-        <div className="mx-auto max-w-2xl">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => navigate('/', { replace: true })}
-          >
-            <ArrowLeft className="mr-1 size-3.5" />
-            Back
-          </Button>
-        </div>
-
         <Card className="mx-auto max-w-2xl">
           <CardHeader>
             <CardTitle>Your invitations</CardTitle>

--- a/src/frontend/src/routes/invitations/my-invitations.tsx
+++ b/src/frontend/src/routes/invitations/my-invitations.tsx
@@ -1,0 +1,108 @@
+import { Container } from '@/components/layout/container';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { LoadingButton } from '@/components/loading-button';
+import { useAppStore } from '@/lib/store';
+import { showErrorToast, showSuccessToast } from '@/lib/toast';
+import { ArrowLeft } from 'lucide-react';
+import { useState, type FC } from 'react';
+import { useNavigate } from 'react-router';
+
+const MyInvitations: FC = () => {
+  const navigate = useNavigate();
+  const { myInvites, acceptOrgInvite, declineOrgInvite } = useAppStore();
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  async function onAccept(inviteId: string): Promise<void> {
+    setBusyId(inviteId);
+    try {
+      await acceptOrgInvite(inviteId);
+      showSuccessToast('Invitation accepted');
+    } catch (err) {
+      showErrorToast('Failed to accept invitation', err);
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function onDecline(inviteId: string): Promise<void> {
+    setBusyId(inviteId);
+    try {
+      await declineOrgInvite(inviteId);
+      showSuccessToast('Invitation declined');
+    } catch (err) {
+      showErrorToast('Failed to decline invitation', err);
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <Container>
+      <div className="space-y-6">
+        <div className="mx-auto max-w-2xl">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => navigate('/', { replace: true })}
+          >
+            <ArrowLeft className="mr-1 size-3.5" />
+            Back
+          </Button>
+        </div>
+
+        <Card className="mx-auto max-w-2xl">
+          <CardHeader>
+            <CardTitle>Your invitations</CardTitle>
+          </CardHeader>
+
+          <CardContent>
+            {myInvites.length === 0 ? (
+              <p className="text-muted-foreground text-sm">
+                You have no pending invitations.
+              </p>
+            ) : (
+              <ul className="divide-y">
+                {myInvites.map(inv => (
+                  <li
+                    key={inv.id}
+                    className="flex items-center justify-between py-3"
+                  >
+                    <div>
+                      <p className="font-medium">{inv.orgName}</p>
+                      <p className="text-muted-foreground text-xs">
+                        Expires{' '}
+                        {new Date(
+                          Number(inv.expiresAtNs / 1_000_000n),
+                        ).toLocaleString()}
+                      </p>
+                    </div>
+                    <div className="flex gap-2">
+                      <LoadingButton
+                        size="sm"
+                        variant="outline"
+                        isLoading={busyId === inv.id}
+                        onClick={() => onDecline(inv.id)}
+                      >
+                        Decline
+                      </LoadingButton>
+                      <LoadingButton
+                        size="sm"
+                        isLoading={busyId === inv.id}
+                        onClick={() => onAccept(inv.id)}
+                      >
+                        Accept
+                      </LoadingButton>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </Container>
+  );
+};
+
+export default MyInvitations;

--- a/src/frontend/src/routes/organizations/organization-invitations.tsx
+++ b/src/frontend/src/routes/organizations/organization-invitations.tsx
@@ -1,0 +1,301 @@
+import { LoadingButton } from '@/components/loading-button';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Separator } from '@/components/ui/separator';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/form';
+import { Input } from '@/components/ui/input';
+import type { InviteStatus, OrgInvite } from '@/lib/api-models';
+import { useAppStore } from '@/lib/store';
+import { showErrorToast, showSuccessToast } from '@/lib/toast';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
+import { useForm } from 'react-hook-form';
+import { Principal } from '@icp-sdk/core/principal';
+import { z } from 'zod';
+
+type InviteTargetKind = 'email' | 'userId' | 'principal';
+
+const inviteSchema = z
+  .object({
+    kind: z.enum(['email', 'userId', 'principal']),
+    value: z.string().trim().min(1, 'Value is required'),
+  })
+  .superRefine((data, ctx) => {
+    if (data.kind === 'email' && !data.value.includes('@')) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['value'],
+        message: 'Must be a valid email',
+      });
+    }
+    if (data.kind === 'principal') {
+      try {
+        Principal.fromText(data.value);
+      } catch {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['value'],
+          message: 'Must be a valid principal',
+        });
+      }
+    }
+  });
+
+type InviteFormData = z.infer<typeof inviteSchema>;
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function formatRelativeExpiry(expiresAtNs: bigint): string {
+  const diffMs = Number(expiresAtNs / 1_000_000n) - Date.now();
+  if (diffMs <= 0) return 'Expired';
+  const mins = Math.floor(diffMs / 60_000);
+  if (mins < 60) return `In ${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `In ${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `In ${days}d`;
+}
+
+function formatInviteTarget(invite: OrgInvite): string {
+  switch (invite.target.kind) {
+    case 'email':
+      return invite.target.email;
+    case 'userId':
+      return invite.target.userId;
+    case 'principal':
+      return invite.target.principal.toString();
+  }
+}
+
+function buildInviteTarget(kind: InviteTargetKind, value: string) {
+  switch (kind) {
+    case 'email':
+      return { kind: 'email' as const, email: value };
+    case 'userId':
+      return { kind: 'userId' as const, userId: value };
+    case 'principal':
+      return {
+        kind: 'principal' as const,
+        principal: Principal.fromText(value),
+      };
+  }
+}
+
+interface OrganizationInvitationsProps {
+  orgId: string;
+}
+
+export const OrganizationInvitations: FC<OrganizationInvitationsProps> = ({
+  orgId,
+}) => {
+  const { listOrgInvites, createOrgInvite, revokeOrgInvite } = useAppStore();
+
+  const inviteForm = useForm<InviteFormData>({
+    resolver: zodResolver(inviteSchema),
+    defaultValues: { kind: 'email', value: '' },
+  });
+
+  const [invites, setInvites] = useState<OrgInvite[]>([]);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<InviteStatus | 'all'>(
+    'pending',
+  );
+
+  const filteredInvites = useMemo(
+    () =>
+      statusFilter === 'all'
+        ? invites
+        : invites.filter(i => i.status === statusFilter),
+    [invites, statusFilter],
+  );
+
+  const refreshInvites = useCallback(async () => {
+    try {
+      setInvites(await listOrgInvites(orgId));
+    } catch (err) {
+      showErrorToast('Failed to load invitations', err);
+    }
+  }, [orgId, listOrgInvites]);
+
+  useEffect(() => {
+    refreshInvites();
+  }, [refreshInvites]);
+
+  async function onInviteSubmit(data: InviteFormData): Promise<void> {
+    try {
+      await createOrgInvite({
+        orgId,
+        target: buildInviteTarget(data.kind, data.value),
+      });
+      showSuccessToast('Invitation created');
+      inviteForm.reset({ kind: data.kind, value: '' });
+      await refreshInvites();
+    } catch (err) {
+      showErrorToast('Failed to create invitation', err);
+    }
+  }
+
+  async function onRevoke(inviteId: string): Promise<void> {
+    setRevokingId(inviteId);
+    try {
+      await revokeOrgInvite(inviteId);
+      showSuccessToast('Invitation revoked');
+      await refreshInvites();
+    } catch (err) {
+      showErrorToast('Failed to revoke invitation', err);
+    } finally {
+      setRevokingId(null);
+    }
+  }
+
+  return (
+    <Card className="mx-auto max-w-2xl">
+      <CardHeader>
+        <CardTitle>Invitations</CardTitle>
+      </CardHeader>
+
+      <CardContent className="space-y-6">
+        <p className="text-muted-foreground text-sm">
+          Invite users by email, user ID, or principal. Invitations expire after
+          7 days. Target existence is never disclosed.
+        </p>
+
+        <Form {...inviteForm}>
+          <form
+            className="space-y-4"
+            onSubmit={inviteForm.handleSubmit(onInviteSubmit)}
+          >
+            <FormField
+              control={inviteForm.control}
+              name="kind"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Target type</FormLabel>
+                  <FormControl>
+                    <select
+                      className="border-input bg-background flex h-9 w-full rounded-md border px-3 py-1 text-sm"
+                      value={field.value}
+                      onChange={e =>
+                        field.onChange(e.target.value as InviteTargetKind)
+                      }
+                    >
+                      <option value="email">Email</option>
+                      <option value="userId">User ID</option>
+                      <option value="principal">Principal</option>
+                    </select>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={inviteForm.control}
+              name="value"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Target</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <LoadingButton
+              type="submit"
+              isLoading={inviteForm.formState.isSubmitting}
+            >
+              Send invitation
+            </LoadingButton>
+          </form>
+        </Form>
+
+        <Separator />
+
+        <div className="flex flex-wrap gap-2">
+          {(['pending', 'accepted', 'declined', 'revoked', 'all'] as const).map(
+            s => (
+              <Button
+                key={s}
+                type="button"
+                size="sm"
+                variant={statusFilter === s ? 'default' : 'outline'}
+                onClick={() => setStatusFilter(s)}
+              >
+                {capitalize(s)}
+              </Button>
+            ),
+          )}
+        </div>
+
+        {filteredInvites.length === 0 ? (
+          <p className="text-muted-foreground text-sm">
+            No invitations in this filter.
+          </p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Target</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Expires</TableHead>
+                <TableHead className="w-24" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filteredInvites.map(inv => (
+                <TableRow key={inv.id}>
+                  <TableCell className="max-w-xs truncate">
+                    {formatInviteTarget(inv)}
+                  </TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={inv.status === 'pending' ? 'default' : 'outline'}
+                    >
+                      {capitalize(inv.status)}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground text-xs">
+                    {inv.status === 'pending'
+                      ? formatRelativeExpiry(inv.expiresAtNs)
+                      : '-'}
+                  </TableCell>
+                  <TableCell>
+                    {inv.status === 'pending' && (
+                      <LoadingButton
+                        size="sm"
+                        variant="ghost"
+                        isLoading={revokingId === inv.id}
+                        onClick={() => onRevoke(inv.id)}
+                      >
+                        Revoke
+                      </LoadingButton>
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/frontend/src/routes/organizations/organization-members.tsx
+++ b/src/frontend/src/routes/organizations/organization-members.tsx
@@ -1,0 +1,60 @@
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import type { OrgUser } from '@/lib/api-models';
+import type { FC } from 'react';
+
+interface OrganizationMembersProps {
+  members: OrgUser[];
+}
+
+export const OrganizationMembers: FC<OrganizationMembersProps> = ({
+  members,
+}) => {
+  return (
+    <Card className="mx-auto max-w-2xl">
+      <CardHeader>
+        <CardTitle>Members</CardTitle>
+      </CardHeader>
+
+      <CardContent>
+        {members.length === 0 ? (
+          <p className="text-muted-foreground text-sm">No members yet.</p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Email</TableHead>
+                <TableHead>User ID</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {members.map(m => (
+                <TableRow key={m.id}>
+                  <TableCell>
+                    {m.email ?? (
+                      <span className="text-muted-foreground">(no email)</span>
+                    )}
+                    {m.email && !m.emailVerified && (
+                      <Badge variant="outline" className="ml-2">
+                        Unverified
+                      </Badge>
+                    )}
+                  </TableCell>
+                  <TableCell className="font-mono text-xs">{m.id}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/frontend/src/routes/organizations/organization-settings.tsx
+++ b/src/frontend/src/routes/organizations/organization-settings.tsx
@@ -12,14 +12,31 @@ import {
 } from '@/components/form';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
 import { useAppStore, selectOrgMap } from '@/lib/store';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
+import type {
+  InviteStatus,
+  OrgInvite,
+  OrgUser,
+  Team,
+} from '@/lib/api-models';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Users } from 'lucide-react';
-import { useEffect, useMemo, useState, type FC } from 'react';
+import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router';
 import { isNil } from '@/lib/nil';
+import { Principal } from '@icp-sdk/core/principal';
 import { z } from 'zod';
 
 const formSchema = z.object({
@@ -32,10 +49,74 @@ const formSchema = z.object({
 
 type FormData = z.infer<typeof formSchema>;
 
+type InviteTargetKind = 'email' | 'userId' | 'principal';
+
+const inviteSchema = z
+  .object({
+    kind: z.enum(['email', 'userId', 'principal']),
+    value: z.string().trim().min(1, 'Value is required'),
+  })
+  .superRefine((data, ctx) => {
+    if (data.kind === 'email' && !data.value.includes('@')) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['value'],
+        message: 'Must be a valid email',
+      });
+    }
+    if (data.kind === 'principal') {
+      try {
+        Principal.fromText(data.value);
+      } catch {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['value'],
+          message: 'Must be a valid principal',
+        });
+      }
+    }
+  });
+
+type InviteFormData = z.infer<typeof inviteSchema>;
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function formatRelativeExpiry(expiresAtNs: bigint): string {
+  const diffMs = Number(expiresAtNs / 1_000_000n) - Date.now();
+  if (diffMs <= 0) return 'Expired';
+  const mins = Math.floor(diffMs / 60_000);
+  if (mins < 60) return `In ${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `In ${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `In ${days}d`;
+}
+
+function formatInviteTarget(invite: OrgInvite): string {
+  switch (invite.target.kind) {
+    case 'email':
+      return invite.target.email;
+    case 'userId':
+      return invite.target.userId;
+    case 'principal':
+      return invite.target.principal.toString();
+  }
+}
+
 const OrganizationSettings: FC = () => {
   const { orgId } = useParams();
   const navigate = useNavigate();
-  const { updateOrganization, deleteOrganization } = useAppStore();
+  const {
+    updateOrganization,
+    deleteOrganization,
+    loadOrgUsers,
+    loadOrgTeams,
+    listOrgInvites,
+    createOrgInvite,
+    revokeOrgInvite,
+  } = useAppStore();
   const orgMap = useAppStore(selectOrgMap);
 
   const organization = useMemo(
@@ -48,11 +129,66 @@ const OrganizationSettings: FC = () => {
     defaultValues: { name: '' },
   });
 
+  const inviteForm = useForm<InviteFormData>({
+    resolver: zodResolver(inviteSchema),
+    defaultValues: { kind: 'email', value: '' },
+  });
+
+  const [members, setMembers] = useState<OrgUser[]>([]);
+  const [teams, setTeams] = useState<Team[]>([]);
+  const [invites, setInvites] = useState<OrgInvite[]>([]);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<InviteStatus | 'all'>(
+    'pending',
+  );
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const filteredInvites = useMemo(
+    () =>
+      statusFilter === 'all'
+        ? invites
+        : invites.filter(i => i.status === statusFilter),
+    [invites, statusFilter],
+  );
+
+  const refreshMembers = useCallback(async () => {
+    if (!orgId) return;
+    try {
+      setMembers(await loadOrgUsers(orgId));
+    } catch (err) {
+      showErrorToast('Failed to load members', err);
+    }
+  }, [orgId, loadOrgUsers]);
+
+  const refreshTeams = useCallback(async () => {
+    if (!orgId) return;
+    try {
+      setTeams(await loadOrgTeams(orgId));
+    } catch (err) {
+      showErrorToast('Failed to load teams', err);
+    }
+  }, [orgId, loadOrgTeams]);
+
+  const refreshInvites = useCallback(async () => {
+    if (!orgId) return;
+    try {
+      setInvites(await listOrgInvites(orgId));
+    } catch (err) {
+      showErrorToast('Failed to load invitations', err);
+    }
+  }, [orgId, listOrgInvites]);
+
   useEffect(() => {
     if (organization) {
       form.reset({ name: organization.name });
     }
   }, [organization, form]);
+
+  useEffect(() => {
+    refreshMembers();
+    refreshTeams();
+    refreshInvites();
+  }, [refreshMembers, refreshTeams, refreshInvites]);
 
   if (isNil(orgId) || isNil(organization)) {
     return (
@@ -71,7 +207,32 @@ const OrganizationSettings: FC = () => {
     }
   }
 
-  const [isDeleting, setIsDeleting] = useState(false);
+  async function onInviteSubmit(data: InviteFormData): Promise<void> {
+    try {
+      await createOrgInvite({
+        orgId: orgId!,
+        target: buildInviteTarget(data.kind, data.value),
+      });
+      showSuccessToast('Invitation created');
+      inviteForm.reset({ kind: data.kind, value: '' });
+      await refreshInvites();
+    } catch (err) {
+      showErrorToast('Failed to create invitation', err);
+    }
+  }
+
+  async function onRevoke(inviteId: string): Promise<void> {
+    setRevokingId(inviteId);
+    try {
+      await revokeOrgInvite(inviteId);
+      showSuccessToast('Invitation revoked');
+      await refreshInvites();
+    } catch (err) {
+      showErrorToast('Failed to revoke invitation', err);
+    } finally {
+      setRevokingId(null);
+    }
+  }
 
   async function onDelete(): Promise<void> {
     setIsDeleting(true);
@@ -96,7 +257,7 @@ const OrganizationSettings: FC = () => {
       />
 
       <div className="mt-6 space-y-6">
-        <Card className="mx-auto max-w-md">
+        <Card className="mx-auto max-w-2xl">
           <CardHeader>
             <CardTitle>Organization Settings</CardTitle>
           </CardHeader>
@@ -125,7 +286,6 @@ const OrganizationSettings: FC = () => {
 
                 <LoadingButton
                   type="submit"
-                  className="w-full"
                   isLoading={form.formState.isSubmitting}
                   disabled={!form.formState.isDirty}
                 >
@@ -136,15 +296,43 @@ const OrganizationSettings: FC = () => {
           </CardContent>
         </Card>
 
-        <Card className="mx-auto max-w-md">
+        <Card className="mx-auto max-w-2xl">
           <CardHeader>
             <CardTitle>Teams</CardTitle>
           </CardHeader>
 
-          <CardContent>
-            <p className="text-muted-foreground mb-4 text-sm">
+          <CardContent className="space-y-4">
+            <p className="text-muted-foreground text-sm">
               Manage the teams in this organization.
             </p>
+
+            {teams.length === 0 ? (
+              <p className="text-muted-foreground text-sm italic">
+                No teams yet.
+              </p>
+            ) : (
+              <ul className="divide-y">
+                {teams.map(t => (
+                  <li
+                    key={t.id}
+                    className="flex items-center justify-between py-2"
+                  >
+                    <span>{t.name}</span>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() =>
+                        navigate(
+                          `/organizations/${orgId}/teams/${t.id}/settings`,
+                        )
+                      }
+                    >
+                      Manage
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            )}
 
             <Button
               variant="outline"
@@ -156,7 +344,182 @@ const OrganizationSettings: FC = () => {
           </CardContent>
         </Card>
 
-        <Card className="mx-auto max-w-md">
+        <Card className="mx-auto max-w-2xl">
+          <CardHeader>
+            <CardTitle>Members</CardTitle>
+          </CardHeader>
+
+          <CardContent>
+            {members.length === 0 ? (
+              <p className="text-muted-foreground text-sm">No members yet.</p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Email</TableHead>
+                    <TableHead>User ID</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {members.map(m => (
+                    <TableRow key={m.id}>
+                      <TableCell>
+                        {m.email ?? (
+                          <span className="text-muted-foreground">
+                            (no email)
+                          </span>
+                        )}
+                        {m.email && !m.emailVerified && (
+                          <Badge variant="outline" className="ml-2">
+                            Unverified
+                          </Badge>
+                        )}
+                      </TableCell>
+                      <TableCell className="font-mono text-xs">
+                        {m.id}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="mx-auto max-w-2xl">
+          <CardHeader>
+            <CardTitle>Invitations</CardTitle>
+          </CardHeader>
+
+          <CardContent className="space-y-6">
+            <p className="text-muted-foreground text-sm">
+              Invite users by email, user ID, or principal. Invitations expire
+              after 7 days. Target existence is never disclosed.
+            </p>
+
+            <Form {...inviteForm}>
+              <form
+                className="space-y-4"
+                onSubmit={inviteForm.handleSubmit(onInviteSubmit)}
+              >
+                <FormField
+                  control={inviteForm.control}
+                  name="kind"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Target type</FormLabel>
+                      <FormControl>
+                        <select
+                          className="border-input bg-background flex h-9 w-full rounded-md border px-3 py-1 text-sm"
+                          value={field.value}
+                          onChange={e =>
+                            field.onChange(e.target.value as InviteTargetKind)
+                          }
+                        >
+                          <option value="email">Email</option>
+                          <option value="userId">User ID</option>
+                          <option value="principal">Principal</option>
+                        </select>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={inviteForm.control}
+                  name="value"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Target</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <LoadingButton
+                  type="submit"
+                  isLoading={inviteForm.formState.isSubmitting}
+                >
+                  Send invitation
+                </LoadingButton>
+              </form>
+            </Form>
+
+            <Separator />
+
+            <div className="flex flex-wrap gap-2">
+              {(
+                ['pending', 'accepted', 'declined', 'revoked', 'all'] as const
+              ).map(s => (
+                <Button
+                  key={s}
+                  type="button"
+                  size="sm"
+                  variant={statusFilter === s ? 'default' : 'outline'}
+                  onClick={() => setStatusFilter(s)}
+                >
+                  {capitalize(s)}
+                </Button>
+              ))}
+            </div>
+
+            {filteredInvites.length === 0 ? (
+              <p className="text-muted-foreground text-sm">
+                No invitations in this filter.
+              </p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Target</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Expires</TableHead>
+                    <TableHead className="w-24" />
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filteredInvites.map(inv => (
+                    <TableRow key={inv.id}>
+                      <TableCell className="max-w-xs truncate">
+                        {formatInviteTarget(inv)}
+                      </TableCell>
+                      <TableCell>
+                        <Badge
+                          variant={
+                            inv.status === 'pending' ? 'default' : 'outline'
+                          }
+                        >
+                          {capitalize(inv.status)}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-muted-foreground text-xs">
+                        {inv.status === 'pending'
+                          ? formatRelativeExpiry(inv.expiresAtNs)
+                          : '-'}
+                      </TableCell>
+                      <TableCell>
+                        {inv.status === 'pending' && (
+                          <LoadingButton
+                            size="sm"
+                            variant="ghost"
+                            isLoading={revokingId === inv.id}
+                            onClick={() => onRevoke(inv.id)}
+                          >
+                            Revoke
+                          </LoadingButton>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="mx-auto max-w-2xl">
           <CardHeader>
             <CardTitle>Danger Zone</CardTitle>
           </CardHeader>
@@ -179,5 +542,19 @@ const OrganizationSettings: FC = () => {
     </Container>
   );
 };
+
+function buildInviteTarget(kind: InviteTargetKind, value: string) {
+  switch (kind) {
+    case 'email':
+      return { kind: 'email' as const, email: value };
+    case 'userId':
+      return { kind: 'userId' as const, userId: value };
+    case 'principal':
+      return {
+        kind: 'principal' as const,
+        principal: Principal.fromText(value),
+      };
+  }
+}
 
 export default OrganizationSettings;

--- a/src/frontend/src/routes/organizations/organization-settings.tsx
+++ b/src/frontend/src/routes/organizations/organization-settings.tsx
@@ -11,28 +11,18 @@ import {
   FormMessage,
 } from '@/components/form';
 import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
-import { Separator } from '@/components/ui/separator';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
-import { Badge } from '@/components/ui/badge';
 import { useAppStore, selectOrgMap } from '@/lib/store';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
-import type { InviteStatus, OrgInvite, OrgUser, Team } from '@/lib/api-models';
+import type { OrgUser, Team } from '@/lib/api-models';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Users } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router';
 import { isNil } from '@/lib/nil';
-import { Principal } from '@icp-sdk/core/principal';
 import { z } from 'zod';
+import { OrganizationTeams } from './organization-teams';
+import { OrganizationMembers } from './organization-members';
+import { OrganizationInvitations } from './organization-invitations';
 
 const formSchema = z.object({
   name: z
@@ -44,74 +34,11 @@ const formSchema = z.object({
 
 type FormData = z.infer<typeof formSchema>;
 
-type InviteTargetKind = 'email' | 'userId' | 'principal';
-
-const inviteSchema = z
-  .object({
-    kind: z.enum(['email', 'userId', 'principal']),
-    value: z.string().trim().min(1, 'Value is required'),
-  })
-  .superRefine((data, ctx) => {
-    if (data.kind === 'email' && !data.value.includes('@')) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['value'],
-        message: 'Must be a valid email',
-      });
-    }
-    if (data.kind === 'principal') {
-      try {
-        Principal.fromText(data.value);
-      } catch {
-        ctx.addIssue({
-          code: 'custom',
-          path: ['value'],
-          message: 'Must be a valid principal',
-        });
-      }
-    }
-  });
-
-type InviteFormData = z.infer<typeof inviteSchema>;
-
-function capitalize(s: string): string {
-  return s.charAt(0).toUpperCase() + s.slice(1);
-}
-
-function formatRelativeExpiry(expiresAtNs: bigint): string {
-  const diffMs = Number(expiresAtNs / 1_000_000n) - Date.now();
-  if (diffMs <= 0) return 'Expired';
-  const mins = Math.floor(diffMs / 60_000);
-  if (mins < 60) return `In ${mins}m`;
-  const hours = Math.floor(mins / 60);
-  if (hours < 24) return `In ${hours}h`;
-  const days = Math.floor(hours / 24);
-  return `In ${days}d`;
-}
-
-function formatInviteTarget(invite: OrgInvite): string {
-  switch (invite.target.kind) {
-    case 'email':
-      return invite.target.email;
-    case 'userId':
-      return invite.target.userId;
-    case 'principal':
-      return invite.target.principal.toString();
-  }
-}
-
 const OrganizationSettings: FC = () => {
   const { orgId } = useParams();
   const navigate = useNavigate();
-  const {
-    updateOrganization,
-    deleteOrganization,
-    loadOrgUsers,
-    loadOrgTeams,
-    listOrgInvites,
-    createOrgInvite,
-    revokeOrgInvite,
-  } = useAppStore();
+  const { updateOrganization, deleteOrganization, loadOrgUsers, loadOrgTeams } =
+    useAppStore();
   const orgMap = useAppStore(selectOrgMap);
 
   const organization = useMemo(
@@ -124,27 +51,9 @@ const OrganizationSettings: FC = () => {
     defaultValues: { name: '' },
   });
 
-  const inviteForm = useForm<InviteFormData>({
-    resolver: zodResolver(inviteSchema),
-    defaultValues: { kind: 'email', value: '' },
-  });
-
   const [members, setMembers] = useState<OrgUser[]>([]);
   const [teams, setTeams] = useState<Team[]>([]);
-  const [invites, setInvites] = useState<OrgInvite[]>([]);
-  const [revokingId, setRevokingId] = useState<string | null>(null);
-  const [statusFilter, setStatusFilter] = useState<InviteStatus | 'all'>(
-    'pending',
-  );
   const [isDeleting, setIsDeleting] = useState(false);
-
-  const filteredInvites = useMemo(
-    () =>
-      statusFilter === 'all'
-        ? invites
-        : invites.filter(i => i.status === statusFilter),
-    [invites, statusFilter],
-  );
 
   const refreshMembers = useCallback(async () => {
     if (!orgId) return;
@@ -164,15 +73,6 @@ const OrganizationSettings: FC = () => {
     }
   }, [orgId, loadOrgTeams]);
 
-  const refreshInvites = useCallback(async () => {
-    if (!orgId) return;
-    try {
-      setInvites(await listOrgInvites(orgId));
-    } catch (err) {
-      showErrorToast('Failed to load invitations', err);
-    }
-  }, [orgId, listOrgInvites]);
-
   useEffect(() => {
     if (organization) {
       form.reset({ name: organization.name });
@@ -182,8 +82,7 @@ const OrganizationSettings: FC = () => {
   useEffect(() => {
     refreshMembers();
     refreshTeams();
-    refreshInvites();
-  }, [refreshMembers, refreshTeams, refreshInvites]);
+  }, [refreshMembers, refreshTeams]);
 
   if (isNil(orgId) || isNil(organization)) {
     return (
@@ -199,33 +98,6 @@ const OrganizationSettings: FC = () => {
       showSuccessToast('Organization updated successfully!');
     } catch (err) {
       showErrorToast('Failed to update organization', err);
-    }
-  }
-
-  async function onInviteSubmit(data: InviteFormData): Promise<void> {
-    try {
-      await createOrgInvite({
-        orgId: orgId!,
-        target: buildInviteTarget(data.kind, data.value),
-      });
-      showSuccessToast('Invitation created');
-      inviteForm.reset({ kind: data.kind, value: '' });
-      await refreshInvites();
-    } catch (err) {
-      showErrorToast('Failed to create invitation', err);
-    }
-  }
-
-  async function onRevoke(inviteId: string): Promise<void> {
-    setRevokingId(inviteId);
-    try {
-      await revokeOrgInvite(inviteId);
-      showSuccessToast('Invitation revoked');
-      await refreshInvites();
-    } catch (err) {
-      showErrorToast('Failed to revoke invitation', err);
-    } finally {
-      setRevokingId(null);
     }
   }
 
@@ -291,228 +163,11 @@ const OrganizationSettings: FC = () => {
           </CardContent>
         </Card>
 
-        <Card className="mx-auto max-w-2xl">
-          <CardHeader>
-            <CardTitle>Teams</CardTitle>
-          </CardHeader>
+        <OrganizationTeams orgId={orgId} teams={teams} />
 
-          <CardContent className="space-y-4">
-            <p className="text-muted-foreground text-sm">
-              Manage the teams in this organization.
-            </p>
+        <OrganizationMembers members={members} />
 
-            {teams.length === 0 ? (
-              <p className="text-muted-foreground text-sm italic">
-                No teams yet.
-              </p>
-            ) : (
-              <ul className="divide-y">
-                {teams.map(t => (
-                  <li
-                    key={t.id}
-                    className="flex items-center justify-between py-2"
-                  >
-                    <span>{t.name}</span>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() =>
-                        navigate(
-                          `/organizations/${orgId}/teams/${t.id}/settings`,
-                        )
-                      }
-                    >
-                      Manage
-                    </Button>
-                  </li>
-                ))}
-              </ul>
-            )}
-
-            <Button
-              variant="outline"
-              onClick={() => navigate(`/organizations/${orgId}/teams`)}
-            >
-              <Users className="mr-1 size-3.5" />
-              Manage Teams
-            </Button>
-          </CardContent>
-        </Card>
-
-        <Card className="mx-auto max-w-2xl">
-          <CardHeader>
-            <CardTitle>Members</CardTitle>
-          </CardHeader>
-
-          <CardContent>
-            {members.length === 0 ? (
-              <p className="text-muted-foreground text-sm">No members yet.</p>
-            ) : (
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Email</TableHead>
-                    <TableHead>User ID</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {members.map(m => (
-                    <TableRow key={m.id}>
-                      <TableCell>
-                        {m.email ?? (
-                          <span className="text-muted-foreground">
-                            (no email)
-                          </span>
-                        )}
-                        {m.email && !m.emailVerified && (
-                          <Badge variant="outline" className="ml-2">
-                            Unverified
-                          </Badge>
-                        )}
-                      </TableCell>
-                      <TableCell className="font-mono text-xs">
-                        {m.id}
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            )}
-          </CardContent>
-        </Card>
-
-        <Card className="mx-auto max-w-2xl">
-          <CardHeader>
-            <CardTitle>Invitations</CardTitle>
-          </CardHeader>
-
-          <CardContent className="space-y-6">
-            <p className="text-muted-foreground text-sm">
-              Invite users by email, user ID, or principal. Invitations expire
-              after 7 days. Target existence is never disclosed.
-            </p>
-
-            <Form {...inviteForm}>
-              <form
-                className="space-y-4"
-                onSubmit={inviteForm.handleSubmit(onInviteSubmit)}
-              >
-                <FormField
-                  control={inviteForm.control}
-                  name="kind"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Target type</FormLabel>
-                      <FormControl>
-                        <select
-                          className="border-input bg-background flex h-9 w-full rounded-md border px-3 py-1 text-sm"
-                          value={field.value}
-                          onChange={e =>
-                            field.onChange(e.target.value as InviteTargetKind)
-                          }
-                        >
-                          <option value="email">Email</option>
-                          <option value="userId">User ID</option>
-                          <option value="principal">Principal</option>
-                        </select>
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={inviteForm.control}
-                  name="value"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Target</FormLabel>
-                      <FormControl>
-                        <Input {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <LoadingButton
-                  type="submit"
-                  isLoading={inviteForm.formState.isSubmitting}
-                >
-                  Send invitation
-                </LoadingButton>
-              </form>
-            </Form>
-
-            <Separator />
-
-            <div className="flex flex-wrap gap-2">
-              {(
-                ['pending', 'accepted', 'declined', 'revoked', 'all'] as const
-              ).map(s => (
-                <Button
-                  key={s}
-                  type="button"
-                  size="sm"
-                  variant={statusFilter === s ? 'default' : 'outline'}
-                  onClick={() => setStatusFilter(s)}
-                >
-                  {capitalize(s)}
-                </Button>
-              ))}
-            </div>
-
-            {filteredInvites.length === 0 ? (
-              <p className="text-muted-foreground text-sm">
-                No invitations in this filter.
-              </p>
-            ) : (
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Target</TableHead>
-                    <TableHead>Status</TableHead>
-                    <TableHead>Expires</TableHead>
-                    <TableHead className="w-24" />
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {filteredInvites.map(inv => (
-                    <TableRow key={inv.id}>
-                      <TableCell className="max-w-xs truncate">
-                        {formatInviteTarget(inv)}
-                      </TableCell>
-                      <TableCell>
-                        <Badge
-                          variant={
-                            inv.status === 'pending' ? 'default' : 'outline'
-                          }
-                        >
-                          {capitalize(inv.status)}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="text-muted-foreground text-xs">
-                        {inv.status === 'pending'
-                          ? formatRelativeExpiry(inv.expiresAtNs)
-                          : '-'}
-                      </TableCell>
-                      <TableCell>
-                        {inv.status === 'pending' && (
-                          <LoadingButton
-                            size="sm"
-                            variant="ghost"
-                            isLoading={revokingId === inv.id}
-                            onClick={() => onRevoke(inv.id)}
-                          >
-                            Revoke
-                          </LoadingButton>
-                        )}
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            )}
-          </CardContent>
-        </Card>
+        <OrganizationInvitations orgId={orgId} />
 
         <Card className="mx-auto max-w-2xl">
           <CardHeader>
@@ -537,19 +192,5 @@ const OrganizationSettings: FC = () => {
     </Container>
   );
 };
-
-function buildInviteTarget(kind: InviteTargetKind, value: string) {
-  switch (kind) {
-    case 'email':
-      return { kind: 'email' as const, email: value };
-    case 'userId':
-      return { kind: 'userId' as const, userId: value };
-    case 'principal':
-      return {
-        kind: 'principal' as const,
-        principal: Principal.fromText(value),
-      };
-  }
-}
 
 export default OrganizationSettings;

--- a/src/frontend/src/routes/organizations/organization-settings.tsx
+++ b/src/frontend/src/routes/organizations/organization-settings.tsx
@@ -24,12 +24,7 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { useAppStore, selectOrgMap } from '@/lib/store';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
-import type {
-  InviteStatus,
-  OrgInvite,
-  OrgUser,
-  Team,
-} from '@/lib/api-models';
+import type { InviteStatus, OrgInvite, OrgUser, Team } from '@/lib/api-models';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Users } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';

--- a/src/frontend/src/routes/organizations/organization-teams.tsx
+++ b/src/frontend/src/routes/organizations/organization-teams.tsx
@@ -1,0 +1,61 @@
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { Team } from '@/lib/api-models';
+import { Users } from 'lucide-react';
+import type { FC } from 'react';
+import { useNavigate } from 'react-router';
+
+interface OrganizationTeamsProps {
+  orgId: string;
+  teams: Team[];
+}
+
+export const OrganizationTeams: FC<OrganizationTeamsProps> = ({
+  orgId,
+  teams,
+}) => {
+  const navigate = useNavigate();
+
+  return (
+    <Card className="mx-auto max-w-2xl">
+      <CardHeader>
+        <CardTitle>Teams</CardTitle>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        <p className="text-muted-foreground text-sm">
+          Manage the teams in this organization.
+        </p>
+
+        {teams.length === 0 ? (
+          <p className="text-muted-foreground text-sm italic">No teams yet.</p>
+        ) : (
+          <ul className="divide-y">
+            {teams.map(t => (
+              <li key={t.id} className="flex items-center justify-between py-2">
+                <span>{t.name}</span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() =>
+                    navigate(`/organizations/${orgId}/teams/${t.id}/settings`)
+                  }
+                >
+                  Manage
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <Button
+          variant="outline"
+          onClick={() => navigate(`/organizations/${orgId}/teams`)}
+        >
+          <Users className="mr-1 size-3.5" />
+          Manage Teams
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/frontend/src/routes/organizations/teams/team-settings.tsx
+++ b/src/frontend/src/routes/organizations/teams/team-settings.tsx
@@ -44,13 +44,8 @@ type FormData = z.infer<typeof formSchema>;
 const TeamSettings: FC = () => {
   const { orgId, teamId } = useParams();
   const navigate = useNavigate();
-  const {
-    updateTeam,
-    deleteTeam,
-    loadOrgUsers,
-    loadTeamUsers,
-    addUserToTeam,
-  } = useAppStore();
+  const { updateTeam, deleteTeam, loadOrgUsers, loadTeamUsers, addUserToTeam } =
+    useAppStore();
   const teamMap = useAppStore(selectTeamMap);
   const orgMap = useAppStore(selectOrgMap);
 

--- a/src/frontend/src/routes/organizations/teams/team-settings.tsx
+++ b/src/frontend/src/routes/organizations/teams/team-settings.tsx
@@ -13,8 +13,19 @@ import {
 import { Input } from '@/components/ui/input';
 import { useAppStore, selectOrgMap, selectTeamMap } from '@/lib/store';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
+import type { OrgUser, TeamUser } from '@/lib/api-models';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { Separator } from '@/components/ui/separator';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useEffect, useMemo, useState, type FC } from 'react';
+import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router';
 import { isNil } from '@/lib/nil';
@@ -33,7 +44,13 @@ type FormData = z.infer<typeof formSchema>;
 const TeamSettings: FC = () => {
   const { orgId, teamId } = useParams();
   const navigate = useNavigate();
-  const { updateTeam, deleteTeam } = useAppStore();
+  const {
+    updateTeam,
+    deleteTeam,
+    loadOrgUsers,
+    loadTeamUsers,
+    addUserToTeam,
+  } = useAppStore();
   const teamMap = useAppStore(selectTeamMap);
   const orgMap = useAppStore(selectOrgMap);
 
@@ -52,11 +69,49 @@ const TeamSettings: FC = () => {
     defaultValues: { name: '' },
   });
 
+  const [orgMembers, setOrgMembers] = useState<OrgUser[]>([]);
+  const [teamMembers, setTeamMembers] = useState<TeamUser[]>([]);
+  const [selectedUserId, setSelectedUserId] = useState<string>('');
+  const [isAdding, setIsAdding] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const refreshOrgMembers = useCallback(async () => {
+    if (!orgId) return;
+    try {
+      setOrgMembers(await loadOrgUsers(orgId));
+    } catch (err) {
+      showErrorToast('Failed to load org members', err);
+    }
+  }, [orgId, loadOrgUsers]);
+
+  const refreshTeamMembers = useCallback(async () => {
+    if (!teamId) return;
+    try {
+      setTeamMembers(await loadTeamUsers(teamId));
+    } catch (err) {
+      showErrorToast('Failed to load team members', err);
+    }
+  }, [teamId, loadTeamUsers]);
+
+  const teamMemberIds = useMemo(
+    () => new Set(teamMembers.map(m => m.id)),
+    [teamMembers],
+  );
+  const addableOrgMembers = useMemo(
+    () => orgMembers.filter(m => !teamMemberIds.has(m.id)),
+    [orgMembers, teamMemberIds],
+  );
+
   useEffect(() => {
     if (team) {
       form.reset({ name: team.name });
     }
   }, [team, form]);
+
+  useEffect(() => {
+    refreshOrgMembers();
+    refreshTeamMembers();
+  }, [refreshOrgMembers, refreshTeamMembers]);
 
   if (isNil(orgId) || isNil(teamId) || isNil(team)) {
     return (
@@ -75,14 +130,27 @@ const TeamSettings: FC = () => {
     }
   }
 
-  const [isDeleting, setIsDeleting] = useState(false);
+  async function onAddMember(): Promise<void> {
+    if (!selectedUserId) return;
+    setIsAdding(true);
+    try {
+      await addUserToTeam(teamId!, selectedUserId);
+      showSuccessToast('Member added to team');
+      setSelectedUserId('');
+      await refreshTeamMembers();
+    } catch (err) {
+      showErrorToast('Failed to add member', err);
+    } finally {
+      setIsAdding(false);
+    }
+  }
 
   async function onDelete(): Promise<void> {
     setIsDeleting(true);
     try {
       await deleteTeam(teamId!);
       showSuccessToast('Team deleted successfully!');
-      navigate(`/organizations/${orgId}/teams`);
+      navigate(`/organizations/${orgId}/settings`);
     } catch (err) {
       showErrorToast('Failed to delete team', err);
     } finally {
@@ -142,6 +210,85 @@ const TeamSettings: FC = () => {
                 </LoadingButton>
               </form>
             </Form>
+          </CardContent>
+        </Card>
+
+        <Card className="mx-auto max-w-md">
+          <CardHeader>
+            <CardTitle>Members</CardTitle>
+          </CardHeader>
+
+          <CardContent className="space-y-6">
+            {teamMembers.length === 0 ? (
+              <p className="text-muted-foreground text-sm">No members yet.</p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Email</TableHead>
+                    <TableHead>User ID</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {teamMembers.map(m => (
+                    <TableRow key={m.id}>
+                      <TableCell>
+                        {m.email ?? (
+                          <span className="text-muted-foreground">
+                            (no email)
+                          </span>
+                        )}
+                        {m.email && !m.emailVerified && (
+                          <Badge variant="outline" className="ml-2">
+                            Unverified
+                          </Badge>
+                        )}
+                      </TableCell>
+                      <TableCell className="font-mono text-xs">
+                        {m.id}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+
+            <Separator />
+
+            <div className="space-y-3">
+              <p className="text-muted-foreground text-sm">
+                Add an existing organization member to this team.
+              </p>
+
+              {addableOrgMembers.length === 0 ? (
+                <p className="text-muted-foreground text-sm italic">
+                  All organization members are already on this team.
+                </p>
+              ) : (
+                <>
+                  <select
+                    className="border-input bg-background flex h-9 w-full rounded-md border px-3 py-1 text-sm"
+                    value={selectedUserId}
+                    onChange={e => setSelectedUserId(e.target.value)}
+                  >
+                    <option value="">Select a member...</option>
+                    {addableOrgMembers.map(m => (
+                      <option key={m.id} value={m.id}>
+                        {m.email ?? m.id}
+                      </option>
+                    ))}
+                  </select>
+
+                  <LoadingButton
+                    isLoading={isAdding}
+                    disabled={!selectedUserId}
+                    onClick={onAddMember}
+                  >
+                    Add to Team
+                  </LoadingButton>
+                </>
+              )}
+            </div>
           </CardContent>
         </Card>
 


### PR DESCRIPTION
Adds an invitation flow so admins can invite users to organizations and teams by email or principal, with accept/revoke/list endpoints, expiry handling, and frontend UI for managing invites and viewing one's own pending invitations.

Tightens the org invite endpoints so only the inviter can list or revoke an invite they created: preventing other org members from seeing invitee emails or revoking invites they didn't issue. Both checks are placeholders until an org permission/admin model lands.