### PR TITLE
chore(flake): only print dev shell banner on interactive TTY

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,12 +74,14 @@
           ];
 
           shellHook = ''
-            echo "SSN Console dev shell"
-            echo "  Rust:  $(rustc --version)"
-            echo "  Bun:   $(bun --version)"
-            echo "  Node:  $(node --version)"
-            echo "  dfx:   $(dfx --version)"
-            echo "  SSL:   $(openssl version)"
+            if [ -t 1 ]; then
+              echo "SSN Console dev shell"
+              echo "  Rust:  $(rustc --version)"
+              echo "  Bun:   $(bun --version)"
+              echo "  Node:  $(node --version)"
+              echo "  dfx:   $(dfx --version)"
+              echo "  SSL:   $(openssl version)"
+            fi
           '';
         };
       }


### PR DESCRIPTION
Gate the shellHook version banner on `[ -t 1 ]` so it only prints when stdout is attached to a terminal. Non-interactive uses — scripts, CI, and `nix develop --command ...` invocations — no longer get the banner prepended to their output.