### PR TITLE
feat: detect deleted canisters in canister-history sync

### DIFF
--- a/src/backend/src/service/canister_service.rs
+++ b/src/backend/src/service/canister_service.rs
@@ -14,11 +14,11 @@ use crate::{
     mapping::{map_canister_info, map_canister_response},
 };
 use candid::Principal;
-use canister_utils::{ApiError, ApiResult, Uuid};
+use canister_utils::{call::is_destination_invalid, ApiError, ApiResult, Uuid};
 use futures::future::join_all;
 use ic_cdk::{
     api::canister_self,
-    call::{Error as CallError, RejectCode},
+    call::Error as CallError,
     management_canister::{
         self, CanisterSettings, CanisterStatusArgs, CreateCanisterArgs, UpdateSettingsArgs,
     },
@@ -107,7 +107,7 @@ async fn fetch_canister_state(canister_id: Principal) -> CanisterState {
 // the user can still recover via the missing-controller flow.
 fn classify_canister_status_error(err: CallError) -> CanisterState {
     if let CallError::CallRejected(rejected) = &err {
-        if rejected.reject_code() == Ok(RejectCode::DestinationInvalid) {
+        if is_destination_invalid(rejected) {
             return CanisterState::Deleted;
         }
     }

--- a/src/canister-history-api/canister_history.did
+++ b/src/canister-history-api/canister_history.did
@@ -48,6 +48,7 @@ type ListCanisterChangesRequest = record {
 type ListCanisterChangesResponse = variant {
   Ok : record {
     changes : vec CanisterChange;
+    is_deleted : bool;
     meta : PaginationMetaResponse;
   };
   Err : ApiError;

--- a/src/canister-history-tests/src/tests/canister-history.spec.ts
+++ b/src/canister-history-tests/src/tests/canister-history.spec.ts
@@ -9,6 +9,7 @@ import {
   TestDriver,
 } from '../support';
 import { Principal } from '@icp-sdk/core/principal';
+import { IDL } from '@icp-sdk/core/candid';
 import {
   type _SERVICE as ManagementCanisterService,
   idlFactory as managementCanisterIdlFactory,
@@ -297,6 +298,152 @@ describe('Canister History', () => {
         origin: [{ FromUser: { user_id: controllerIdentity.getPrincipal() } }],
         details: [{ CodeUninstall: {} }],
       });
+    });
+  });
+
+  describe('deleted canisters', () => {
+    async function triggerSyncAndWait(): Promise<void> {
+      driver.actor.setIdentity(controllerIdentity);
+
+      // Wait for any in-progress sync to finish, then trigger a new one
+      for (let i = 0; i < 20; i++) {
+        const res = await driver.actor.trigger_sync_canister_histories({});
+        const ok = extractOkResponse(res);
+        if (ok.message.includes('triggered successfully')) {
+          await driver.pic.tick(10);
+          return;
+        }
+        await driver.pic.tick(5);
+      }
+
+      throw new Error('Could not trigger a sync — previous one never finished');
+    }
+
+    async function createAndSyncCanister(): Promise<Principal> {
+      driver.actor.setIdentity(controllerIdentity);
+
+      const canisterId = await driver.pic.createCanister({
+        sender: controllerIdentity.getPrincipal(),
+      });
+
+      // Set a narrow range covering only the canister-history canister
+      // and the newly created canister to keep sync fast.
+      await driver.actor.update_subnet_canister_ranges({
+        canister_ranges: [[driver.canisterId, canisterId]],
+      });
+
+      // The init timer fires a sync at t=0. Advance time so it triggers,
+      // then wait for it to fully complete before proceeding.
+      await driver.pic.advanceTime(minutesToMilliseconds(5));
+      await driver.pic.tick(10);
+
+      return canisterId;
+    }
+
+    async function deleteCanisterOnChain(canisterId: Principal): Promise<void> {
+      await driver.pic.stopCanister({
+        canisterId,
+        sender: controllerIdentity.getPrincipal(),
+      });
+
+      const DeleteCanisterArgs = IDL.Record({ canister_id: IDL.Principal });
+      await driver.pic.updateCall({
+        canisterId: Principal.managementCanister(),
+        method: 'delete_canister',
+        arg: new Uint8Array(
+          IDL.encode([DeleteCanisterArgs], [{ canister_id: canisterId }]),
+        ),
+        sender: controllerIdentity.getPrincipal(),
+      });
+    }
+
+    it('should mark a canister as deleted after sync', async () => {
+      const canisterId = await createAndSyncCanister();
+
+      // Verify is_deleted is false before deletion
+      const beforeRes = await driver.actor.list_canister_changes({
+        canister_id: canisterId,
+        limit: [],
+        page: [],
+        reverse: [],
+      });
+      const before = extractOkResponse(beforeRes);
+      expect(before.is_deleted).toBe(false);
+      expect(before.changes).toHaveLength(1);
+
+      // Delete the canister on-chain, then re-sync
+      await deleteCanisterOnChain(canisterId);
+      await triggerSyncAndWait();
+
+      // Verify is_deleted is now true
+      const afterRes = await driver.actor.list_canister_changes({
+        canister_id: canisterId,
+        limit: [],
+        page: [],
+        reverse: [],
+      });
+      const after = extractOkResponse(afterRes);
+      expect(after.is_deleted).toBe(true);
+      expect(after.changes).toHaveLength(1);
+    });
+
+    it('should not mark unknown canisters as deleted', async () => {
+      driver.actor.setIdentity(controllerIdentity);
+
+      // Create and immediately delete a canister without syncing first
+      const canisterId = await driver.pic.createCanister({
+        sender: controllerIdentity.getPrincipal(),
+      });
+
+      // Set range covering this canister
+      await driver.actor.update_subnet_canister_ranges({
+        canister_ranges: [[driver.canisterId, canisterId]],
+      });
+
+      await deleteCanisterOnChain(canisterId);
+
+      // Wait for init sync, then trigger a fresh sync
+      await driver.pic.advanceTime(minutesToMilliseconds(5));
+      await driver.pic.tick(10);
+      await triggerSyncAndWait();
+
+      const res = await driver.actor.list_canister_changes({
+        canister_id: canisterId,
+        limit: [],
+        page: [],
+        reverse: [],
+      });
+      const result = extractOkResponse(res);
+      expect(result.is_deleted).toBe(false);
+      expect(result.changes).toHaveLength(0);
+    });
+
+    it('should skip already-deleted canisters on subsequent syncs', async () => {
+      const canisterId = await createAndSyncCanister();
+
+      await deleteCanisterOnChain(canisterId);
+
+      // First sync marks as deleted
+      await triggerSyncAndWait();
+
+      const firstRes = await driver.actor.list_canister_changes({
+        canister_id: canisterId,
+        limit: [],
+        page: [],
+        reverse: [],
+      });
+      expect(extractOkResponse(firstRes).is_deleted).toBe(true);
+
+      // Second sync should succeed without errors (skips deleted)
+      await triggerSyncAndWait();
+
+      const secondRes = await driver.actor.list_canister_changes({
+        canister_id: canisterId,
+        limit: [],
+        page: [],
+        reverse: [],
+      });
+      expect(extractOkResponse(secondRes).is_deleted).toBe(true);
     });
   });
 });

--- a/src/canister-history/src/dto.rs
+++ b/src/canister-history/src/dto.rs
@@ -48,6 +48,7 @@ pub struct ListCanisterChangesRequest {
 #[derive(Debug, Clone, CandidType, Deserialize)]
 pub struct ListCanisterChangesResponse {
     pub changes: Vec<CanisterChange>,
+    pub is_deleted: bool,
     pub meta: PaginationMetaResponse,
 }
 

--- a/src/canister-history/src/service.rs
+++ b/src/canister-history/src/service.rs
@@ -76,8 +76,13 @@ pub fn list_canister_changes(req: ListCanisterChangesRequest) -> ListCanisterCha
         .map(map_canister_change_response)
         .collect::<Vec<_>>();
 
+    let is_deleted = repository::get_canister_change_info(req.canister_id)
+        .map(|info| info.is_deleted)
+        .unwrap_or(false);
+
     ListCanisterChangesResponse {
         changes,
+        is_deleted,
         meta: PaginationMetaResponse {
             limit,
             page,

--- a/src/canister-history/src/service.rs
+++ b/src/canister-history/src/service.rs
@@ -141,13 +141,14 @@ pub async fn sync_canister_histories() -> ApiResult {
 /// previously stored changes, and inserts any new changes into the repository.
 /// It also handles cases where changes may have been missed due to truncation.
 async fn process_canister_changes(canister_id: Principal) -> ApiResult {
-    let mut stored_canister_info = repository::get_canister_change_info(canister_id)
-        .unwrap_or_else(|| CanisterChangeInfo {
-            total_num_changes: 0,
-            stored_num_changes: 0,
-            missed_ranges: vec![],
-            is_deleted: false,
-        });
+    let existing = repository::get_canister_change_info(canister_id);
+
+    let mut stored_canister_info = existing.clone().unwrap_or_else(|| CanisterChangeInfo {
+        total_num_changes: 0,
+        stored_num_changes: 0,
+        missed_ranges: vec![],
+        is_deleted: false,
+    });
 
     if stored_canister_info.is_deleted {
         return Ok(());
@@ -156,8 +157,10 @@ async fn process_canister_changes(canister_id: Principal) -> ApiResult {
     let canister_info = match get_canister_info(canister_id).await {
         Ok(info) => info,
         Err(GetCanisterInfoError::CanisterDeleted) => {
-            stored_canister_info.is_deleted = true;
-            repository::upsert_canister_change_info(canister_id, stored_canister_info);
+            if existing.is_some() {
+                stored_canister_info.is_deleted = true;
+                repository::upsert_canister_change_info(canister_id, stored_canister_info);
+            }
             return Ok(());
         }
         Err(GetCanisterInfoError::Other(err)) => return Err(err),

--- a/src/canister-history/src/service.rs
+++ b/src/canister-history/src/service.rs
@@ -13,10 +13,10 @@ use crate::model::CanisterChangeInfo;
 use crate::repository;
 use crate::{canister_id::CanisterIdRange, mapping::map_management_canister_change_response};
 use candid::Principal;
-use canister_utils::{ApiError, ApiResult};
+use canister_utils::{call::is_destination_invalid, ApiError, ApiResult};
 use futures::future::join_all;
 use ic_cdk::{
-    call::Call,
+    call::{Call, CallFailed},
     management_canister::{CanisterInfoArgs, CanisterInfoResult},
 };
 
@@ -141,9 +141,6 @@ pub async fn sync_canister_histories() -> ApiResult {
 /// previously stored changes, and inserts any new changes into the repository.
 /// It also handles cases where changes may have been missed due to truncation.
 async fn process_canister_changes(canister_id: Principal) -> ApiResult {
-    // [TODO]: Detect deleted canisters
-    let canister_info = get_canister_info(canister_id).await?;
-
     let mut stored_canister_info = repository::get_canister_change_info(canister_id)
         .unwrap_or_else(|| CanisterChangeInfo {
             total_num_changes: 0,
@@ -155,6 +152,16 @@ async fn process_canister_changes(canister_id: Principal) -> ApiResult {
     if stored_canister_info.is_deleted {
         return Ok(());
     }
+
+    let canister_info = match get_canister_info(canister_id).await {
+        Ok(info) => info,
+        Err(GetCanisterInfoError::CanisterDeleted) => {
+            stored_canister_info.is_deleted = true;
+            repository::upsert_canister_change_info(canister_id, stored_canister_info);
+            return Ok(());
+        }
+        Err(GetCanisterInfoError::Other(err)) => return Err(err),
+    };
 
     // The starting index is the total number of changes ever, less than the
     // number of changes returned in this call
@@ -190,7 +197,14 @@ async fn process_canister_changes(canister_id: Principal) -> ApiResult {
     Ok(())
 }
 
-async fn get_canister_info(canister_id: Principal) -> ApiResult<CanisterInfoResult> {
+enum GetCanisterInfoError {
+    CanisterDeleted,
+    Other(ApiError),
+}
+
+async fn get_canister_info(
+    canister_id: Principal,
+) -> Result<CanisterInfoResult, GetCanisterInfoError> {
     Call::bounded_wait(Principal::management_canister(), "canister_info")
         .with_arg(&CanisterInfoArgs {
             canister_id,
@@ -198,14 +212,19 @@ async fn get_canister_info(canister_id: Principal) -> ApiResult<CanisterInfoResu
         })
         .await
         .map_err(|err| {
-            ApiError::dependency_error(format!(
+            if let CallFailed::CallRejected(rejected) = &err {
+                if is_destination_invalid(rejected) {
+                    return GetCanisterInfoError::CanisterDeleted;
+                }
+            }
+            GetCanisterInfoError::Other(ApiError::dependency_error(format!(
                 "Failed to call the `canister_info` management canister endpoint: {err}"
-            ))
+            )))
         })?
         .candid::<CanisterInfoResult>()
         .map_err(|err| {
-            ApiError::dependency_error(format!(
+            GetCanisterInfoError::Other(ApiError::dependency_error(format!(
                 "Failed to decode the candid response from the `canister_info` management canister endpoint: {err}"
-            ))
+            )))
         })
 }

--- a/src/canister-utils/src/call.rs
+++ b/src/canister-utils/src/call.rs
@@ -1,0 +1,5 @@
+use ic_cdk::call::{CallRejected, RejectCode};
+
+pub fn is_destination_invalid(rejected: &CallRejected) -> bool {
+    rejected.reject_code() == Ok(RejectCode::DestinationInvalid)
+}

--- a/src/canister-utils/src/lib.rs
+++ b/src/canister-utils/src/lib.rs
@@ -1,4 +1,5 @@
 mod auth;
+pub mod call;
 mod cbor;
 mod error;
 mod principal;

--- a/src/frontend/src/lib/api-models/canister-history.ts
+++ b/src/frontend/src/lib/api-models/canister-history.ts
@@ -30,6 +30,7 @@ export type CanisterChange = {
 
 export type ListCanisterChangesResponse = {
   changes: CanisterChange[];
+  isDeleted: boolean;
   totalPages: bigint;
 };
 
@@ -106,6 +107,7 @@ export function mapListCanisterChangesResponse(
   }
   return {
     changes: res.Ok.changes.map(mapCanisterChange),
+    isDeleted: res.Ok.is_deleted,
     totalPages: res.Ok.meta.total_pages,
   };
 }

--- a/src/frontend/src/routes/canisters/canister-detail.tsx
+++ b/src/frontend/src/routes/canisters/canister-detail.tsx
@@ -54,7 +54,7 @@ const StatRow: FC<StatRowProps> = ({ label, value }) => (
 );
 
 type SectionCardProps = {
-  title: string;
+  title: React.ReactNode;
   children: React.ReactNode;
   footer?: React.ReactNode;
 };
@@ -269,16 +269,27 @@ type CanisterHistoryProps = { canisterPrincipal: string };
 const CanisterHistory: FC<CanisterHistoryProps> = ({ canisterPrincipal }) => {
   const { canisterHistoryApi } = useAppStore();
   const [changes, setChanges] = useState<CanisterChange[] | null>(null);
+  const [isDeleted, setIsDeleted] = useState(false);
 
   useEffect(() => {
     canisterHistoryApi
       .listCanisterChanges(canisterPrincipal)
-      .then(res => setChanges(res.changes))
+      .then(res => {
+        setChanges(res.changes);
+        setIsDeleted(res.isDeleted);
+      })
       .catch(() => setChanges([]));
   }, [canisterPrincipal]);
 
   return (
-    <SectionCard title="History">
+    <SectionCard
+      title={
+        <div className="flex items-center gap-2">
+          History
+          {isDeleted && <Badge variant="destructive">Deleted</Badge>}
+        </div>
+      }
+    >
       {changes === null ? (
         <p className="text-muted-foreground text-xs">Loading...</p>
       ) : changes.length === 0 ? (


### PR DESCRIPTION
When canister_info returns a DestinationInvalid reject code, mark the canister as deleted and stop syncing its history. Extract the is_destination_invalid check into canister-utils so both backend and canister-history share the same logic.