### PR TITLE
feat(frontend): unify layout with global sidebar and consistent breadcrumbs

### DIFF
--- a/src/frontend/src/components/layout/app-sidebar.tsx
+++ b/src/frontend/src/components/layout/app-sidebar.tsx
@@ -3,9 +3,21 @@ import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
   SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
 } from '@/components/ui/sidebar';
+import { CreditCardIcon, LayoutDashboardIcon } from 'lucide-react';
 import type { FC } from 'react';
+import { NavLink } from 'react-router';
+
+const navItems = [
+  { to: '/dashboard', label: 'Dashboard', icon: LayoutDashboardIcon },
+  { to: '/billing', label: 'Billing', icon: CreditCardIcon },
+];
 
 export const AppSidebar: FC = () => {
   return (
@@ -14,7 +26,25 @@ export const AppSidebar: FC = () => {
         <ProjectSelector />
       </SidebarHeader>
 
-      <SidebarContent>{/* [TODO]... */}</SidebarContent>
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {navItems.map(({ to, label, icon: Icon }) => (
+                <SidebarMenuItem key={to}>
+                  <SidebarMenuButton
+                    tooltip={label}
+                    render={<NavLink to={to} />}
+                  >
+                    <Icon />
+                    <span>{label}</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
 
       <SidebarFooter>{/* [TODO]... */}</SidebarFooter>
     </Sidebar>

--- a/src/frontend/src/components/layout/default-layout.tsx
+++ b/src/frontend/src/components/layout/default-layout.tsx
@@ -1,4 +1,6 @@
+import { AppSidebar } from '@/components/layout/app-sidebar';
 import { Header } from '@/components/layout/header';
+import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
 import { useAppStore } from '@/lib/store';
 import { type FC } from 'react';
 import { Outlet } from 'react-router';
@@ -6,23 +8,37 @@ import { Toaster } from 'sonner';
 import LoadingSpinner from '@/components/loading-spinner';
 
 export const DefaultLayout: FC = () => {
-  const { isProfileInitialized, isProfileLoading } = useAppStore();
+  const { isProfileInitialized, isProfileLoading, isAuthenticated } =
+    useAppStore();
+
+  if (!isProfileInitialized || isProfileLoading) {
+    return (
+      <>
+        <Toaster position="bottom-right" richColors />
+        <LoadingSpinner className="mt-8" message="Initializing..." />
+      </>
+    );
+  }
 
   return (
     <>
       <Toaster position="bottom-right" richColors />
+      <div className="flex flex-col">
+        <Header />
 
-      {!isProfileInitialized || isProfileLoading ? (
-        <LoadingSpinner className="mt-8" message="Initializing..." />
-      ) : (
-        <div className="flex flex-col">
-          <Header />
-
-          <div className="flex flex-1">
+        <div className="flex flex-1">
+          {isAuthenticated ? (
+            <SidebarProvider>
+              <AppSidebar />
+              <SidebarInset>
+                <Outlet />
+              </SidebarInset>
+            </SidebarProvider>
+          ) : (
             <Outlet />
-          </div>
+          )}
         </div>
-      )}
+      </div>
     </>
   );
 };

--- a/src/frontend/src/components/layout/header.tsx
+++ b/src/frontend/src/components/layout/header.tsx
@@ -25,28 +25,6 @@ export const Header: FC = () => {
 
       <NavigationMenu>
         <NavigationMenuList>
-          {isAuthenticated && (
-            <>
-              <NavigationMenuItem>
-                <NavigationMenuLink
-                  className={navigationMenuTriggerStyle()}
-                  render={<NavLink to="/dashboard" />}
-                >
-                  Dashboard
-                </NavigationMenuLink>
-              </NavigationMenuItem>
-
-              <NavigationMenuItem>
-                <NavigationMenuLink
-                  className={navigationMenuTriggerStyle()}
-                  render={<NavLink to="/billing" />}
-                >
-                  Billing
-                </NavigationMenuLink>
-              </NavigationMenuItem>
-            </>
-          )}
-
           <NavigationMenuItem>
             <NavigationMenuLink
               className={navigationMenuTriggerStyle()}

--- a/src/frontend/src/components/layout/project-layout.tsx
+++ b/src/frontend/src/components/layout/project-layout.tsx
@@ -1,18 +1,11 @@
-import { AppSidebar } from '@/components/layout/app-sidebar';
-import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
+import { Container } from '@/components/layout/container';
 import type { FC } from 'react';
 import { Outlet } from 'react-router';
 
 export const ProjectLayout: FC = () => {
   return (
-    <SidebarProvider>
-      <AppSidebar />
-
-      <SidebarInset>
-        <div className="p-3">
-          <Outlet />
-        </div>
-      </SidebarInset>
-    </SidebarProvider>
+    <Container>
+      <Outlet />
+    </Container>
   );
 };

--- a/src/frontend/src/components/layout/project-selector.tsx
+++ b/src/frontend/src/components/layout/project-selector.tsx
@@ -14,7 +14,6 @@ import {
   useSidebar,
 } from '@/components/ui/sidebar';
 import { isNil } from '@/lib/nil';
-import { useRequireProjectId } from '@/lib/params';
 import {
   selectOrgMap,
   selectOrgsWithProjects,
@@ -29,18 +28,22 @@ import {
   Settings,
 } from 'lucide-react';
 import { useMemo, type FC } from 'react';
-import { NavLink } from 'react-router';
+import { NavLink, useParams } from 'react-router';
 
 export const ProjectSelector: FC = () => {
   const { isMobile } = useSidebar();
-  const projectId = useRequireProjectId();
+  const { projectId: projectIdParam } = useParams();
   const orgsWithProjects = useAppStore(selectOrgsWithProjects);
   const projectMap = useAppStore(selectProjectMap);
   const orgMap = useAppStore(selectOrgMap);
+  const projects = useAppStore(s => s.projects);
+
+  const activeProjectId = projectIdParam ?? projects[0]?.id;
 
   const activeProject = useMemo(
-    () => projectMap.get(projectId) ?? null,
-    [projectId, projectMap],
+    () =>
+      isNil(activeProjectId) ? null : (projectMap.get(activeProjectId) ?? null),
+    [activeProjectId, projectMap],
   );
 
   const activeOrganization = useMemo(() => {
@@ -62,6 +65,10 @@ export const ProjectSelector: FC = () => {
 
     return activeOrgWithProjects?.projects ?? [];
   }, [activeOrganization, orgsWithProjects]);
+
+  if (orgsWithProjects.length === 0) {
+    return null;
+  }
 
   return (
     <SidebarMenu>
@@ -167,11 +174,19 @@ export const ProjectSelector: FC = () => {
             </DropdownMenuContent>
           </DropdownMenu>
         ) : (
-          <SidebarMenuButton>
-            <FolderOpen className="size-4" />
+          activeProject && (
+            <SidebarMenuButton
+              render={
+                <NavLink to={`/projects/${activeProject.id}/canisters`} />
+              }
+            >
+              <FolderOpen className="size-4" />
 
-            <span className="truncate text-sm">{activeProject?.name}</span>
-          </SidebarMenuButton>
+              <div className="flex flex-1 flex-col">
+                <span className="truncate text-sm">{activeProject.name}</span>
+              </div>
+            </SidebarMenuButton>
+          )
         )}
       </SidebarMenuItem>
     </SidebarMenu>

--- a/src/frontend/src/routes/canisters/canisters.tsx
+++ b/src/frontend/src/routes/canisters/canisters.tsx
@@ -43,7 +43,6 @@ const Canisters: FC = () => {
   return (
     <>
       <Breadcrumbs
-        className="mb-3"
         items={[
           { label: 'Home', to: '/canisters' },
           ...(organization
@@ -57,7 +56,7 @@ const Canisters: FC = () => {
           { label: project?.name ?? 'Project' },
         ]}
       />
-      <H1>Canisters</H1>
+      <H1 className="mt-3">Canisters</H1>
       {isCanistersLoading || isNil(projectCanisters) ? (
         <CanisterSkeleton className="mt-8" />
       ) : (

--- a/src/frontend/src/routes/organizations/create-organization.tsx
+++ b/src/frontend/src/routes/organizations/create-organization.tsx
@@ -51,7 +51,6 @@ const CreateOrganization: FC = () => {
   return (
     <Container>
       <Breadcrumbs
-        className="mx-auto max-w-md"
         items={[
           { label: 'Home', to: '/canisters' },
           { label: 'New Organization' },

--- a/src/frontend/src/routes/organizations/organization-settings.tsx
+++ b/src/frontend/src/routes/organizations/organization-settings.tsx
@@ -88,15 +88,14 @@ const OrganizationSettings: FC = () => {
 
   return (
     <Container>
-      <div className="space-y-6">
-        <Breadcrumbs
-          className="mx-auto max-w-md"
-          items={[
-            { label: 'Home', to: '/canisters' },
-            { label: organization.name },
-          ]}
-        />
+      <Breadcrumbs
+        items={[
+          { label: 'Home', to: '/canisters' },
+          { label: organization.name },
+        ]}
+      />
 
+      <div className="mt-6 space-y-6">
         <Card className="mx-auto max-w-md">
           <CardHeader>
             <CardTitle>Organization Settings</CardTitle>

--- a/src/frontend/src/routes/organizations/teams/create-team.tsx
+++ b/src/frontend/src/routes/organizations/teams/create-team.tsx
@@ -64,7 +64,6 @@ const CreateTeam: FC = () => {
   return (
     <Container>
       <Breadcrumbs
-        className="mx-auto max-w-md"
         items={[
           { label: 'Home', to: '/canisters' },
           {

--- a/src/frontend/src/routes/organizations/teams/team-list.tsx
+++ b/src/frontend/src/routes/organizations/teams/team-list.tsx
@@ -48,18 +48,18 @@ const TeamList: FC = () => {
 
   return (
     <Container>
-      <div className="mx-auto max-w-md space-y-6">
-        <Breadcrumbs
-          items={[
-            { label: 'Home', to: '/canisters' },
-            {
-              label: organization.name,
-              to: `/organizations/${orgId}/settings`,
-            },
-            { label: 'Teams' },
-          ]}
-        />
+      <Breadcrumbs
+        items={[
+          { label: 'Home', to: '/canisters' },
+          {
+            label: organization.name,
+            to: `/organizations/${orgId}/settings`,
+          },
+          { label: 'Teams' },
+        ]}
+      />
 
+      <div className="mx-auto mt-6 max-w-md space-y-6">
         <Card>
           <CardHeader className="flex flex-row items-center justify-between">
             <CardTitle>Teams in {organization.name}</CardTitle>

--- a/src/frontend/src/routes/organizations/teams/team-settings.tsx
+++ b/src/frontend/src/routes/organizations/teams/team-settings.tsx
@@ -92,20 +92,19 @@ const TeamSettings: FC = () => {
 
   return (
     <Container>
-      <div className="space-y-6">
-        <Breadcrumbs
-          className="mx-auto max-w-md"
-          items={[
-            { label: 'Home', to: '/canisters' },
-            {
-              label: organization?.name ?? 'Organization',
-              to: `/organizations/${orgId}/settings`,
-            },
-            { label: 'Teams', to: `/organizations/${orgId}/teams` },
-            { label: team.name },
-          ]}
-        />
+      <Breadcrumbs
+        items={[
+          { label: 'Home', to: '/canisters' },
+          {
+            label: organization?.name ?? 'Organization',
+            to: `/organizations/${orgId}/settings`,
+          },
+          { label: 'Teams', to: `/organizations/${orgId}/teams` },
+          { label: team.name },
+        ]}
+      />
 
+      <div className="mt-6 space-y-6">
         <Card className="mx-auto max-w-md">
           <CardHeader>
             <CardTitle>Team Settings</CardTitle>


### PR DESCRIPTION
Move the sidebar into DefaultLayout so every authenticated page has it, relocate the Dashboard and Billing placeholders from the header nav into the sidebar, make ProjectSelector tolerant of non-project routes by falling back to the first project, and align breadcrumbs across all pages by dropping width constraints and switching ProjectLayout to Container so canister pages share the same max-w-4xl alignment.