### PR TITLE
fix: prevent inactive users from creating proposals

### DIFF
--- a/src/backend-tests/src/support/error.ts
+++ b/src/backend-tests/src/support/error.ts
@@ -76,6 +76,15 @@ export function noProfileError(principal: Principal): ApiErrorResponse {
   };
 }
 
+export function inactiveUserError(): ApiErrorResponse {
+  return {
+    Err: {
+      code: [{ Unauthorized: {} }],
+      message: `Inactive users cannot perform this action.`,
+    },
+  };
+}
+
 export function noTermsAndConditionsError(id: string): ApiErrorResponse {
   return {
     Err: {

--- a/src/backend-tests/src/support/test-driver.ts
+++ b/src/backend-tests/src/support/test-driver.ts
@@ -11,6 +11,7 @@ import { controllerIdentity } from './identity';
 import { ProposalDriver } from './proposal-driver';
 import { extractOkResponse } from './error';
 import * as crypto from 'node:crypto';
+import { UserDriver } from './user-driver';
 
 export const BACKEND_WASM_PATH = resolve(
   __dirname,
@@ -34,6 +35,7 @@ export const PRIVATE_KEY = privateKey;
 
 export class TestDriver {
   public readonly proposals: ProposalDriver;
+  public readonly users: UserDriver;
 
   public get actor(): Actor<BackendService> {
     return this.fixture.actor;
@@ -48,6 +50,7 @@ export class TestDriver {
     private readonly fixture: CanisterFixture<BackendService>,
   ) {
     this.proposals = new ProposalDriver(pic, fixture.canisterId);
+    this.users = new UserDriver(pic, fixture.canisterId);
   }
 
   public static async create(initialDate = new Date()): Promise<TestDriver> {

--- a/src/backend-tests/src/support/user-driver.ts
+++ b/src/backend-tests/src/support/user-driver.ts
@@ -1,0 +1,36 @@
+import {
+  generateRandomIdentity,
+  type Actor,
+  type PocketIc,
+} from '@dfinity/pic';
+import type { Principal } from '@icp-sdk/core/principal';
+import { idlFactory, type _SERVICE, type UserProfile } from '@ssn/backend-api';
+import { extractOkResponse } from './error';
+import { anonymousIdentity, controllerIdentity } from './identity';
+import type { Identity } from '@icp-sdk/core/agent';
+
+export class UserDriver {
+  private readonly actor: Actor<_SERVICE>;
+
+  constructor(pic: PocketIc, canisterId: Principal) {
+    this.actor = pic.createActor<_SERVICE>(idlFactory, canisterId);
+  }
+
+  public async createUser(): Promise<[Identity, UserProfile]> {
+    const identity = generateRandomIdentity();
+    this.actor.setIdentity(identity);
+
+    const profileRes = await this.actor.create_my_user_profile();
+    const profile = extractOkResponse(profileRes);
+
+    this.actor.setIdentity(controllerIdentity);
+    await this.actor.update_user_profile({
+      user_id: profile.id,
+      status: [{ Active: null }],
+    });
+
+    this.actor.setIdentity(anonymousIdentity);
+
+    return [identity, profile];
+  }
+}

--- a/src/backend-tests/src/tests/canister.spec.ts
+++ b/src/backend-tests/src/tests/canister.spec.ts
@@ -3,6 +3,7 @@ import {
   anonymousIdentity,
   controllerIdentity,
   extractOkResponse,
+  inactiveUserError,
   latestTermsAndConditionsError,
   noProfileError,
   notOwnedProjectError,
@@ -103,9 +104,8 @@ describe('Canisters', () => {
     });
 
     it('should return an empty array when the user has no canisters', async () => {
-      const aliceIdentity = generateRandomIdentity();
+      const [aliceIdentity] = await driver.users.createUser();
       driver.actor.setIdentity(aliceIdentity);
-      await driver.actor.create_my_user_profile();
 
       const canistersRes = await driver.actor.list_my_canisters();
       const canisters = extractOkResponse(canistersRes);
@@ -113,16 +113,14 @@ describe('Canisters', () => {
     });
 
     it('should return all canisters owned by the user', async () => {
-      const aliceIdentity = generateRandomIdentity();
+      const [aliceIdentity] = await driver.users.createUser();
       driver.actor.setIdentity(aliceIdentity);
-      await driver.actor.create_my_user_profile();
       const aliceProject = await driver.getDefaultProject();
       await driver.proposals.createCanister(aliceIdentity, aliceProject.id);
       await driver.proposals.createCanister(aliceIdentity, aliceProject.id);
 
-      const bobIdentity = generateRandomIdentity();
+      const [bobIdentity] = await driver.users.createUser();
       driver.actor.setIdentity(bobIdentity);
-      await driver.actor.create_my_user_profile();
       const bobProject = await driver.getDefaultProject();
       await driver.proposals.createCanister(bobIdentity, bobProject.id);
       await driver.proposals.createCanister(bobIdentity, bobProject.id);
@@ -169,11 +167,22 @@ describe('Canisters', () => {
       expect(res).toEqual(noProfileError(aliceIdentity.getPrincipal()));
     });
 
-    it('should return an error for a project the user does not have access to', async () => {
+    it('should return an error for an inactive user', async () => {
       const aliceIdentity = generateRandomIdentity();
       driver.actor.setIdentity(aliceIdentity);
-      const aliceProfileRes = await driver.actor.create_my_user_profile();
-      const aliceProfile = extractOkResponse(aliceProfileRes);
+
+      await driver.actor.create_my_user_profile();
+      const project = await driver.getDefaultProject();
+
+      const res = await driver.actor.create_proposal({
+        project_id: project.id,
+        operation: [{ CreateCanister: {} }],
+      });
+      expect(res).toEqual(inactiveUserError());
+    });
+
+    it('should return an error for a project the user does not have access to', async () => {
+      const [aliceIdentity, aliceProfile] = await driver.users.createUser();
 
       const bobIdentity = generateRandomIdentity();
       driver.actor.setIdentity(bobIdentity);
@@ -189,10 +198,8 @@ describe('Canisters', () => {
     });
 
     it('should return an error for a project that does not exist', async () => {
-      const aliceIdentity = generateRandomIdentity();
+      const [aliceIdentity, aliceProfile] = await driver.users.createUser();
       driver.actor.setIdentity(aliceIdentity);
-      const aliceProfileRes = await driver.actor.create_my_user_profile();
-      const aliceProfile = extractOkResponse(aliceProfileRes);
 
       const res = await driver.actor.create_proposal({
         project_id: projectId,
@@ -202,9 +209,8 @@ describe('Canisters', () => {
     });
 
     it('should create a canister for a valid user', async () => {
-      const aliceIdentity = generateRandomIdentity();
+      const [aliceIdentity] = await driver.users.createUser();
       driver.actor.setIdentity(aliceIdentity);
-      await driver.actor.create_my_user_profile();
 
       const project = await driver.getDefaultProject();
       await driver.proposals.createCanister(aliceIdentity, project.id);
@@ -215,9 +221,7 @@ describe('Canisters', () => {
     });
 
     it('should return an error for a user who has not accepted the latest terms and conditions', async () => {
-      const aliceIdentity = generateRandomIdentity();
-      driver.actor.setIdentity(aliceIdentity);
-      await driver.actor.create_my_user_profile();
+      const [aliceIdentity] = await driver.users.createUser();
 
       driver.actor.setIdentity(controllerIdentity);
       await driver.actor.create_my_user_profile();
@@ -236,9 +240,7 @@ describe('Canisters', () => {
     });
 
     it('should return an error for a user who has explicitly rejected the latest terms and conditions', async () => {
-      const aliceIdentity = generateRandomIdentity();
-      driver.actor.setIdentity(aliceIdentity);
-      await driver.actor.create_my_user_profile();
+      const [aliceIdentity] = await driver.users.createUser();
 
       driver.actor.setIdentity(controllerIdentity);
       await driver.actor.create_my_user_profile();
@@ -284,9 +286,7 @@ describe('Canisters', () => {
     });
 
     it('should create a canister for a user who has accepted the latest terms and conditions', async () => {
-      const aliceIdentity = generateRandomIdentity();
-      driver.actor.setIdentity(aliceIdentity);
-      await driver.actor.create_my_user_profile();
+      const [aliceIdentity] = await driver.users.createUser();
 
       driver.actor.setIdentity(controllerIdentity);
       await driver.actor.create_my_user_profile();
@@ -353,10 +353,7 @@ describe('Canisters', () => {
     });
 
     it('should return an error for a project the user does not have access to', async () => {
-      const aliceIdentity = generateRandomIdentity();
-      driver.actor.setIdentity(aliceIdentity);
-      const aliceProfileRes = await driver.actor.create_my_user_profile();
-      const aliceProfile = extractOkResponse(aliceProfileRes);
+      const [aliceIdentity, aliceProfile] = await driver.users.createUser();
 
       const bobIdentity = generateRandomIdentity();
       driver.actor.setIdentity(bobIdentity);
@@ -379,10 +376,8 @@ describe('Canisters', () => {
     });
 
     it('should return an error for a project that does not exist', async () => {
-      const aliceIdentity = generateRandomIdentity();
+      const [aliceIdentity, aliceProfile] = await driver.users.createUser();
       driver.actor.setIdentity(aliceIdentity);
-      const aliceProfileRes = await driver.actor.create_my_user_profile();
-      const aliceProfile = extractOkResponse(aliceProfileRes);
 
       const res = await driver.actor.create_proposal({
         project_id: projectId,
@@ -399,9 +394,8 @@ describe('Canisters', () => {
     });
 
     it('should return an error for a canister that does not exist', async () => {
-      const aliceIdentity = generateRandomIdentity();
+      const [aliceIdentity] = await driver.users.createUser();
       driver.actor.setIdentity(aliceIdentity);
-      await driver.actor.create_my_user_profile();
       const project = await driver.getDefaultProject();
 
       const proposal = await driver.proposals.addCanisterController(
@@ -421,9 +415,8 @@ describe('Canisters', () => {
     });
 
     it('should return an error if the controller has already been added', async () => {
-      const aliceIdentity = generateRandomIdentity();
+      const [aliceIdentity] = await driver.users.createUser();
       driver.actor.setIdentity(aliceIdentity);
-      await driver.actor.create_my_user_profile();
 
       const project = await driver.getDefaultProject();
       await driver.proposals.createCanister(aliceIdentity, project.id);
@@ -457,9 +450,8 @@ describe('Canisters', () => {
     });
 
     it('should add a controller for a valid user and canister', async () => {
-      const aliceIdentity = generateRandomIdentity();
+      const [aliceIdentity] = await driver.users.createUser();
       driver.actor.setIdentity(aliceIdentity);
-      await driver.actor.create_my_user_profile();
 
       const project = await driver.getDefaultProject();
       await driver.proposals.createCanister(aliceIdentity, project.id);
@@ -483,9 +475,8 @@ describe('Canisters', () => {
     });
 
     it('should return an error for a user who has not accepted the latest terms and conditions', async () => {
-      const aliceIdentity = generateRandomIdentity();
+      const [aliceIdentity] = await driver.users.createUser();
       driver.actor.setIdentity(aliceIdentity);
-      await driver.actor.create_my_user_profile();
 
       const project = await driver.getDefaultProject();
       await driver.proposals.createCanister(aliceIdentity, project.id);
@@ -515,9 +506,8 @@ describe('Canisters', () => {
     });
 
     it('should return an error for a user who has explicitly rejected the latest terms and conditions', async () => {
-      const aliceIdentity = generateRandomIdentity();
+      const [aliceIdentity] = await driver.users.createUser();
       driver.actor.setIdentity(aliceIdentity);
-      await driver.actor.create_my_user_profile();
 
       const project = await driver.getDefaultProject();
       await driver.proposals.createCanister(aliceIdentity, project.id);
@@ -588,9 +578,8 @@ describe('Canisters', () => {
     });
 
     it('should add a controller for a user who has accepted the latest terms and conditions', async () => {
-      const aliceIdentity = generateRandomIdentity();
+      const [aliceIdentity] = await driver.users.createUser();
       driver.actor.setIdentity(aliceIdentity);
-      await driver.actor.create_my_user_profile();
 
       driver.actor.setIdentity(controllerIdentity);
       await driver.actor.create_my_user_profile();

--- a/src/backend-tests/src/tests/list-all-canisters.spec.ts
+++ b/src/backend-tests/src/tests/list-all-canisters.spec.ts
@@ -81,16 +81,9 @@ describe('list_all_canisters', () => {
       const numAliceProjects = 5;
       const numBobProjects = 3;
 
-      aliceIdentity = generateRandomIdentity();
-      bobIdentity = generateRandomIdentity();
-
+      [aliceIdentity, aliceProfile] = await driver.users.createUser();
       driver.actor.setIdentity(aliceIdentity);
-      await driver.actor.create_my_user_profile();
       await driver.actor.update_my_user_profile({ email: [aliceEmail] });
-
-      const aliceProfileRes = await driver.actor.get_my_user_profile();
-      aliceProfile = extractOkResponse(aliceProfileRes)[0]!;
-
       const aliceProject = await driver.getDefaultProject();
       for (let i = 0; i < numAliceProjects; i++) {
         await driver.proposals.createCanister(aliceIdentity, aliceProject.id);
@@ -98,13 +91,9 @@ describe('list_all_canisters', () => {
       const aliceCanistersRes = await driver.actor.list_my_canisters();
       aliceCanisters = extractOkResponse(aliceCanistersRes);
 
+      [bobIdentity, bobProfile] = await driver.users.createUser();
       driver.actor.setIdentity(bobIdentity);
-      await driver.actor.create_my_user_profile();
       await driver.actor.update_my_user_profile({ email: [bobEmail] });
-
-      const bobProfileRes = await driver.actor.get_my_user_profile();
-      bobProfile = extractOkResponse(bobProfileRes)[0]!;
-
       const bobProject = await driver.getDefaultProject();
       for (let i = 0; i < numBobProjects; i++) {
         await driver.proposals.createCanister(bobIdentity, bobProject.id);

--- a/src/backend/src/controller/proposal.rs
+++ b/src/backend/src/controller/proposal.rs
@@ -8,7 +8,7 @@ use ic_cdk::{api::msg_caller, *};
 #[update]
 async fn create_proposal(request: CreateProposalRequest) -> ApiResultDto<CreateProposalResponse> {
     let caller = msg_caller();
-    if let Err(err) = access_control_service::assert_accepted_latest_terms_and_conditions(&caller) {
+    if let Err(err) = access_control_service::assert_has_platform_access(&caller) {
         return ApiResultDto::Err(err);
     }
 

--- a/src/backend/src/service/access_control_service.rs
+++ b/src/backend/src/service/access_control_service.rs
@@ -1,5 +1,6 @@
 use crate::data::{
     terms_and_conditions_repository, trusted_partner_repository, user_profile_repository,
+    UserStatus,
 };
 use candid::Principal;
 use canister_utils::{assert_authenticated, ApiError, ApiResult};
@@ -17,7 +18,7 @@ pub fn assert_trusted_partner(caller: &Principal) -> ApiResult {
     Ok(())
 }
 
-pub fn assert_accepted_latest_terms_and_conditions(caller: &Principal) -> ApiResult {
+pub fn assert_has_platform_access(caller: &Principal) -> ApiResult {
     assert_authenticated(caller)?;
 
     if is_controller(caller) {
@@ -25,10 +26,17 @@ pub fn assert_accepted_latest_terms_and_conditions(caller: &Principal) -> ApiRes
     }
 
     let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-
     if !terms_and_conditions_repository::has_accepted_latest_terms_and_conditions(user_id) {
         return Err(ApiError::unauthorized(
             "The latest terms and conditions must be accepted to perform this action.".to_string(),
+        ));
+    }
+
+    let profile = user_profile_repository::get_user_profile_by_user_id(&user_id)
+        .ok_or_else(|| ApiError::unauthorized("User profile not found.".to_string()))?;
+    if profile.status == UserStatus::Inactive {
+        return Err(ApiError::unauthorized(
+            "Inactive users cannot perform this action.".to_string(),
         ));
     }
 

--- a/turbo.json
+++ b/turbo.json
@@ -30,6 +30,7 @@
     },
     "test": {
       "dependsOn": ["^build"],
+      "cache": false,
       "outputs": []
     }
   }


### PR DESCRIPTION
Users should not be able to create canisters until their account is "active".