### PR TITLE
feat: canister detail page with history

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,7 @@
         "@dfinity/zod-schemas": "^3.0.2",
         "@hookform/resolvers": "^5.2.2",
         "@ssn/backend-api": "workspace:*",
+        "@ssn/canister-history-api": "workspace:*",
         "@ssn/management-canister": "workspace:*",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -11,6 +11,7 @@
     "@dfinity/zod-schemas": "^3.0.2",
     "@hookform/resolvers": "^5.2.2",
     "@ssn/backend-api": "workspace:*",
+    "@ssn/canister-history-api": "workspace:*",
     "@ssn/management-canister": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/frontend/src/env.tsx
+++ b/src/frontend/src/env.tsx
@@ -18,6 +18,9 @@ export const IDENTITY_PROVIDER = IS_LOCAL
   : 'https://id.ai';
 
 export const BACKEND_CANISTER_ID: string = getEnvVar('CANISTER_ID_BACKEND');
+export const CANISTER_HISTORY_CANISTER_ID: string = getEnvVar(
+  'CANISTER_ID_CANISTER_HISTORY',
+);
 
 export const SHOULD_FETCH_ROOT_KEY = IS_LOCAL;
 

--- a/src/frontend/src/lib/api-models/canister-history.ts
+++ b/src/frontend/src/lib/api-models/canister-history.ts
@@ -1,0 +1,111 @@
+import { fromCandidOpt } from '@/lib/utils';
+import type {
+  CanisterChange as ApiCanisterChange,
+  ListCanisterChangesResponse as ApiListCanisterChangesResponse,
+} from '@ssn/canister-history-api';
+
+export type CanisterChangeOrigin =
+  | { type: 'user'; userId: string }
+  | { type: 'canister'; canisterId: string; canisterVersion: bigint | null };
+
+export type CanisterChangeDetails =
+  | { type: 'creation'; controllers: string[] }
+  | { type: 'codeUninstall' }
+  | {
+      type: 'codeDeployment';
+      mode: 'install' | 'reinstall' | 'upgrade' | null;
+      moduleHash: string;
+    }
+  | { type: 'controllersChange'; controllers: string[] }
+  | { type: 'loadSnapshot' };
+
+export type CanisterChange = {
+  id: string;
+  canisterId: string;
+  timestampNanos: bigint;
+  canisterVersion: bigint;
+  origin: CanisterChangeOrigin | null;
+  details: CanisterChangeDetails | null;
+};
+
+export type ListCanisterChangesResponse = {
+  changes: CanisterChange[];
+  totalPages: bigint;
+};
+
+function mapOrigin(
+  raw: ApiCanisterChange['origin'],
+): CanisterChangeOrigin | null {
+  const origin = fromCandidOpt(raw);
+  if (origin === null) return null;
+  if ('FromUser' in origin) {
+    return { type: 'user', userId: origin.FromUser.user_id.toText() };
+  }
+  return {
+    type: 'canister',
+    canisterId: origin.FromCanister.canister_id.toText(),
+    canisterVersion: fromCandidOpt(origin.FromCanister.canister_version),
+  };
+}
+
+function mapDetails(
+  raw: ApiCanisterChange['details'],
+): CanisterChangeDetails | null {
+  const details = fromCandidOpt(raw);
+  if (details === null) return null;
+  if ('Creation' in details) {
+    return {
+      type: 'creation',
+      controllers: details.Creation.controllers.map(p => p.toText()),
+    };
+  }
+  if ('CodeUninstall' in details) {
+    return { type: 'codeUninstall' };
+  }
+  if ('CodeDeployment' in details) {
+    const modeOpt = fromCandidOpt(details.CodeDeployment.mode);
+    let mode: 'install' | 'reinstall' | 'upgrade' | null = null;
+    if (modeOpt !== null) {
+      if ('Install' in modeOpt) mode = 'install';
+      else if ('Reinstall' in modeOpt) mode = 'reinstall';
+      else mode = 'upgrade';
+    }
+    return {
+      type: 'codeDeployment',
+      mode,
+      moduleHash: Array.from(details.CodeDeployment.module_hash)
+        .map(b => b.toString(16).padStart(2, '0'))
+        .join(''),
+    };
+  }
+  if ('ControllersChange' in details) {
+    return {
+      type: 'controllersChange',
+      controllers: details.ControllersChange.controllers.map(p => p.toText()),
+    };
+  }
+  return { type: 'loadSnapshot' };
+}
+
+function mapCanisterChange(raw: ApiCanisterChange): CanisterChange {
+  return {
+    id: raw.id,
+    canisterId: raw.canister_id.toText(),
+    timestampNanos: raw.timestamp_nanos,
+    canisterVersion: raw.canister_version,
+    origin: mapOrigin(raw.origin),
+    details: mapDetails(raw.details),
+  };
+}
+
+export function mapListCanisterChangesResponse(
+  res: ApiListCanisterChangesResponse,
+): ListCanisterChangesResponse {
+  if ('Err' in res) {
+    throw new Error(res.Err.message);
+  }
+  return {
+    changes: res.Ok.changes.map(mapCanisterChange),
+    totalPages: res.Ok.meta.total_pages,
+  };
+}

--- a/src/frontend/src/lib/api-models/canister.ts
+++ b/src/frontend/src/lib/api-models/canister.ts
@@ -53,9 +53,9 @@ export type CanisterInfo = {
 };
 
 export enum CanisterStatus {
-  Running = 'running',
-  Stopping = 'stopping',
-  Stopped = 'stopped',
+  Running = 'Running',
+  Stopping = 'Stopping',
+  Stopped = 'Stopped',
 }
 
 export function mapListMyCanistersResponse(

--- a/src/frontend/src/lib/api-models/index.ts
+++ b/src/frontend/src/lib/api-models/index.ts
@@ -1,4 +1,5 @@
 export * from './canister';
+export * from './canister-history';
 export * from './error';
 export * from './management-canister';
 export * from './organization';

--- a/src/frontend/src/lib/api/canister-history.ts
+++ b/src/frontend/src/lib/api/canister-history.ts
@@ -1,0 +1,23 @@
+import {
+  mapListCanisterChangesResponse,
+  type ListCanisterChangesResponse,
+} from '@/lib/api-models/canister-history';
+import type { ActorSubclass } from '@icp-sdk/core/agent';
+import { Principal } from '@icp-sdk/core/principal';
+import type { _SERVICE } from '@ssn/canister-history-api';
+
+export class CanisterHistoryApi {
+  constructor(private readonly actor: ActorSubclass<_SERVICE>) {}
+
+  public async listCanisterChanges(
+    canisterId: string,
+  ): Promise<ListCanisterChangesResponse> {
+    const res = await this.actor.list_canister_changes({
+      canister_id: Principal.from(canisterId),
+      reverse: [true],
+      limit: [50n],
+      page: [],
+    });
+    return mapListCanisterChangesResponse(res);
+  }
+}

--- a/src/frontend/src/lib/api/index.ts
+++ b/src/frontend/src/lib/api/index.ts
@@ -1,4 +1,5 @@
 export * from './canister';
+export * from './canister-history';
 export * from './management-canister';
 export * from './organization';
 export * from './project';

--- a/src/frontend/src/lib/format.ts
+++ b/src/frontend/src/lib/format.ts
@@ -1,0 +1,62 @@
+export function formatBytes(bytes: bigint): string {
+  const n = Number(bytes);
+  if (n === 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.min(
+    Math.floor(Math.log(n) / Math.log(1024)),
+    units.length - 1,
+  );
+  const value = n / Math.pow(1024, i);
+  return `${i === 0 ? value.toFixed(0) : value.toFixed(2)} ${units[i]}`;
+}
+
+export function formatCycles(cycles: bigint): string {
+  if (cycles === 0n) return '0';
+  const thresholds: [bigint, string][] = [
+    [1_000_000_000_000n, 'T'],
+    [1_000_000_000n, 'B'],
+    [1_000_000n, 'M'],
+    [1_000n, 'K'],
+  ];
+  for (const [threshold, suffix] of thresholds) {
+    if (cycles >= threshold) {
+      return `${(Number(cycles) / Number(threshold)).toFixed(2)} ${suffix}`;
+    }
+  }
+  return cycles.toString();
+}
+
+export function formatNumber(value: bigint): string {
+  return value.toLocaleString();
+}
+
+export function formatTimestamp(nanos: bigint): string {
+  return new Date(Number(nanos / 1_000_000n)).toLocaleString();
+}
+
+export function formatDuration(seconds: bigint): string {
+  const s = Number(seconds);
+  if (s === 0) return '0 s';
+  const units: [number, string][] = [
+    [86400 * 365, 'y'],
+    [86400 * 30, 'mo'],
+    [86400 * 7, 'w'],
+    [86400, 'd'],
+    [3600, 'h'],
+    [60, 'min'],
+    [1, 's'],
+  ];
+  for (const [divisor, label] of units) {
+    if (s >= divisor) {
+      const value = s / divisor;
+      return `${Number.isInteger(value) ? value : value.toFixed(1)} ${label}`;
+    }
+  }
+  return `${s} s`;
+}
+
+export function formatHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}

--- a/src/frontend/src/lib/params.ts
+++ b/src/frontend/src/lib/params.ts
@@ -16,3 +16,17 @@ export function useRequireProjectId(): string {
     return projectId;
   }, [projectId]);
 }
+
+export function useRequireCanisterId(): string {
+  const { canisterId } = useParams();
+  const returnTo = useReturnTo();
+
+  return useMemo(() => {
+    if (isNil(canisterId)) {
+      returnTo('/');
+      throw new Error(':canisterId param is required');
+    }
+
+    return canisterId;
+  }, [canisterId]);
+}

--- a/src/frontend/src/lib/store/api.ts
+++ b/src/frontend/src/lib/store/api.ts
@@ -1,6 +1,11 @@
-import { BACKEND_CANISTER_ID, SHOULD_FETCH_ROOT_KEY } from '@/env';
+import {
+  BACKEND_CANISTER_ID,
+  CANISTER_HISTORY_CANISTER_ID,
+  SHOULD_FETCH_ROOT_KEY,
+} from '@/env';
 import {
   CanisterApi,
+  CanisterHistoryApi,
   TrustedPartnerApi,
   UserProfileApi,
   ManagementCanisterApi,
@@ -20,6 +25,10 @@ import {
   type _SERVICE as BACKEND_API_SERVICE,
 } from '@ssn/backend-api';
 import {
+  idlFactory as canisterHistoryIdlFactory,
+  type _SERVICE as CANISTER_HISTORY_SERVICE,
+} from '@ssn/canister-history-api';
+import {
   idlFactory as managementCanisterIdlFactory,
   type _SERVICE as MANAGEMENT_CANISTER_SERVICE,
 } from '@ssn/management-canister';
@@ -38,6 +47,13 @@ const managementCanisterActor = Actor.createActor<MANAGEMENT_CANISTER_SERVICE>(
     canisterId: Principal.managementCanister(),
   },
 );
+const canisterHistoryActor = Actor.createActor<CANISTER_HISTORY_SERVICE>(
+  canisterHistoryIdlFactory,
+  {
+    agent: agent,
+    canisterId: CANISTER_HISTORY_CANISTER_ID,
+  },
+);
 
 const userProfileApi = new UserProfileApi(actor);
 const canisterApi = new CanisterApi(actor);
@@ -49,6 +65,7 @@ const termsAndConditionsApi = new TermsAndConditionsApi(actor);
 const projectApi = new ProjectApi(actor);
 const organizationApi = new OrganizationApi(actor);
 const teamApi = new TeamApi(actor);
+const canisterHistoryApi = new CanisterHistoryApi(canisterHistoryActor);
 const authApi = new AuthApi(OFFCHAIN_SERVICE_URL);
 
 export const createApiSlice: AppStateCreator<ApiSlice> = (_set, get) => ({
@@ -56,6 +73,7 @@ export const createApiSlice: AppStateCreator<ApiSlice> = (_set, get) => ({
   actor,
   userProfileApi,
   canisterApi,
+  canisterHistoryApi,
   managementCanisterApi,
   trustedPartnerApi,
   termsAndConditionsApi,

--- a/src/frontend/src/lib/store/canister.ts
+++ b/src/frontend/src/lib/store/canister.ts
@@ -16,9 +16,14 @@ export const createCanistersSlice: AppStateCreator<CanistersSlice> = (
   canisters: null,
 
   async initializeCanisters(projectId) {
-    const { isAuthenticated, refreshCanisters } = get();
+    const { isAuthenticated, canisters, refreshCanisters } = get();
 
     if (!isAuthenticated) {
+      set({ isCanistersInitialized: true });
+      return;
+    }
+
+    if (canisters?.has(projectId)) {
       set({ isCanistersInitialized: true });
       return;
     }

--- a/src/frontend/src/lib/store/model.ts
+++ b/src/frontend/src/lib/store/model.ts
@@ -14,6 +14,7 @@ import type {
 } from '@/lib/api-models';
 import type {
   CanisterApi,
+  CanisterHistoryApi,
   TrustedPartnerApi,
   UserProfileApi,
   ManagementCanisterApi,
@@ -46,6 +47,7 @@ export type ApiSlice = {
   actor: ActorSubclass<_SERVICE>;
   userProfileApi: UserProfileApi;
   canisterApi: CanisterApi;
+  canisterHistoryApi: CanisterHistoryApi;
   authApi: AuthApi;
   managementCanisterApi: ManagementCanisterApi;
   trustedPartnerApi: TrustedPartnerApi;

--- a/src/frontend/src/router.tsx
+++ b/src/frontend/src/router.tsx
@@ -8,6 +8,7 @@ const TermsAndConditions = lazy(
   () => import('@/routes/terms-and-conditions/terms-and-conditions'),
 );
 const Canisters = lazy(() => import('@/routes/canisters/canisters'));
+const CanisterDetail = lazy(() => import('@/routes/canisters/canister-detail'));
 const RedirectToProjectCanisters = lazy(
   () =>
     import('@/routes/redirect-to-project-canisters/redirect-to-project-canisters'),
@@ -51,6 +52,7 @@ export const Router: FC = () => (
 
         <Route path="projects/:projectId" element={<ProjectLayout />}>
           <Route path="canisters" element={<Canisters />} />
+          <Route path="canisters/:canisterId" element={<CanisterDetail />} />
         </Route>
       </Route>
     </Routes>

--- a/src/frontend/src/routes/canisters/canister-detail.tsx
+++ b/src/frontend/src/routes/canisters/canister-detail.tsx
@@ -1,0 +1,387 @@
+import { H1 } from '@/components/typography/h1';
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useRequireAuth } from '@/lib/auth';
+import {
+  CanisterStatus,
+  type CanisterChange,
+  type CanisterInfo,
+} from '@/lib/api-models';
+import {
+  formatBytes,
+  formatHex,
+  formatNumber,
+  formatTimestamp,
+} from '@/lib/format';
+import { isNil } from '@/lib/nil';
+import { useRequireProjectId, useRequireCanisterId } from '@/lib/params';
+import { useAppStore } from '@/lib/store';
+import { AddControllerForm } from '@/routes/canisters/add-controller-form';
+import { AddMissingCanisterControllerCta } from '@/routes/canisters/add-missing-canister-controller-cta';
+import { Button } from '@/components/ui/button';
+import { RefreshCw } from 'lucide-react';
+import { useEffect, useMemo, useState, type FC } from 'react';
+import { Link } from 'react-router';
+
+function statusBadgeVariant(
+  status: CanisterStatus,
+): 'success' | 'outline' | 'destructive' {
+  switch (status) {
+    case CanisterStatus.Running:
+      return 'success';
+    case CanisterStatus.Stopping:
+      return 'outline';
+    case CanisterStatus.Stopped:
+      return 'destructive';
+  }
+}
+
+type StatRowProps = { label: string; value: string };
+
+const StatRow: FC<StatRowProps> = ({ label, value }) => (
+  <div className="flex justify-between py-1 text-xs">
+    <span className="text-muted-foreground">{label}</span>
+    <span className="font-medium">{value}</span>
+  </div>
+);
+
+type SectionCardProps = {
+  title: string;
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+};
+
+const SectionCard: FC<SectionCardProps> = ({ title, children, footer }) => (
+  <Card size="sm">
+    <CardHeader>
+      <CardTitle>{title}</CardTitle>
+    </CardHeader>
+    <CardContent>{children}</CardContent>
+    {footer && <CardFooter>{footer}</CardFooter>}
+  </Card>
+);
+
+type CanisterInfoSectionsProps = { info: CanisterInfo };
+
+const CanisterInfoSections: FC<CanisterInfoSectionsProps> = ({ info }) => {
+  const logVisibilityLabel =
+    typeof info.settings.logVisibility === 'string'
+      ? info.settings.logVisibility === 'controllers'
+        ? 'Controllers only'
+        : 'Public'
+      : `${info.settings.logVisibility.length} allowed viewer(s)`;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <SectionCard
+        title="Settings"
+        footer={
+          <AddControllerForm canisterId={info.settings.controllers[0] ?? ''} />
+        }
+      >
+        <StatRow
+          label="Compute Allocation"
+          value={
+            info.settings.computeAllocation === 0n
+              ? 'Best effort'
+              : `${info.settings.computeAllocation}%`
+          }
+        />
+        <StatRow
+          label="Memory Allocation"
+          value={
+            info.settings.memoryAllocation === 0n
+              ? 'Unlimited'
+              : formatBytes(info.settings.memoryAllocation)
+          }
+        />
+        <StatRow label="Log Visibility" value={logVisibilityLabel} />
+        <StatRow
+          label="Wasm Memory Limit"
+          value={
+            info.settings.wasmMemoryLimit === 0n
+              ? 'Unlimited'
+              : formatBytes(info.settings.wasmMemoryLimit)
+          }
+        />
+        <StatRow
+          label="Wasm Memory Threshold"
+          value={
+            info.settings.wasmMemoryThreshold === 0n
+              ? 'None'
+              : formatBytes(info.settings.wasmMemoryThreshold)
+          }
+        />
+
+        <div className="mt-3">
+          <div className="mb-1 text-xs font-medium">Controllers</div>
+          {info.settings.controllers.length > 0 ? (
+            <div className="flex flex-col gap-1">
+              {info.settings.controllers.map(c => (
+                <p
+                  key={c}
+                  className="text-muted-foreground font-mono text-xs break-all"
+                >
+                  {c}
+                </p>
+              ))}
+            </div>
+          ) : (
+            <p className="text-muted-foreground text-xs">No controllers.</p>
+          )}
+        </div>
+
+        {info.settings.environmentVariables.length > 0 && (
+          <div className="mt-3">
+            <div className="mb-1 text-xs font-medium">
+              Environment Variables
+            </div>
+            <div className="flex flex-col gap-1">
+              {info.settings.environmentVariables.map(env => (
+                <div key={env.name} className="flex justify-between text-xs">
+                  <span className="font-medium">{env.name}</span>
+                  <span className="text-muted-foreground font-mono">
+                    {env.value}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </SectionCard>
+
+      <SectionCard title="Overview">
+        <StatRow label="Status" value={info.status} />
+        <StatRow label="Version" value={info.version.toString()} />
+        <StatRow
+          label="Module Hash"
+          value={
+            isNil(info.moduleHash)
+              ? 'None'
+              : formatHex(info.moduleHash).slice(0, 16) + '...'
+          }
+        />
+        <StatRow
+          label="Ready for Migration"
+          value={info.readyForMigration ? 'Yes' : 'No'}
+        />
+      </SectionCard>
+
+      <SectionCard title="Memory">
+        <StatRow label="Total" value={formatBytes(info.memorySize)} />
+        <StatRow
+          label="Wasm"
+          value={formatBytes(info.memoryMetrics.wasmMemorySize)}
+        />
+        <StatRow
+          label="Stable"
+          value={formatBytes(info.memoryMetrics.stableMemorySize)}
+        />
+        <StatRow
+          label="Global"
+          value={formatBytes(info.memoryMetrics.globalMemorySize)}
+        />
+        <StatRow
+          label="Wasm Binary"
+          value={formatBytes(info.memoryMetrics.wasmBinarySize)}
+        />
+        <StatRow
+          label="Custom Sections"
+          value={formatBytes(info.memoryMetrics.customSectionsSize)}
+        />
+        <StatRow
+          label="Canister History"
+          value={formatBytes(info.memoryMetrics.canisterHistorySize)}
+        />
+        <StatRow
+          label="Chunk Store"
+          value={formatBytes(info.memoryMetrics.wasmChunkStoreSize)}
+        />
+        <StatRow
+          label="Snapshots"
+          value={formatBytes(info.memoryMetrics.snapshotsSize)}
+        />
+      </SectionCard>
+
+      <SectionCard title="Query Stats">
+        <StatRow
+          label="Total Calls"
+          value={formatNumber(info.queryStats.numCallsTotal)}
+        />
+        <StatRow
+          label="Total Instructions"
+          value={formatNumber(info.queryStats.numInstructionsTotal)}
+        />
+        <StatRow
+          label="Request Bytes"
+          value={formatBytes(info.queryStats.requestPayloadBytesTotal)}
+        />
+        <StatRow
+          label="Response Bytes"
+          value={formatBytes(info.queryStats.responsePayloadBytesTotal)}
+        />
+      </SectionCard>
+    </div>
+  );
+};
+
+function changeLabel(change: CanisterChange): string {
+  if (change.details === null) return 'Unknown';
+  switch (change.details.type) {
+    case 'creation':
+      return 'Created';
+    case 'codeUninstall':
+      return 'Code Uninstall';
+    case 'codeDeployment': {
+      const mode = change.details.mode;
+      if (mode === 'install') return 'Code Install';
+      if (mode === 'reinstall') return 'Code Reinstall';
+      if (mode === 'upgrade') return 'Code Upgrade';
+      return 'Code Deployment';
+    }
+    case 'controllersChange':
+      return 'Controllers Changed';
+    case 'loadSnapshot':
+      return 'Snapshot Loaded';
+  }
+}
+
+function changeOriginLabel(change: CanisterChange): string {
+  if (change.origin === null) return '';
+  if (change.origin.type === 'user') return change.origin.userId;
+  return change.origin.canisterId;
+}
+
+type CanisterHistoryProps = { canisterPrincipal: string };
+
+const CanisterHistory: FC<CanisterHistoryProps> = ({ canisterPrincipal }) => {
+  const { canisterHistoryApi } = useAppStore();
+  const [changes, setChanges] = useState<CanisterChange[] | null>(null);
+
+  useEffect(() => {
+    canisterHistoryApi
+      .listCanisterChanges(canisterPrincipal)
+      .then(res => setChanges(res.changes))
+      .catch(() => setChanges([]));
+  }, [canisterPrincipal]);
+
+  return (
+    <SectionCard title="History">
+      {changes === null ? (
+        <p className="text-muted-foreground text-xs">Loading...</p>
+      ) : changes.length === 0 ? (
+        <p className="text-muted-foreground text-xs">No history available.</p>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {changes.map(change => (
+            <div
+              key={change.id}
+              className="flex items-start justify-between gap-2 py-1 text-xs"
+            >
+              <div>
+                <span className="font-medium">{changeLabel(change)}</span>
+                {change.origin !== null && (
+                  <span className="text-muted-foreground ml-1.5 font-mono">
+                    {changeOriginLabel(change)}
+                  </span>
+                )}
+              </div>
+              <div className="text-muted-foreground shrink-0 text-right">
+                <div>{formatTimestamp(change.timestampNanos)}</div>
+                <div>v{change.canisterVersion.toString()}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </SectionCard>
+  );
+};
+
+const CanisterDetail: FC = () => {
+  useRequireAuth();
+  const {
+    isCanistersLoading,
+    isCanistersInitialized,
+    initializeCanisters,
+    refreshCanisters,
+    canisters,
+  } = useAppStore();
+  const projectId = useRequireProjectId();
+  const canisterId = useRequireCanisterId();
+
+  useEffect(() => {
+    initializeCanisters(projectId);
+  }, [projectId]);
+
+  const canister = useMemo(
+    () => canisters?.get(projectId)?.find(c => c.id === canisterId) ?? null,
+    [canisters, projectId, canisterId],
+  );
+
+  const isLoading = isCanistersLoading || !isCanistersInitialized;
+
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <Link
+          to={`/projects/${projectId}/canisters`}
+          className="text-muted-foreground hover:text-foreground text-xs transition-colors"
+        >
+          &larr; Canisters
+        </Link>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          disabled={isCanistersLoading}
+          onClick={() => refreshCanisters(projectId)}
+        >
+          <RefreshCw className={isCanistersLoading ? 'animate-spin' : ''} />
+        </Button>
+      </div>
+
+      <H1 className="mt-3">Canister</H1>
+
+      {isLoading ? (
+        <div className="mt-6 flex flex-col gap-4">
+          <Skeleton className="h-32 w-full" />
+          <Skeleton className="h-32 w-full" />
+          <Skeleton className="h-32 w-full" />
+        </div>
+      ) : isNil(canister) ? (
+        <p className="text-muted-foreground mt-6 text-center text-sm">
+          Canister not found.
+        </p>
+      ) : (
+        <div className="mt-6 flex flex-col gap-4">
+          <div className="flex flex-col items-center gap-1">
+            <p className="text-center font-mono text-xs break-all">
+              {canister.principal}
+            </p>
+            {canister.info && (
+              <Badge variant={statusBadgeVariant(canister.info.status)}>
+                {canister.info.status}
+              </Badge>
+            )}
+          </div>
+
+          {isNil(canister.info) ? (
+            <AddMissingCanisterControllerCta canisterId={canister.principal} />
+          ) : (
+            <CanisterInfoSections info={canister.info} />
+          )}
+          <CanisterHistory canisterPrincipal={canister.principal} />
+        </div>
+      )}
+    </>
+  );
+};
+
+export default CanisterDetail;

--- a/src/frontend/src/routes/canisters/canister-grid-entry.tsx
+++ b/src/frontend/src/routes/canisters/canister-grid-entry.tsx
@@ -1,78 +1,92 @@
-import { Fragment, useMemo, type FC } from 'react';
+import { useMemo, type FC } from 'react';
 import {
   Card,
+  CardAction,
   CardContent,
   CardDescription,
   CardFooter,
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import {
-  Item,
-  ItemContent,
-  ItemDescription,
-  ItemGroup,
-  ItemSeparator,
-} from '@/components/ui/item';
-import { AddControllerForm } from '@/routes/canisters/add-controller-form';
+import { Badge } from '@/components/ui/badge';
 import { AddMissingCanisterControllerCta } from '@/routes/canisters/add-missing-canister-controller-cta';
-import { isNil, isNotNil } from '@/lib/nil';
-import type { Canister } from '@/lib/api-models';
+import { isNil } from '@/lib/nil';
+import { CanisterStatus, type Canister } from '@/lib/api-models';
+import { formatBytes, formatCycles } from '@/lib/format';
+import { useRequireProjectId } from '@/lib/params';
+import { Link } from 'react-router';
 
 export type CanisterGridEntryProps = {
   canister: Canister;
 };
 
-export const CanisterGridEntry: FC<CanisterGridEntryProps> = ({ canister }) => {
-  const isMissingController = useMemo(() => isNil(canister.info), [canister]);
+function statusBadgeVariant(
+  status: CanisterStatus,
+): 'success' | 'outline' | 'destructive' {
+  switch (status) {
+    case CanisterStatus.Running:
+      return 'success';
+    case CanisterStatus.Stopping:
+      return 'outline';
+    case CanisterStatus.Stopped:
+      return 'destructive';
+  }
+}
 
-  const hasControllers = useMemo(
-    () =>
-      isNotNil(canister.info) && canister.info.settings.controllers.length > 0,
-    [canister],
-  );
+export const CanisterGridEntry: FC<CanisterGridEntryProps> = ({ canister }) => {
+  const projectId = useRequireProjectId();
+  const isMissingController = useMemo(() => isNil(canister.info), [canister]);
 
   return (
     <>
-      <Card>
+      <Card size="sm">
         <CardHeader>
           <CardTitle>Canister</CardTitle>
-          <CardDescription>{canister.principal}</CardDescription>
+          <CardDescription className="truncate font-mono">
+            {canister.principal}
+          </CardDescription>
+          {canister.info && (
+            <CardAction>
+              <Badge variant={statusBadgeVariant(canister.info.status)}>
+                {canister.info.status}
+              </Badge>
+            </CardAction>
+          )}
         </CardHeader>
 
-        <CardContent>
-          <CardTitle>Controllers</CardTitle>
-
-          {hasControllers ? (
-            <ItemGroup className="mt-3">
-              <ItemSeparator />
-              {canister.info?.settings.controllers.map(
-                (controller, i, controllers) => (
-                  <Fragment key={controller}>
-                    <Item>
-                      <ItemContent>
-                        <ItemDescription>{controller}</ItemDescription>
-                      </ItemContent>
-                    </Item>
-
-                    {i !== controllers.length - 1 && <ItemSeparator />}
-                  </Fragment>
-                ),
-              )}
-              <ItemSeparator />
-            </ItemGroup>
-          ) : (
-            <CardDescription>
-              There are no controllers for this canister!
-            </CardDescription>
-          )}
-        </CardContent>
-
-        {!isMissingController && (
-          <CardFooter className="flex justify-center">
-            <AddControllerForm canisterId={canister.principal} />
-          </CardFooter>
+        {canister.info && (
+          <CardContent>
+            <div className="grid grid-cols-3 gap-2 text-xs">
+              <div>
+                <div className="text-muted-foreground mb-0.5">Cycles</div>
+                <div className="font-medium">
+                  {formatCycles(canister.info.cycles)}
+                </div>
+              </div>
+              <div>
+                <div className="text-muted-foreground mb-0.5">Memory</div>
+                <div className="font-medium">
+                  {formatBytes(canister.info.memorySize)}
+                </div>
+              </div>
+              <div>
+                <div className="text-muted-foreground mb-0.5">Burn / day</div>
+                <div className="font-medium">
+                  {formatCycles(canister.info.idleCyclesBurnedPerDay)}
+                </div>
+              </div>
+            </div>
+          </CardContent>
         )}
+
+        <CardFooter>
+          <Link
+            to={`/projects/${projectId}/canisters/${canister.id}`}
+            className="text-muted-foreground hover:text-foreground text-xs transition-colors"
+          >
+            View details &rarr;
+          </Link>
+        </CardFooter>
       </Card>
 
       {isMissingController && (

--- a/turbo.json
+++ b/turbo.json
@@ -25,7 +25,8 @@
     },
     "start": {
       "dependsOn": ["^build"],
-      "cache": false
+      "cache": false,
+      "persistent": true
     },
     "test": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
- Add detail route with settings, overview, memory, query stats, and canister history (via @ssn/canister-history-api)
- Remove cycles-related fields (not applicable on Swiss Subnet)
- Cache canister list per project to avoid redundant fetches
- Capitalize CanisterStatus enum values
- Fix turbo start task as persistent