### PR TITLE
feat(frontend): dashboard and billing placeholders

### DIFF
--- a/src/frontend/src/components/layout/header.tsx
+++ b/src/frontend/src/components/layout/header.tsx
@@ -25,6 +25,28 @@ export const Header: FC = () => {
 
       <NavigationMenu>
         <NavigationMenuList>
+          {isAuthenticated && (
+            <>
+              <NavigationMenuItem>
+                <NavigationMenuLink
+                  className={navigationMenuTriggerStyle()}
+                  render={<NavLink to="/dashboard" />}
+                >
+                  Dashboard
+                </NavigationMenuLink>
+              </NavigationMenuItem>
+
+              <NavigationMenuItem>
+                <NavigationMenuLink
+                  className={navigationMenuTriggerStyle()}
+                  render={<NavLink to="/billing" />}
+                >
+                  Billing
+                </NavigationMenuLink>
+              </NavigationMenuItem>
+            </>
+          )}
+
           <NavigationMenuItem>
             <NavigationMenuLink
               className={navigationMenuTriggerStyle()}

--- a/src/frontend/src/router.tsx
+++ b/src/frontend/src/router.tsx
@@ -15,6 +15,8 @@ const RedirectToProjectCanisters = lazy(
 );
 const Admin = lazy(() => import('@/routes/admin/admin'));
 const Verify = lazy(() => import('@/routes/verify/verify'));
+const Dashboard = lazy(() => import('@/routes/dashboard/dashboard'));
+const Billing = lazy(() => import('@/routes/billing/billing'));
 const CreateOrganization = lazy(
   () => import('@/routes/organizations/create-organization'),
 );
@@ -38,6 +40,8 @@ export const Router: FC = () => (
         <Route path="canisters" element={<RedirectToProjectCanisters />} />
         <Route path="admin" element={<Admin />} />
         <Route path="verify" element={<Verify />} />
+        <Route path="dashboard" element={<Dashboard />} />
+        <Route path="billing" element={<Billing />} />
         <Route path="organizations/new" element={<CreateOrganization />} />
         <Route
           path="organizations/:orgId/settings"

--- a/src/frontend/src/routes/billing/billing.tsx
+++ b/src/frontend/src/routes/billing/billing.tsx
@@ -1,0 +1,31 @@
+import { Breadcrumbs } from '@/components/breadcrumbs';
+import { Container } from '@/components/layout/container';
+import { H1 } from '@/components/typography/h1';
+import { Card, CardContent } from '@/components/ui/card';
+import { useRequireAuth } from '@/lib/auth';
+import type { FC } from 'react';
+
+const Billing: FC = () => {
+  useRequireAuth();
+
+  return (
+    <Container>
+      <Breadcrumbs
+        items={[{ label: 'Home', to: '/canisters' }, { label: 'Billing' }]}
+      />
+
+      <H1 className="mt-3">Billing</H1>
+
+      <Card className="mt-6">
+        <CardContent>
+          <p className="text-muted-foreground text-sm">
+            Invoices, payment methods, and usage-based charges across all your
+            organizations will appear here. Coming soon.
+          </p>
+        </CardContent>
+      </Card>
+    </Container>
+  );
+};
+
+export default Billing;

--- a/src/frontend/src/routes/canisters/canister-detail.tsx
+++ b/src/frontend/src/routes/canisters/canister-detail.tsx
@@ -350,25 +350,27 @@ const CanisterDetail: FC = () => {
 
   return (
     <>
-      <div className="flex items-center justify-between gap-2">
-        <Breadcrumbs
-          items={[
-            { label: 'Home', to: '/canisters' },
-            ...(organization
-              ? [
-                  {
-                    label: organization.name,
-                    to: `/organizations/${organization.id}/settings`,
-                  },
-                ]
-              : []),
-            {
-              label: project?.name ?? 'Project',
-              to: `/projects/${projectId}/canisters`,
-            },
-            { label: canisterLabel },
-          ]}
-        />
+      <Breadcrumbs
+        items={[
+          { label: 'Home', to: '/canisters' },
+          ...(organization
+            ? [
+                {
+                  label: organization.name,
+                  to: `/organizations/${organization.id}/settings`,
+                },
+              ]
+            : []),
+          {
+            label: project?.name ?? 'Project',
+            to: `/projects/${projectId}/canisters`,
+          },
+          { label: canisterLabel },
+        ]}
+      />
+
+      <div className="mt-3 flex items-center justify-between gap-2">
+        <H1>Canister</H1>
         <Button
           variant="ghost"
           size="icon-sm"
@@ -378,8 +380,6 @@ const CanisterDetail: FC = () => {
           <RefreshCw className={isCanistersLoading ? 'animate-spin' : ''} />
         </Button>
       </div>
-
-      <H1 className="mt-3">Canister</H1>
 
       {isLoading ? (
         <div className="mt-6 flex flex-col gap-4">

--- a/src/frontend/src/routes/dashboard/dashboard.tsx
+++ b/src/frontend/src/routes/dashboard/dashboard.tsx
@@ -1,0 +1,207 @@
+import { Breadcrumbs } from '@/components/breadcrumbs';
+import { Container } from '@/components/layout/container';
+import { H1 } from '@/components/typography/h1';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Sparkles } from 'lucide-react';
+import { CanisterStatus } from '@/lib/api-models';
+import { useRequireAuth } from '@/lib/auth';
+import { formatBytes, formatCycles } from '@/lib/format';
+import { isNotNil } from '@/lib/nil';
+import { selectOrgsWithProjects, useAppStore } from '@/lib/store';
+import { Link } from 'react-router';
+import { useEffect, useMemo, type FC } from 'react';
+
+type StatRowProps = { label: string; value: string };
+
+const StatRow: FC<StatRowProps> = ({ label, value }) => (
+  <div className="flex justify-between py-1 text-sm">
+    <span className="text-muted-foreground">{label}</span>
+    <span className="font-medium">{value}</span>
+  </div>
+);
+
+const Dashboard: FC = () => {
+  useRequireAuth();
+  const { organizations, projects, teams, canisters, initializeCanisters } =
+    useAppStore();
+  const orgsWithProjects = useAppStore(selectOrgsWithProjects);
+
+  const defaultProject = projects[0];
+  const defaultProjectId = defaultProject?.id;
+
+  useEffect(() => {
+    if (isNotNil(defaultProjectId)) {
+      initializeCanisters(defaultProjectId);
+    }
+  }, [defaultProjectId, initializeCanisters]);
+
+  const defaultCanisters = useMemo(
+    () =>
+      isNotNil(defaultProjectId)
+        ? (canisters?.get(defaultProjectId) ?? [])
+        : [],
+    [canisters, defaultProjectId],
+  );
+
+  const canisterStats = useMemo(() => {
+    let running = 0;
+    let stopping = 0;
+    let stopped = 0;
+    let totalCycles = 0n;
+    let totalIdleBurn = 0n;
+    let totalMemory = 0n;
+    let withInfo = 0;
+
+    for (const canister of defaultCanisters) {
+      if (!canister.info) continue;
+      withInfo += 1;
+      totalCycles += canister.info.cycles;
+      totalIdleBurn += canister.info.idleCyclesBurnedPerDay;
+      totalMemory += canister.info.memorySize;
+      if (canister.info.status === CanisterStatus.Running) running += 1;
+      else if (canister.info.status === CanisterStatus.Stopping) stopping += 1;
+      else if (canister.info.status === CanisterStatus.Stopped) stopped += 1;
+    }
+
+    return {
+      total: defaultCanisters.length,
+      withInfo,
+      running,
+      stopping,
+      stopped,
+      totalCycles,
+      totalIdleBurn,
+      totalMemory,
+    };
+  }, [defaultCanisters]);
+
+  const daysOfRuntime = useMemo(() => {
+    if (canisterStats.totalIdleBurn === 0n) return null;
+    const days =
+      Number(canisterStats.totalCycles) / Number(canisterStats.totalIdleBurn);
+    if (!Number.isFinite(days)) return null;
+    return days;
+  }, [canisterStats]);
+
+  return (
+    <Container>
+      <Breadcrumbs
+        items={[{ label: 'Home', to: '/canisters' }, { label: 'Dashboard' }]}
+      />
+
+      <H1 className="mt-3">Dashboard</H1>
+
+      <Alert className="mt-6">
+        <Sparkles />
+        <AlertTitle>Work in progress</AlertTitle>
+        <AlertDescription>
+          This is an early view of your workspace. Richer metrics, activity, and
+          team insights are on the way.
+        </AlertDescription>
+      </Alert>
+
+      <div className="mt-4 grid gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Footprint</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <StatRow
+              label="Organizations"
+              value={organizations.length.toString()}
+            />
+            <StatRow label="Projects" value={projects.length.toString()} />
+            <StatRow label="Teams" value={teams.length.toString()} />
+            <StatRow label="Canisters" value={canisterStats.total.toString()} />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Canisters</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {canisterStats.withInfo === 0 ? (
+              <p className="text-muted-foreground text-sm">
+                No canister metrics available yet.
+              </p>
+            ) : (
+              <>
+                <StatRow
+                  label="Running"
+                  value={`${canisterStats.running} / ${canisterStats.withInfo}`}
+                />
+                {canisterStats.stopping > 0 && (
+                  <StatRow
+                    label="Stopping"
+                    value={canisterStats.stopping.toString()}
+                  />
+                )}
+                {canisterStats.stopped > 0 && (
+                  <StatRow
+                    label="Stopped"
+                    value={canisterStats.stopped.toString()}
+                  />
+                )}
+                <StatRow
+                  label="Total Cycles"
+                  value={formatCycles(canisterStats.totalCycles)}
+                />
+                <StatRow
+                  label="Idle Burn / Day"
+                  value={formatCycles(canisterStats.totalIdleBurn)}
+                />
+                {daysOfRuntime !== null && (
+                  <StatRow
+                    label="Idle Runtime"
+                    value={`~${daysOfRuntime.toFixed(0)} days`}
+                  />
+                )}
+                <StatRow
+                  label="Memory"
+                  value={formatBytes(canisterStats.totalMemory)}
+                />
+              </>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="md:col-span-2">
+          <CardHeader>
+            <CardTitle>Organizations</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {orgsWithProjects.length === 0 ? (
+              <p className="text-muted-foreground text-sm">
+                You don't belong to any organizations yet.
+              </p>
+            ) : (
+              <ul className="divide-y">
+                {orgsWithProjects.map(org => (
+                  <li
+                    key={org.id}
+                    className="flex items-center justify-between py-3 text-sm"
+                  >
+                    <Link
+                      to={`/organizations/${org.id}/settings`}
+                      className="hover:text-foreground font-medium transition-colors"
+                    >
+                      {org.name}
+                    </Link>
+                    <span className="text-muted-foreground text-xs">
+                      {org.projects.length}{' '}
+                      {org.projects.length === 1 ? 'project' : 'projects'}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </Container>
+  );
+};
+
+export default Dashboard;

--- a/src/frontend/src/routes/organizations/teams/team-list.tsx
+++ b/src/frontend/src/routes/organizations/teams/team-list.tsx
@@ -49,30 +49,28 @@ const TeamList: FC = () => {
   return (
     <Container>
       <div className="mx-auto max-w-md space-y-6">
-        <div className="flex items-center justify-between">
-          <Breadcrumbs
-            items={[
-              { label: 'Home', to: '/canisters' },
-              {
-                label: organization.name,
-                to: `/organizations/${orgId}/settings`,
-              },
-              { label: 'Teams' },
-            ]}
-          />
-
-          <Button
-            size="sm"
-            onClick={() => navigate(`/organizations/${orgId}/teams/new`)}
-          >
-            <Plus className="mr-1 size-3.5" />
-            New Team
-          </Button>
-        </div>
+        <Breadcrumbs
+          items={[
+            { label: 'Home', to: '/canisters' },
+            {
+              label: organization.name,
+              to: `/organizations/${orgId}/settings`,
+            },
+            { label: 'Teams' },
+          ]}
+        />
 
         <Card>
-          <CardHeader>
+          <CardHeader className="flex flex-row items-center justify-between">
             <CardTitle>Teams in {organization.name}</CardTitle>
+
+            <Button
+              size="sm"
+              onClick={() => navigate(`/organizations/${orgId}/teams/new`)}
+            >
+              <Plus className="mr-1 size-3.5" />
+              New Team
+            </Button>
           </CardHeader>
 
           <CardContent>


### PR DESCRIPTION
Add /dashboard and /billing routes linked from the header. Billing is a coming-soon card. Dashboard shows footprint counts, default-project canister stats, and an org list, plus a WIP alert.

Also fix breadcrumb-row height jumps by moving the New Team button into the team list card header and the refresh button next to the canister detail H1.