### PR TITLE
feat(frontend): breadcrumb navigation and canister controller fixes

### DIFF
--- a/src/frontend/src/components/breadcrumbs.tsx
+++ b/src/frontend/src/components/breadcrumbs.tsx
@@ -1,0 +1,51 @@
+import { cn } from '@/lib/utils';
+import { ChevronRight } from 'lucide-react';
+import { Fragment, type FC } from 'react';
+import { Link } from 'react-router';
+
+export type BreadcrumbItem = {
+  label: string;
+  to?: string;
+};
+
+export type BreadcrumbsProps = {
+  items: BreadcrumbItem[];
+  className?: string;
+};
+
+export const Breadcrumbs: FC<BreadcrumbsProps> = ({ items, className }) => (
+  <nav
+    aria-label="Breadcrumb"
+    className={cn(
+      'text-muted-foreground flex flex-wrap items-center gap-1 text-xs',
+      className,
+    )}
+  >
+    {items.map((item, index) => {
+      const isLast = index === items.length - 1;
+      return (
+        <Fragment key={`${index}-${item.label}`}>
+          {index > 0 && <ChevronRight className="size-3 shrink-0" />}
+          {item.to && !isLast ? (
+            <Link
+              to={item.to}
+              className="hover:text-foreground max-w-[16ch] truncate transition-colors"
+            >
+              {item.label}
+            </Link>
+          ) : (
+            <span
+              className={cn(
+                'max-w-[24ch] truncate',
+                isLast && 'text-foreground font-medium',
+              )}
+              aria-current={isLast ? 'page' : undefined}
+            >
+              {item.label}
+            </span>
+          )}
+        </Fragment>
+      );
+    })}
+  </nav>
+);

--- a/src/frontend/src/lib/api/canister.ts
+++ b/src/frontend/src/lib/api/canister.ts
@@ -6,7 +6,20 @@ import {
 import { isNil } from '@/lib/nil';
 import type { ActorSubclass } from '@icp-sdk/core/agent';
 import { Principal } from '@icp-sdk/core/principal';
-import type { _SERVICE } from '@ssn/backend-api';
+import type { _SERVICE, Proposal } from '@ssn/backend-api';
+
+function assertProposalExecuted(proposal: Proposal): void {
+  const [status] = proposal.status;
+  if (isNil(status)) {
+    throw new Error('Proposal returned without a status');
+  }
+  if ('Failed' in status) {
+    throw new Error(status.Failed.message);
+  }
+  if ('Rejected' in status) {
+    throw new Error('Proposal was rejected');
+  }
+}
 
 export class CanisterApi {
   constructor(private readonly actor: ActorSubclass<_SERVICE>) {}
@@ -32,7 +45,7 @@ export class CanisterApi {
         },
       ],
     });
-    mapOkResponse(createRes);
+    assertProposalExecuted(mapOkResponse(createRes));
   }
 
   public async addCanisterController(
@@ -56,6 +69,6 @@ export class CanisterApi {
         },
       ],
     });
-    mapOkResponse(createRes);
+    assertProposalExecuted(mapOkResponse(createRes));
   }
 }

--- a/src/frontend/src/routes/canisters/canister-detail.tsx
+++ b/src/frontend/src/routes/canisters/canister-detail.tsx
@@ -1,4 +1,5 @@
 import { H1 } from '@/components/typography/h1';
+import { Breadcrumbs } from '@/components/breadcrumbs';
 import {
   Card,
   CardContent,
@@ -22,13 +23,12 @@ import {
 } from '@/lib/format';
 import { isNil } from '@/lib/nil';
 import { useRequireProjectId, useRequireCanisterId } from '@/lib/params';
-import { useAppStore } from '@/lib/store';
+import { selectOrgMap, selectProjectMap, useAppStore } from '@/lib/store';
 import { AddControllerForm } from '@/routes/canisters/add-controller-form';
 import { AddMissingCanisterControllerCta } from '@/routes/canisters/add-missing-canister-controller-cta';
 import { Button } from '@/components/ui/button';
 import { RefreshCw } from 'lucide-react';
 import { useEffect, useMemo, useState, type FC } from 'react';
-import { Link } from 'react-router';
 
 function statusBadgeVariant(
   status: CanisterStatus,
@@ -68,9 +68,15 @@ const SectionCard: FC<SectionCardProps> = ({ title, children, footer }) => (
   </Card>
 );
 
-type CanisterInfoSectionsProps = { info: CanisterInfo };
+type CanisterInfoSectionsProps = {
+  canisterPrincipal: string;
+  info: CanisterInfo;
+};
 
-const CanisterInfoSections: FC<CanisterInfoSectionsProps> = ({ info }) => {
+const CanisterInfoSections: FC<CanisterInfoSectionsProps> = ({
+  canisterPrincipal,
+  info,
+}) => {
   const logVisibilityLabel =
     typeof info.settings.logVisibility === 'string'
       ? info.settings.logVisibility === 'controllers'
@@ -82,9 +88,7 @@ const CanisterInfoSections: FC<CanisterInfoSectionsProps> = ({ info }) => {
     <div className="flex flex-col gap-4">
       <SectionCard
         title="Settings"
-        footer={
-          <AddControllerForm canisterId={info.settings.controllers[0] ?? ''} />
-        }
+        footer={<AddControllerForm canisterId={canisterPrincipal} />}
       >
         <StatRow
           label="Compute Allocation"
@@ -314,6 +318,8 @@ const CanisterDetail: FC = () => {
     refreshCanisters,
     canisters,
   } = useAppStore();
+  const projectMap = useAppStore(selectProjectMap);
+  const orgMap = useAppStore(selectOrgMap);
   const projectId = useRequireProjectId();
   const canisterId = useRequireCanisterId();
 
@@ -326,17 +332,43 @@ const CanisterDetail: FC = () => {
     [canisters, projectId, canisterId],
   );
 
+  const project = useMemo(
+    () => projectMap.get(projectId) ?? null,
+    [projectId, projectMap],
+  );
+
+  const organization = useMemo(
+    () => (project ? (orgMap.get(project.orgId) ?? null) : null),
+    [project, orgMap],
+  );
+
   const isLoading = isCanistersLoading || !isCanistersInitialized;
+
+  const canisterLabel = canister
+    ? `${canister.principal.slice(0, 5)}...${canister.principal.slice(-3)}`
+    : 'Canister';
 
   return (
     <>
-      <div className="flex items-center justify-between">
-        <Link
-          to={`/projects/${projectId}/canisters`}
-          className="text-muted-foreground hover:text-foreground text-xs transition-colors"
-        >
-          &larr; Canisters
-        </Link>
+      <div className="flex items-center justify-between gap-2">
+        <Breadcrumbs
+          items={[
+            { label: 'Home', to: '/canisters' },
+            ...(organization
+              ? [
+                  {
+                    label: organization.name,
+                    to: `/organizations/${organization.id}/settings`,
+                  },
+                ]
+              : []),
+            {
+              label: project?.name ?? 'Project',
+              to: `/projects/${projectId}/canisters`,
+            },
+            { label: canisterLabel },
+          ]}
+        />
         <Button
           variant="ghost"
           size="icon-sm"
@@ -375,7 +407,10 @@ const CanisterDetail: FC = () => {
           {isNil(canister.info) ? (
             <AddMissingCanisterControllerCta canisterId={canister.principal} />
           ) : (
-            <CanisterInfoSections info={canister.info} />
+            <CanisterInfoSections
+              canisterPrincipal={canister.principal}
+              info={canister.info}
+            />
           )}
           <CanisterHistory canisterPrincipal={canister.principal} />
         </div>

--- a/src/frontend/src/routes/canisters/canisters.tsx
+++ b/src/frontend/src/routes/canisters/canisters.tsx
@@ -1,6 +1,7 @@
 import { H1 } from '@/components/typography/h1';
+import { Breadcrumbs } from '@/components/breadcrumbs';
 import { useRequireAuth } from '@/lib/auth';
-import { useAppStore } from '@/lib/store';
+import { selectOrgMap, selectProjectMap, useAppStore } from '@/lib/store';
 import { CanisterGrid } from '@/routes/canisters/canister-grid';
 import { CreateCanisterButton } from '@/routes/canisters/create-canister-button';
 import { useEffect, useMemo, type FC } from 'react';
@@ -11,11 +12,23 @@ import { useRequireProjectId } from '@/lib/params';
 const Canisters: FC = () => {
   useRequireAuth();
   const { isCanistersLoading, initializeCanisters, canisters } = useAppStore();
+  const projectMap = useAppStore(selectProjectMap);
+  const orgMap = useAppStore(selectOrgMap);
   const projectId = useRequireProjectId();
 
   useEffect(() => {
     initializeCanisters(projectId);
   }, [projectId]);
+
+  const project = useMemo(
+    () => projectMap.get(projectId) ?? null,
+    [projectId, projectMap],
+  );
+
+  const organization = useMemo(
+    () => (project ? (orgMap.get(project.orgId) ?? null) : null),
+    [project, orgMap],
+  );
 
   const projectCanisterMap = useMemo(
     () => canisters?.get(projectId) ?? null,
@@ -29,6 +42,21 @@ const Canisters: FC = () => {
 
   return (
     <>
+      <Breadcrumbs
+        className="mb-3"
+        items={[
+          { label: 'Home', to: '/canisters' },
+          ...(organization
+            ? [
+                {
+                  label: organization.name,
+                  to: `/organizations/${organization.id}/settings`,
+                },
+              ]
+            : []),
+          { label: project?.name ?? 'Project' },
+        ]}
+      />
       <H1>Canisters</H1>
       {isCanistersLoading || isNil(projectCanisters) ? (
         <CanisterSkeleton className="mt-8" />

--- a/src/frontend/src/routes/organizations/create-organization.tsx
+++ b/src/frontend/src/routes/organizations/create-organization.tsx
@@ -1,5 +1,6 @@
 import { LoadingButton } from '@/components/loading-button';
 import { Container } from '@/components/layout/container';
+import { Breadcrumbs } from '@/components/breadcrumbs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Form,
@@ -9,12 +10,10 @@ import {
   FormLabel,
   FormMessage,
 } from '@/components/form';
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useAppStore } from '@/lib/store';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { ArrowLeft } from 'lucide-react';
 import type { FC } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router';
@@ -51,12 +50,13 @@ const CreateOrganization: FC = () => {
 
   return (
     <Container>
-      <div className="mx-auto max-w-md">
-        <Button variant="ghost" size="sm" onClick={() => navigate(-1)}>
-          <ArrowLeft className="mr-1 size-3.5" />
-          Back
-        </Button>
-      </div>
+      <Breadcrumbs
+        className="mx-auto max-w-md"
+        items={[
+          { label: 'Home', to: '/canisters' },
+          { label: 'New Organization' },
+        ]}
+      />
 
       <Card className="mx-auto mt-6 max-w-md">
         <CardHeader>

--- a/src/frontend/src/routes/organizations/organization-settings.tsx
+++ b/src/frontend/src/routes/organizations/organization-settings.tsx
@@ -1,5 +1,6 @@
 import { LoadingButton } from '@/components/loading-button';
 import { Container } from '@/components/layout/container';
+import { Breadcrumbs } from '@/components/breadcrumbs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Form,
@@ -14,7 +15,7 @@ import { Button } from '@/components/ui/button';
 import { useAppStore, selectOrgMap } from '@/lib/store';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { ArrowLeft, Users } from 'lucide-react';
+import { Users } from 'lucide-react';
 import { useEffect, useMemo, useState, type FC } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router';
@@ -88,12 +89,13 @@ const OrganizationSettings: FC = () => {
   return (
     <Container>
       <div className="space-y-6">
-        <div className="mx-auto max-w-md">
-          <Button variant="ghost" size="sm" onClick={() => navigate(-1)}>
-            <ArrowLeft className="mr-1 size-3.5" />
-            Back
-          </Button>
-        </div>
+        <Breadcrumbs
+          className="mx-auto max-w-md"
+          items={[
+            { label: 'Home', to: '/canisters' },
+            { label: organization.name },
+          ]}
+        />
 
         <Card className="mx-auto max-w-md">
           <CardHeader>

--- a/src/frontend/src/routes/organizations/teams/create-team.tsx
+++ b/src/frontend/src/routes/organizations/teams/create-team.tsx
@@ -1,5 +1,6 @@
 import { LoadingButton } from '@/components/loading-button';
 import { Container } from '@/components/layout/container';
+import { Breadcrumbs } from '@/components/breadcrumbs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Form,
@@ -9,12 +10,10 @@ import {
   FormLabel,
   FormMessage,
 } from '@/components/form';
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useAppStore } from '@/lib/store';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { ArrowLeft } from 'lucide-react';
 import type { FC } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router';
@@ -64,18 +63,18 @@ const CreateTeam: FC = () => {
 
   return (
     <Container>
-      <div className="mx-auto max-w-md">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() =>
-            navigate(`/organizations/${orgId}/teams`, { replace: true })
-          }
-        >
-          <ArrowLeft className="mr-1 size-3.5" />
-          Back
-        </Button>
-      </div>
+      <Breadcrumbs
+        className="mx-auto max-w-md"
+        items={[
+          { label: 'Home', to: '/canisters' },
+          {
+            label: organization.name,
+            to: `/organizations/${orgId}/settings`,
+          },
+          { label: 'Teams', to: `/organizations/${orgId}/teams` },
+          { label: 'New Team' },
+        ]}
+      />
 
       <Card className="mx-auto mt-6 max-w-md">
         <CardHeader>

--- a/src/frontend/src/routes/organizations/teams/team-list.tsx
+++ b/src/frontend/src/routes/organizations/teams/team-list.tsx
@@ -1,9 +1,10 @@
 import { Container } from '@/components/layout/container';
+import { Breadcrumbs } from '@/components/breadcrumbs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { useAppStore } from '@/lib/store';
 import { showErrorToast } from '@/lib/toast';
-import { ArrowLeft, Plus } from 'lucide-react';
+import { Plus } from 'lucide-react';
 import { useEffect, useState, type FC } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { isNil } from '@/lib/nil';
@@ -49,16 +50,16 @@ const TeamList: FC = () => {
     <Container>
       <div className="mx-auto max-w-md space-y-6">
         <div className="flex items-center justify-between">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() =>
-              navigate(`/organizations/${orgId}/settings`, { replace: true })
-            }
-          >
-            <ArrowLeft className="mr-1 size-3.5" />
-            Back
-          </Button>
+          <Breadcrumbs
+            items={[
+              { label: 'Home', to: '/canisters' },
+              {
+                label: organization.name,
+                to: `/organizations/${orgId}/settings`,
+              },
+              { label: 'Teams' },
+            ]}
+          />
 
           <Button
             size="sm"

--- a/src/frontend/src/routes/organizations/teams/team-settings.tsx
+++ b/src/frontend/src/routes/organizations/teams/team-settings.tsx
@@ -1,5 +1,6 @@
 import { LoadingButton } from '@/components/loading-button';
 import { Container } from '@/components/layout/container';
+import { Breadcrumbs } from '@/components/breadcrumbs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Form,
@@ -10,11 +11,9 @@ import {
   FormMessage,
 } from '@/components/form';
 import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
-import { useAppStore, selectTeamMap } from '@/lib/store';
+import { useAppStore, selectOrgMap, selectTeamMap } from '@/lib/store';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { ArrowLeft } from 'lucide-react';
 import { useEffect, useMemo, useState, type FC } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router';
@@ -36,10 +35,16 @@ const TeamSettings: FC = () => {
   const navigate = useNavigate();
   const { updateTeam, deleteTeam } = useAppStore();
   const teamMap = useAppStore(selectTeamMap);
+  const orgMap = useAppStore(selectOrgMap);
 
   const team = useMemo(
     () => (teamId ? teamMap.get(teamId) : undefined),
     [teamId, teamMap],
+  );
+
+  const organization = useMemo(
+    () => (orgId ? orgMap.get(orgId) : undefined),
+    [orgId, orgMap],
   );
 
   const form = useForm<FormData>({
@@ -88,18 +93,18 @@ const TeamSettings: FC = () => {
   return (
     <Container>
       <div className="space-y-6">
-        <div className="mx-auto max-w-md">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() =>
-              navigate(`/organizations/${orgId}/teams`, { replace: true })
-            }
-          >
-            <ArrowLeft className="mr-1 size-3.5" />
-            Back
-          </Button>
-        </div>
+        <Breadcrumbs
+          className="mx-auto max-w-md"
+          items={[
+            { label: 'Home', to: '/canisters' },
+            {
+              label: organization?.name ?? 'Organization',
+              to: `/organizations/${orgId}/settings`,
+            },
+            { label: 'Teams', to: `/organizations/${orgId}/teams` },
+            { label: team.name },
+          ]}
+        />
 
         <Card className="mx-auto max-w-md">
           <CardHeader>


### PR DESCRIPTION
Replace back buttons with breadcrumbs across organization, team, and canister routes. Every parent link is now an explicit path derived from URL params, never navigate(-1), so navigation cycles are impossible. "Home" points to /canisters, matching the home page's default-project redirect.