### PR TITLE
fix(frontend): enforce auth guards at the router level

### DIFF
--- a/src/frontend/src/components/layout/admin-route.tsx
+++ b/src/frontend/src/components/layout/admin-route.tsx
@@ -1,0 +1,8 @@
+import { useRequireAdminAuth } from '@/lib/auth';
+import type { FC } from 'react';
+import { Outlet } from 'react-router';
+
+export const AdminRoute: FC = () => {
+  useRequireAdminAuth();
+  return <Outlet />;
+};

--- a/src/frontend/src/components/layout/default-layout.tsx
+++ b/src/frontend/src/components/layout/default-layout.tsx
@@ -1,7 +1,7 @@
 import { AppSidebar } from '@/components/layout/app-sidebar';
 import { Header } from '@/components/layout/header';
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
-import { useAppStore } from '@/lib/store';
+import { selectIsActive, useAppStore } from '@/lib/store';
 import { type FC } from 'react';
 import { Outlet } from 'react-router';
 import { Toaster } from 'sonner';
@@ -10,6 +10,7 @@ import LoadingSpinner from '@/components/loading-spinner';
 export const DefaultLayout: FC = () => {
   const { isProfileInitialized, isProfileLoading, isAuthenticated } =
     useAppStore();
+  const isActive = useAppStore(selectIsActive);
 
   if (!isProfileInitialized || isProfileLoading) {
     return (
@@ -27,7 +28,7 @@ export const DefaultLayout: FC = () => {
         <Header />
 
         <div className="flex flex-1">
-          {isAuthenticated ? (
+          {isAuthenticated && isActive ? (
             <SidebarProvider>
               <AppSidebar />
               <SidebarInset>

--- a/src/frontend/src/components/layout/protected-route.tsx
+++ b/src/frontend/src/components/layout/protected-route.tsx
@@ -1,0 +1,8 @@
+import { useRequireAuth } from '@/lib/auth';
+import type { FC } from 'react';
+import { Outlet } from 'react-router';
+
+export const ProtectedRoute: FC = () => {
+  useRequireAuth();
+  return <Outlet />;
+};

--- a/src/frontend/src/router.tsx
+++ b/src/frontend/src/router.tsx
@@ -1,5 +1,7 @@
+import { AdminRoute } from '@/components/layout/admin-route';
 import { DefaultLayout } from '@/components/layout/default-layout';
 import { ProjectLayout } from '@/components/layout/project-layout';
+import { ProtectedRoute } from '@/components/layout/protected-route';
 import { lazy, type FC } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router';
 
@@ -38,31 +40,39 @@ export const Router: FC = () => (
       <Route element={<DefaultLayout />}>
         <Route index element={<Home />} />
         <Route path="terms-and-conditions" element={<TermsAndConditions />} />
-        <Route path="canisters" element={<RedirectToProjectCanisters />} />
-        <Route path="admin" element={<Admin />} />
-        <Route
-          path="admin/users/:userId/canisters"
-          element={<UserCanisters />}
-        />
         <Route path="verify" element={<Verify />} />
-        <Route path="dashboard" element={<Dashboard />} />
 
-        <Route path="billing" element={<Billing />} />
-        <Route path="organizations/new" element={<CreateOrganization />} />
-        <Route
-          path="organizations/:orgId/settings"
-          element={<OrganizationSettings />}
-        />
-        <Route path="organizations/:orgId/teams" element={<TeamList />} />
-        <Route path="organizations/:orgId/teams/new" element={<CreateTeam />} />
-        <Route
-          path="organizations/:orgId/teams/:teamId/settings"
-          element={<TeamSettings />}
-        />
+        <Route element={<ProtectedRoute />}>
+          <Route path="canisters" element={<RedirectToProjectCanisters />} />
+          <Route path="dashboard" element={<Dashboard />} />
+          <Route path="billing" element={<Billing />} />
+          <Route path="organizations/new" element={<CreateOrganization />} />
+          <Route
+            path="organizations/:orgId/settings"
+            element={<OrganizationSettings />}
+          />
+          <Route path="organizations/:orgId/teams" element={<TeamList />} />
+          <Route
+            path="organizations/:orgId/teams/new"
+            element={<CreateTeam />}
+          />
+          <Route
+            path="organizations/:orgId/teams/:teamId/settings"
+            element={<TeamSettings />}
+          />
 
-        <Route path="projects/:projectId" element={<ProjectLayout />}>
-          <Route path="canisters" element={<Canisters />} />
-          <Route path="canisters/:canisterId" element={<CanisterDetail />} />
+          <Route path="projects/:projectId" element={<ProjectLayout />}>
+            <Route path="canisters" element={<Canisters />} />
+            <Route path="canisters/:canisterId" element={<CanisterDetail />} />
+          </Route>
+        </Route>
+
+        <Route element={<AdminRoute />}>
+          <Route path="admin" element={<Admin />} />
+          <Route
+            path="admin/users/:userId/canisters"
+            element={<UserCanisters />}
+          />
         </Route>
       </Route>
     </Routes>

--- a/src/frontend/src/routes/admin/admin.tsx
+++ b/src/frontend/src/routes/admin/admin.tsx
@@ -1,6 +1,5 @@
 import { H1 } from '@/components/typography/h1';
 import { H2 } from '@/components/typography/h2';
-import { useRequireAdminAuth } from '@/lib/auth';
 import { TrustedPartnerForm } from '@/routes/admin/trusted-partner-form';
 import { TrustedPartnerTable } from '@/routes/admin/trusted-partner-table';
 import { UserTable } from '@/routes/admin/user-table';
@@ -16,8 +15,6 @@ import { TermsAndConditionsForm } from '@/routes/admin/terms-and-conditions-form
 import { Container } from '@/components/layout/container';
 
 const Admin: FC = () => {
-  useRequireAdminAuth();
-
   const { userStats } = useAppStore();
 
   return (

--- a/src/frontend/src/routes/admin/user-canisters.tsx
+++ b/src/frontend/src/routes/admin/user-canisters.tsx
@@ -1,7 +1,6 @@
 import { Container } from '@/components/layout/container';
 import { LoadingSpinner } from '@/components/loading-spinner';
 import { H1 } from '@/components/typography/h1';
-import { useRequireAdminAuth } from '@/lib/auth';
 import { useAppStore } from '@/lib/store';
 import { useCallback, useEffect, useState, type FC } from 'react';
 import { useParams, Link } from 'react-router';
@@ -13,8 +12,6 @@ import { showErrorToast } from '@/lib/toast';
 import { UserCanisterCard } from '@/routes/admin/user-canister-card';
 
 const UserCanisters: FC = () => {
-  useRequireAdminAuth();
-
   const { userId } = useParams<{ userId: string }>();
   const { canisterApi } = useAppStore();
   const [canisters, setCanisters] = useState<Canister[] | null>(null);

--- a/src/frontend/src/routes/billing/billing.tsx
+++ b/src/frontend/src/routes/billing/billing.tsx
@@ -2,12 +2,9 @@ import { Breadcrumbs } from '@/components/breadcrumbs';
 import { Container } from '@/components/layout/container';
 import { H1 } from '@/components/typography/h1';
 import { Card, CardContent } from '@/components/ui/card';
-import { useRequireAuth } from '@/lib/auth';
 import type { FC } from 'react';
 
 const Billing: FC = () => {
-  useRequireAuth();
-
   return (
     <Container>
       <Breadcrumbs

--- a/src/frontend/src/routes/canisters/canister-detail.tsx
+++ b/src/frontend/src/routes/canisters/canister-detail.tsx
@@ -9,7 +9,6 @@ import {
 } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useRequireAuth } from '@/lib/auth';
 import {
   CanisterStatus,
   type CanisterChange,
@@ -310,7 +309,6 @@ const CanisterHistory: FC<CanisterHistoryProps> = ({ canisterPrincipal }) => {
 };
 
 const CanisterDetail: FC = () => {
-  useRequireAuth();
   const {
     isCanistersLoading,
     isCanistersInitialized,

--- a/src/frontend/src/routes/canisters/canisters.tsx
+++ b/src/frontend/src/routes/canisters/canisters.tsx
@@ -1,6 +1,5 @@
 import { H1 } from '@/components/typography/h1';
 import { Breadcrumbs } from '@/components/breadcrumbs';
-import { useRequireAuth } from '@/lib/auth';
 import { selectOrgMap, selectProjectMap, useAppStore } from '@/lib/store';
 import { CanisterGrid } from '@/routes/canisters/canister-grid';
 import { CreateCanisterButton } from '@/routes/canisters/create-canister-button';
@@ -10,7 +9,6 @@ import { isNil } from '@/lib/nil';
 import { useRequireProjectId } from '@/lib/params';
 
 const Canisters: FC = () => {
-  useRequireAuth();
   const { isCanistersLoading, initializeCanisters, canisters } = useAppStore();
   const projectMap = useAppStore(selectProjectMap);
   const orgMap = useAppStore(selectOrgMap);

--- a/src/frontend/src/routes/dashboard/dashboard.tsx
+++ b/src/frontend/src/routes/dashboard/dashboard.tsx
@@ -5,7 +5,6 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Sparkles } from 'lucide-react';
 import { CanisterStatus } from '@/lib/api-models';
-import { useRequireAuth } from '@/lib/auth';
 import { formatBytes, formatCycles } from '@/lib/format';
 import { isNotNil } from '@/lib/nil';
 import { selectOrgsWithProjects, useAppStore } from '@/lib/store';
@@ -22,7 +21,6 @@ const StatRow: FC<StatRowProps> = ({ label, value }) => (
 );
 
 const Dashboard: FC = () => {
-  useRequireAuth();
   const { organizations, projects, teams, canisters, initializeCanisters } =
     useAppStore();
   const orgsWithProjects = useAppStore(selectOrgsWithProjects);

--- a/src/frontend/src/routes/redirect-to-project-canisters/redirect-to-project-canisters.tsx
+++ b/src/frontend/src/routes/redirect-to-project-canisters/redirect-to-project-canisters.tsx
@@ -1,11 +1,9 @@
 import { useEffect, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import { useAppStore } from '@/lib/store';
-import { useRequireAuth } from '@/lib/auth';
 import { isNil, isNotNil } from '@/lib/nil';
 
 const RedirectToCanisters: FC = () => {
-  useRequireAuth();
   const navigate = useNavigate();
   const { projects } = useAppStore();
 


### PR DESCRIPTION
Group protected routes under new ProtectedRoute / AdminRoute layout components in router.tsx so guards can't be forgotten on new routes. Fixes waitlisted users being able to reach organizations/* routes directly. Also hide the sidebar for inactive users in DefaultLayout.