### PR TITLE
feat: gate services on OrgAuth/ProjectAuth capability tokens

### DIFF
--- a/src/backend-tests/src/support/error.ts
+++ b/src/backend-tests/src/support/error.ts
@@ -55,14 +55,29 @@ export const latestTermsAndConditionsError = {
   },
 };
 
-export function notOwnedProjectError(
-  userId: string,
+// Generic "project not found or no access" error. Returned whenever the
+// caller is not allowed to learn whether a project id exists or which org
+// it belongs to. Non-existent project ids and projects in orgs the caller
+// can't see must share this exact error to prevent probing.
+export function projectNotFoundOrNoAccessError(
   projectId: string,
 ): ApiErrorResponse {
   return {
     Err: {
-      code: [{ Unauthorized: {} }],
-      message: `User with id ${userId} does not have access to project with id ${projectId}`,
+      code: [{ ClientError: {} }],
+      message: `Project with id ${projectId} does not exist or you do not have access.`,
+    },
+  };
+}
+
+// Generic "team not found or no access" error. Same pattern as the project
+// variant above: collapses "non-existent team" and "team in another org"
+// into a single response.
+export function teamNotFoundOrNoAccessError(teamId: string): ApiErrorResponse {
+  return {
+    Err: {
+      code: [{ ClientError: {} }],
+      message: `Team with id ${teamId} does not exist or you do not have access.`,
     },
   };
 }
@@ -99,6 +114,40 @@ export function noOrgError(userId: string, orgId: string): ApiErrorResponse {
     Err: {
       code: [{ Unauthorized: {} }],
       message: `User with id ${userId} does not belong to org with id ${orgId}`,
+    },
+  };
+}
+
+// Returned when the caller is an org member but the aggregate of their team
+// permissions does not include a required bit (e.g. TEAM_MANAGE,
+// MEMBER_MANAGE). `permissions` must match the Display formatting of the
+// required OrgPermissions value, e.g. "TEAM_MANAGE" or
+// "MEMBER_MANAGE | TEAM_MANAGE".
+export function lacksOrgPermissionError(
+  userId: string,
+  orgId: string,
+  permissions: string,
+): ApiErrorResponse {
+  return {
+    Err: {
+      code: [{ Unauthorized: {} }],
+      message: `User with id ${userId} lacks required permissions on org with id ${orgId}: ${permissions}`,
+    },
+  };
+}
+
+// Returned when the caller is an org member but none of the teams they
+// belong to are linked to the project. Distinct from
+// `projectNotFoundOrNoAccessError` — the project exists and is in the
+// caller's org, but they have no team link granting access.
+export function noProjectTeamLinkError(
+  userId: string,
+  projectId: string,
+): ApiErrorResponse {
+  return {
+    Err: {
+      code: [{ Unauthorized: {} }],
+      message: `User with id ${userId} does not have access to project with id ${projectId}`,
     },
   };
 }

--- a/src/backend-tests/src/tests/canister.spec.ts
+++ b/src/backend-tests/src/tests/canister.spec.ts
@@ -7,7 +7,7 @@ import {
   inactiveUserError,
   latestTermsAndConditionsError,
   noProfileError,
-  notOwnedProjectError,
+  projectNotFoundOrNoAccessError,
   TestDriver,
   unauthenticatedError,
 } from '../support';
@@ -217,7 +217,7 @@ describe('Canisters', () => {
     });
 
     it('should return an error for a project the user does not have access to', async () => {
-      const [aliceIdentity, aliceProfile] = await driver.users.createUser();
+      const [aliceIdentity] = await driver.users.createUser();
 
       const bobIdentity = generateRandomIdentity();
       driver.actor.setIdentity(bobIdentity);
@@ -229,18 +229,20 @@ describe('Canisters', () => {
         project_id: bobProject.id,
         operation: [{ CreateCanister: {} }],
       });
-      expect(res).toEqual(notOwnedProjectError(aliceProfile.id, bobProject.id));
+      // Same error as "project does not exist" below: cross-org access and
+      // non-existent ids must be indistinguishable.
+      expect(res).toEqual(projectNotFoundOrNoAccessError(bobProject.id));
     });
 
     it('should return an error for a project that does not exist', async () => {
-      const [aliceIdentity, aliceProfile] = await driver.users.createUser();
+      const [aliceIdentity] = await driver.users.createUser();
       driver.actor.setIdentity(aliceIdentity);
 
       const res = await driver.actor.create_proposal({
         project_id: projectId,
         operation: [{ CreateCanister: {} }],
       });
-      expect(res).toEqual(notOwnedProjectError(aliceProfile.id, projectId));
+      expect(res).toEqual(projectNotFoundOrNoAccessError(projectId));
     });
 
     it('should create a canister for a valid user', async () => {
@@ -394,7 +396,7 @@ describe('Canisters', () => {
     });
 
     it('should return an error for a project the user does not have access to', async () => {
-      const [aliceIdentity, aliceProfile] = await driver.users.createUser();
+      const [aliceIdentity] = await driver.users.createUser();
 
       const bobIdentity = generateRandomIdentity();
       driver.actor.setIdentity(bobIdentity);
@@ -413,11 +415,12 @@ describe('Canisters', () => {
           },
         ],
       });
-      expect(res).toEqual(notOwnedProjectError(aliceProfile.id, bobProject.id));
+      // Same error as "project does not exist" below.
+      expect(res).toEqual(projectNotFoundOrNoAccessError(bobProject.id));
     });
 
     it('should return an error for a project that does not exist', async () => {
-      const [aliceIdentity, aliceProfile] = await driver.users.createUser();
+      const [aliceIdentity] = await driver.users.createUser();
       driver.actor.setIdentity(aliceIdentity);
 
       const res = await driver.actor.create_proposal({
@@ -431,7 +434,7 @@ describe('Canisters', () => {
           },
         ],
       });
-      expect(res).toEqual(notOwnedProjectError(aliceProfile.id, projectId));
+      expect(res).toEqual(projectNotFoundOrNoAccessError(projectId));
     });
 
     it('should return an error for a canister that does not exist', async () => {

--- a/src/backend-tests/src/tests/invite.spec.ts
+++ b/src/backend-tests/src/tests/invite.spec.ts
@@ -374,7 +374,8 @@ describe('Org Invites', () => {
       expect(res).toEqual({
         Err: {
           code: [{ Unauthorized: {} }],
-          message: 'Only the inviter can revoke this invite.',
+          message:
+            'Only the inviter or a member manager can revoke this invite.',
         },
       });
     });

--- a/src/backend-tests/src/tests/project.spec.ts
+++ b/src/backend-tests/src/tests/project.spec.ts
@@ -5,6 +5,9 @@ import {
   extractOkResponse,
   noOrgError,
   noProfileError,
+  noProjectTeamLinkError,
+  projectNotFoundOrNoAccessError,
+  teamNotFoundOrNoAccessError,
   TestDriver,
   unauthenticatedError,
 } from '../support';
@@ -233,7 +236,7 @@ describe('Projects', () => {
     it('should return an error for a non-existent project', async () => {
       await setupUser();
       const res = await driver.actor.get_project({ project_id: fakeOrgId });
-      expect('Err' in res && res.Err.message).toContain('does not exist');
+      expect(res).toEqual(projectNotFoundOrNoAccessError(fakeOrgId));
     });
 
     it('should return an error if the caller is not in the org', async () => {
@@ -245,9 +248,11 @@ describe('Projects', () => {
         }),
       );
 
-      const bob = await setupUser();
+      await setupUser();
       const res = await driver.actor.get_project({ project_id: project.id });
-      expect(res).toEqual(noOrgError(bob.profile.id, alice.org.id));
+      // Same error as "non-existent project" above: cross-org access must
+      // not be distinguishable from a missing id.
+      expect(res).toEqual(projectNotFoundOrNoAccessError(project.id));
     });
 
     it('should get a project', async () => {
@@ -285,7 +290,7 @@ describe('Projects', () => {
         project_id: fakeOrgId,
         name: 'x',
       });
-      expect('Err' in res && res.Err.message).toContain('does not exist');
+      expect(res).toEqual(projectNotFoundOrNoAccessError(fakeOrgId));
     });
 
     it('should return an error if the caller is not in the org', async () => {
@@ -297,12 +302,12 @@ describe('Projects', () => {
         }),
       );
 
-      const bob = await setupUser();
+      await setupUser();
       const res = await driver.actor.update_project({
         project_id: project.id,
         name: 'hijack',
       });
-      expect(res).toEqual(noOrgError(bob.profile.id, alice.org.id));
+      expect(res).toEqual(projectNotFoundOrNoAccessError(project.id));
     });
 
     it('should return an error for an empty name', async () => {
@@ -352,7 +357,7 @@ describe('Projects', () => {
     it('should return an error for a non-existent project', async () => {
       await setupUser();
       const res = await driver.actor.delete_project({ project_id: fakeOrgId });
-      expect('Err' in res && res.Err.message).toContain('does not exist');
+      expect(res).toEqual(projectNotFoundOrNoAccessError(fakeOrgId));
     });
 
     it('should return an error if the caller is not in the org', async () => {
@@ -364,11 +369,11 @@ describe('Projects', () => {
         }),
       );
 
-      const bob = await setupUser();
+      await setupUser();
       const res = await driver.actor.delete_project({
         project_id: project.id,
       });
-      expect(res).toEqual(noOrgError(bob.profile.id, alice.org.id));
+      expect(res).toEqual(projectNotFoundOrNoAccessError(project.id));
     });
 
     it('should return an error when deleting the last project', async () => {
@@ -445,11 +450,11 @@ describe('Projects', () => {
         }),
       );
 
-      const bob = await setupUser();
+      await setupUser();
       const res = await driver.actor.list_project_teams({
         project_id: project.id,
       });
-      expect(res).toEqual(noOrgError(bob.profile.id, alice.org.id));
+      expect(res).toEqual(projectNotFoundOrNoAccessError(project.id));
     });
 
     it('should list teams attached to a project', async () => {
@@ -484,7 +489,7 @@ describe('Projects', () => {
         project_id: fakeOrgId,
         team_id: fakeOrgId,
       });
-      expect('Err' in res && res.Err.message).toContain('Project with id');
+      expect(res).toEqual(projectNotFoundOrNoAccessError(fakeOrgId));
     });
 
     it('should return an error for a non-existent team', async () => {
@@ -500,7 +505,7 @@ describe('Projects', () => {
         project_id: project.id,
         team_id: fakeOrgId,
       });
-      expect('Err' in res && res.Err.message).toContain('Team with id');
+      expect(res).toEqual(teamNotFoundOrNoAccessError(fakeOrgId));
     });
 
     it('should return an error when the team is in another org', async () => {
@@ -523,7 +528,9 @@ describe('Projects', () => {
         project_id: project.id,
         team_id: bobTeam!.id,
       });
-      expect('Err' in res && res.Err.message).toContain('same organization');
+      // Same error as "non-existent team" above: a project admin must not
+      // be able to probe team ids across orgs.
+      expect(res).toEqual(teamNotFoundOrNoAccessError(bobTeam!.id));
     });
 
     it('should attach a team to a project', async () => {
@@ -650,6 +657,104 @@ describe('Projects', () => {
         team_id: team.id,
       });
       expect(res).toEqual({ Ok: {} });
+    });
+  });
+
+  // An org member whose teams have no link to a given project must be denied
+  // on every project-scoped endpoint, even though they can see the org. This
+  // exercises the `has_link = false` branch of ProjectAuth inside the same
+  // org, which is distinct from the cross-org deny path covered elsewhere.
+  // All deny assertions share one PocketIC instance.
+  describe('permission enforcement for in-org member with unlinked team', () => {
+    it('should deny project-scoped ops when the caller has no team link', async () => {
+      const alice = await setupUser();
+      const defaultProject = await driver.getDefaultProject();
+
+      // Alice creates a second team, Team B. New teams have no project links
+      // until explicitly attached via add_team_to_project.
+      const createTeamRes = await driver.actor.create_team({
+        org_id: alice.org.id,
+        name: 'Team B',
+      });
+      const { team: teamB } = extractOkResponse(createTeamRes);
+
+      // Bob signs up (lands in his own default org), then Alice invites him
+      // into her org. Bob accepts, then Alice places him on Team B ONLY,
+      // never on the default team that owns defaultProject.
+      const bob = await setupUser();
+      driver.actor.setIdentity(alice.identity);
+      const inviteRes = await driver.actor.create_org_invite({
+        org_id: alice.org.id,
+        target: { UserId: bob.profile.id },
+      });
+      const { invite } = extractOkResponse(inviteRes);
+      driver.actor.setIdentity(bob.identity);
+      await driver.actor.accept_org_invite({ invite_id: invite.id });
+      driver.actor.setIdentity(alice.identity);
+      await driver.actor.add_user_to_team({
+        team_id: teamB.id,
+        user_id: bob.profile.id,
+      });
+
+      // Bob acts. He is in alice.org, so org-scoped reads succeed.
+      driver.actor.setIdentity(bob.identity);
+
+      const myProjects = await driver.actor.list_my_projects({});
+      expect(extractOkResponse(myProjects).projects).toEqual([]);
+
+      const orgProjects = await driver.actor.list_org_projects({
+        org_id: alice.org.id,
+      });
+      const { projects } = extractOkResponse(orgProjects);
+      expect(projects.map(p => p.id)).toContain(defaultProject.id);
+
+      // Project-scoped endpoints must all deny — Bob's only team (Team B) is
+      // not linked to defaultProject, so ProjectAuth::require fails at the
+      // has_link check with the "does not have access" unauthorized error.
+      const getRes = await driver.actor.get_project({
+        project_id: defaultProject.id,
+      });
+      expect(getRes).toEqual(
+        noProjectTeamLinkError(bob.profile.id, defaultProject.id),
+      );
+
+      const updateRes = await driver.actor.update_project({
+        project_id: defaultProject.id,
+        name: 'Hijacked',
+      });
+      expect(updateRes).toEqual(
+        noProjectTeamLinkError(bob.profile.id, defaultProject.id),
+      );
+
+      const deleteRes = await driver.actor.delete_project({
+        project_id: defaultProject.id,
+      });
+      expect(deleteRes).toEqual(
+        noProjectTeamLinkError(bob.profile.id, defaultProject.id),
+      );
+
+      const listTeamsRes = await driver.actor.list_project_teams({
+        project_id: defaultProject.id,
+      });
+      expect(listTeamsRes).toEqual(
+        noProjectTeamLinkError(bob.profile.id, defaultProject.id),
+      );
+
+      const addTeamRes = await driver.actor.add_team_to_project({
+        project_id: defaultProject.id,
+        team_id: teamB.id,
+      });
+      expect(addTeamRes).toEqual(
+        noProjectTeamLinkError(bob.profile.id, defaultProject.id),
+      );
+
+      const removeTeamRes = await driver.actor.remove_team_from_project({
+        project_id: defaultProject.id,
+        team_id: teamB.id,
+      });
+      expect(removeTeamRes).toEqual(
+        noProjectTeamLinkError(bob.profile.id, defaultProject.id),
+      );
     });
   });
 });

--- a/src/backend-tests/src/tests/project.spec.ts
+++ b/src/backend-tests/src/tests/project.spec.ts
@@ -699,8 +699,14 @@ describe('Projects', () => {
       // Bob acts. He is in alice.org, so org-scoped reads succeed.
       driver.actor.setIdentity(bob.identity);
 
+      // Bob still has his own signup-created default project (in his own
+      // org) — list_my_projects is team-scoped, not org-scoped — but
+      // Alice's defaultProject must not appear since his only team in her
+      // org (Team B) has no link to it.
       const myProjects = await driver.actor.list_my_projects({});
-      expect(extractOkResponse(myProjects).projects).toEqual([]);
+      expect(
+        extractOkResponse(myProjects).projects.map(p => p.id),
+      ).not.toContain(defaultProject.id);
 
       const orgProjects = await driver.actor.list_org_projects({
         org_id: alice.org.id,

--- a/src/backend-tests/src/tests/team.spec.ts
+++ b/src/backend-tests/src/tests/team.spec.ts
@@ -2,8 +2,10 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   anonymousIdentity,
   extractOkResponse,
+  lacksOrgPermissionError,
   noOrgError,
   noProfileError,
+  teamNotFoundOrNoAccessError,
   TestDriver,
   unauthenticatedError,
 } from '../support';
@@ -215,12 +217,7 @@ describe('Teams', () => {
     it('should return an error for a non-existent team', async () => {
       await setupUser();
       const res = await driver.actor.get_team({ team_id: fakeTeamId });
-      expect(res).toEqual({
-        Err: {
-          code: [{ ClientError: {} }],
-          message: `Team with id ${fakeTeamId} does not exist.`,
-        },
-      });
+      expect(res).toEqual(teamNotFoundOrNoAccessError(fakeTeamId));
     });
 
     it('should return an error if the user is not in the org', async () => {
@@ -230,11 +227,13 @@ describe('Teams', () => {
       });
       const [aliceDefaultTeam] = extractOkResponse(aliceTeamsRes);
 
-      const bob = await setupUser();
+      await setupUser();
       const getRes = await driver.actor.get_team({
         team_id: aliceDefaultTeam!.id,
       });
-      expect(getRes).toEqual(noOrgError(bob.profile.id, alice.org!.id));
+      // Same error as "non-existent team" above: cross-org access must not
+      // be distinguishable from a missing id.
+      expect(getRes).toEqual(teamNotFoundOrNoAccessError(aliceDefaultTeam!.id));
     });
 
     it('should get a team', async () => {
@@ -266,12 +265,7 @@ describe('Teams', () => {
         team_id: fakeTeamId,
         name: 'New Name',
       });
-      expect(res).toEqual({
-        Err: {
-          code: [{ ClientError: {} }],
-          message: `Team with id ${fakeTeamId} does not exist.`,
-        },
-      });
+      expect(res).toEqual(teamNotFoundOrNoAccessError(fakeTeamId));
     });
 
     it('should return an error if the user is not in the org', async () => {
@@ -281,12 +275,12 @@ describe('Teams', () => {
       });
       const [aliceDefaultTeam] = extractOkResponse(aliceTeamsRes);
 
-      const bob = await setupUser();
+      await setupUser();
       const res = await driver.actor.update_team({
         team_id: aliceDefaultTeam!.id,
         name: 'Hijacked',
       });
-      expect(res).toEqual(noOrgError(bob.profile.id, alice.org!.id));
+      expect(res).toEqual(teamNotFoundOrNoAccessError(aliceDefaultTeam!.id));
     });
 
     it('should return an error for an empty name', async () => {
@@ -358,12 +352,7 @@ describe('Teams', () => {
     it('should return an error for a non-existent team', async () => {
       await setupUser();
       const res = await driver.actor.delete_team({ team_id: fakeTeamId });
-      expect(res).toEqual({
-        Err: {
-          code: [{ ClientError: {} }],
-          message: `Team with id ${fakeTeamId} does not exist.`,
-        },
-      });
+      expect(res).toEqual(teamNotFoundOrNoAccessError(fakeTeamId));
     });
 
     it('should return an error if the user is not in the org', async () => {
@@ -374,9 +363,9 @@ describe('Teams', () => {
       });
       const { team } = extractOkResponse(createRes);
 
-      const bob = await setupUser();
+      await setupUser();
       const res = await driver.actor.delete_team({ team_id: team.id });
-      expect(res).toEqual(noOrgError(bob.profile.id, alice.org!.id));
+      expect(res).toEqual(teamNotFoundOrNoAccessError(team.id));
     });
 
     it('should return an error when deleting the last team', async () => {
@@ -446,12 +435,7 @@ describe('Teams', () => {
         team_id: fakeTeamId,
         user_id: profile.id,
       });
-      expect(res).toEqual({
-        Err: {
-          code: [{ ClientError: {} }],
-          message: `Team with id ${fakeTeamId} does not exist.`,
-        },
-      });
+      expect(res).toEqual(teamNotFoundOrNoAccessError(fakeTeamId));
     });
 
     it('should return an error if the caller is not in the org', async () => {
@@ -466,7 +450,7 @@ describe('Teams', () => {
         team_id: aliceDefaultTeam!.id,
         user_id: bob.profile.id,
       });
-      expect(res).toEqual(noOrgError(bob.profile.id, alice.org!.id));
+      expect(res).toEqual(teamNotFoundOrNoAccessError(aliceDefaultTeam!.id));
     });
 
     it('should return an error if the target user is not in the org', async () => {
@@ -560,11 +544,11 @@ describe('Teams', () => {
       });
       const [defaultTeam] = extractOkResponse(teamsRes);
 
-      const bob = await setupUser();
+      await setupUser();
       const res = await driver.actor.list_team_users({
         team_id: defaultTeam!.id,
       });
-      expect(res).toEqual(noOrgError(bob.profile.id, alice.org!.id));
+      expect(res).toEqual(teamNotFoundOrNoAccessError(defaultTeam!.id));
     });
 
     it('should be idempotent when adding an existing member', async () => {
@@ -578,6 +562,84 @@ describe('Teams', () => {
         user_id: profile.id,
       });
       expect(res).toEqual({ Ok: {} });
+    });
+  });
+
+  // An org member who is not in any team has an aggregate of OrgPermissions
+  // EMPTY, so every bit-gated op must be denied with the "lacks required
+  // permissions" error. Read-only ops that require only org membership
+  // (OrgPermissions::EMPTY) must still succeed. Bundled into a single
+  // PocketIC instance to keep test setup cost down.
+  describe('permission enforcement for in-org member with no team', () => {
+    it('should allow membership-only reads and reject bit-gated ops', async () => {
+      const alice = await setupUser();
+      const aliceTeamsRes = await driver.actor.list_org_teams({
+        org_id: alice.org!.id,
+      });
+      const [defaultTeam] = extractOkResponse(aliceTeamsRes);
+
+      // Bob signs up (gets his own default org), then Alice invites him into
+      // her org. After accept_org_invite Bob is a member of Alice's org but
+      // is in NO team → aggregate OrgPermissions = EMPTY.
+      const bob = await setupUser();
+      driver.actor.setIdentity(alice.identity);
+      const inviteRes = await driver.actor.create_org_invite({
+        org_id: alice.org!.id,
+        target: { UserId: bob.profile.id },
+      });
+      const { invite } = extractOkResponse(inviteRes);
+      driver.actor.setIdentity(bob.identity);
+      await driver.actor.accept_org_invite({ invite_id: invite.id });
+
+      // Read-only endpoints require only org membership (EMPTY) — allow.
+      const listTeamsRes = await driver.actor.list_org_teams({
+        org_id: alice.org!.id,
+      });
+      expect(extractOkResponse(listTeamsRes)).toHaveLength(1);
+
+      const getTeamRes = await driver.actor.get_team({
+        team_id: defaultTeam!.id,
+      });
+      expect(extractOkResponse(getTeamRes)).toEqual({ team: defaultTeam });
+
+      const listMembersRes = await driver.actor.list_team_users({
+        team_id: defaultTeam!.id,
+      });
+      expect(extractOkResponse(listMembersRes).map(m => m.id)).toEqual([
+        alice.profile.id,
+      ]);
+
+      // Bit-gated endpoints — deny.
+      const createRes = await driver.actor.create_team({
+        org_id: alice.org!.id,
+        name: 'Hijacked',
+      });
+      expect(createRes).toEqual(
+        lacksOrgPermissionError(bob.profile.id, alice.org!.id, 'TEAM_MANAGE'),
+      );
+
+      const updateRes = await driver.actor.update_team({
+        team_id: defaultTeam!.id,
+        name: 'Hijacked',
+      });
+      expect(updateRes).toEqual(
+        lacksOrgPermissionError(bob.profile.id, alice.org!.id, 'TEAM_MANAGE'),
+      );
+
+      const deleteRes = await driver.actor.delete_team({
+        team_id: defaultTeam!.id,
+      });
+      expect(deleteRes).toEqual(
+        lacksOrgPermissionError(bob.profile.id, alice.org!.id, 'TEAM_MANAGE'),
+      );
+
+      const addMemberRes = await driver.actor.add_user_to_team({
+        team_id: defaultTeam!.id,
+        user_id: bob.profile.id,
+      });
+      expect(addMemberRes).toEqual(
+        lacksOrgPermissionError(bob.profile.id, alice.org!.id, 'MEMBER_MANAGE'),
+      );
     });
   });
 });

--- a/src/backend/src/data/organization_repository.rs
+++ b/src/backend/src/data/organization_repository.rs
@@ -103,16 +103,17 @@ pub fn add_user_to_org(user_id: Uuid, org_id: Uuid) {
     });
 }
 
-pub fn assert_user_in_org(user_id: Uuid, org_id: Uuid) -> ApiResult {
-    with_state(|s| {
-        if !s.organization_user_index.contains(&(org_id, user_id)) {
-            return Err(ApiError::unauthorized(format!(
-                "User with id {user_id} does not belong to org with id {org_id}"
-            )));
-        }
+pub fn is_user_in_org(user_id: Uuid, org_id: Uuid) -> bool {
+    with_state(|s| s.organization_user_index.contains(&(org_id, user_id)))
+}
 
-        Ok(())
-    })
+pub fn assert_user_in_org(user_id: Uuid, org_id: Uuid) -> ApiResult {
+    if !is_user_in_org(user_id, org_id) {
+        return Err(ApiError::unauthorized(format!(
+            "User with id {user_id} does not belong to org with id {org_id}"
+        )));
+    }
+    Ok(())
 }
 
 struct OrganizationState {

--- a/src/backend/src/data/organization_repository.rs
+++ b/src/backend/src/data/organization_repository.rs
@@ -103,17 +103,13 @@ pub fn add_user_to_org(user_id: Uuid, org_id: Uuid) {
     });
 }
 
+// Predicate-only membership check. Authorization-grade checks must go
+// through `service::access_control_service::OrgAuth` so that a successful
+// check produces a capability token rather than a bare bool. This function
+// is reserved for cases that are not themselves authorization decisions
+// (e.g. "is the invite target already a member" idempotency checks).
 pub fn is_user_in_org(user_id: Uuid, org_id: Uuid) -> bool {
     with_state(|s| s.organization_user_index.contains(&(org_id, user_id)))
-}
-
-pub fn assert_user_in_org(user_id: Uuid, org_id: Uuid) -> ApiResult {
-    if !is_user_in_org(user_id, org_id) {
-        return Err(ApiError::unauthorized(format!(
-            "User with id {user_id} does not belong to org with id {org_id}"
-        )));
-    }
-    Ok(())
 }
 
 struct OrganizationState {

--- a/src/backend/src/data/project_repository.rs
+++ b/src/backend/src/data/project_repository.rs
@@ -228,20 +228,6 @@ pub fn org_has_projects(org_id: Uuid) -> bool {
     })
 }
 
-pub fn assert_any_team_has_project(
-    user_id: &Uuid,
-    team_ids: &[Uuid],
-    project_to_check: Uuid,
-) -> ApiResult {
-    if !list_all_team_project_ids(team_ids).contains(&project_to_check) {
-        return Err(ApiError::unauthorized(format!(
-            "User with id {user_id} does not have access to project with id {project_to_check}"
-        )));
-    }
-
-    Ok(())
-}
-
 struct ProjectState {
     projects: ProjectMemory,
     project_team_index: ProjectTeamIndexMemory, // TODO: remove after migration has run on all environments

--- a/src/backend/src/data/project_repository.rs
+++ b/src/backend/src/data/project_repository.rs
@@ -67,6 +67,33 @@ pub fn is_team_in_project(team_id: Uuid, project_id: Uuid) -> bool {
     })
 }
 
+#[allow(dead_code)]
+pub fn get_project_team_permissions(project_id: Uuid, team_id: Uuid) -> Option<ProjectPermissions> {
+    with_state(|s| s.project_team_permissions_index.get(&(project_id, team_id)))
+}
+
+// Union ProjectPermissions of every team in `team_ids` that is linked to
+// `project_id`. Also returns whether any of those teams were linked.
+pub fn aggregate_team_project_permissions(
+    team_ids: &[Uuid],
+    project_id: Uuid,
+) -> (ProjectPermissions, bool) {
+    with_state(|s| {
+        let mut perms = ProjectPermissions::EMPTY;
+        let mut has_link = false;
+        for team_id in team_ids {
+            if let Some(p) = s
+                .project_team_permissions_index
+                .get(&(project_id, *team_id))
+            {
+                perms = perms.union(p);
+                has_link = true;
+            }
+        }
+        (perms, has_link)
+    })
+}
+
 pub fn list_project_team_ids(project_id: Uuid) -> Vec<Uuid> {
     with_state(|s| {
         s.project_team_permissions_index

--- a/src/backend/src/data/team_repository.rs
+++ b/src/backend/src/data/team_repository.rs
@@ -144,15 +144,20 @@ pub fn aggregate_user_org_permissions(user_id: Uuid, org_id: Uuid) -> OrgPermiss
     })
 }
 
-// Invariant check: at least one team in the org has ORG_ADMIN AND at least
-// one member. Called after any mutation that could break this (team
-// deletion, permission revocation, member removal).
-pub fn org_admin_is_populated(org_id: Uuid) -> bool {
+// Invariant predicate: would the org still have at least one team holding
+// ORG_ADMIN with at least one member if `excluded_team_id` were removed?
+// Used as a pre-mutation check on delete paths — on the IC, returning Err
+// after a mutation does not roll back state, so this must be evaluated
+// before any repository write that could break the invariant.
+pub fn org_admin_is_populated_excluding_team(org_id: Uuid, excluded_team_id: Uuid) -> bool {
     with_state(|s| {
         s.organization_team_permissions_index
             .range((org_id, Uuid::MIN)..=(org_id, Uuid::MAX))
             .any(|entry| {
                 let (_, team_id) = *entry.key();
+                if team_id == excluded_team_id {
+                    return false;
+                }
                 entry.value().contains(OrgPermissions::ORG_ADMIN)
                     && s.team_user_index
                         .range((team_id, Uuid::MIN)..=(team_id, Uuid::MAX))

--- a/src/backend/src/data/team_repository.rs
+++ b/src/backend/src/data/team_repository.rs
@@ -113,6 +113,55 @@ pub fn is_user_in_team(user_id: Uuid, team_id: Uuid) -> bool {
     with_state(|s| s.team_user_index.contains(&(team_id, user_id)))
 }
 
+#[allow(dead_code)]
+pub fn get_org_team_permissions(org_id: Uuid, team_id: Uuid) -> Option<OrgPermissions> {
+    with_state(|s| {
+        s.organization_team_permissions_index
+            .get(&(org_id, team_id))
+    })
+}
+
+// Union the OrgPermissions of every team the user belongs to within `org_id`.
+// Returns OrgPermissions::EMPTY if the user has no teams in the org.
+pub fn aggregate_user_org_permissions(user_id: Uuid, org_id: Uuid) -> OrgPermissions {
+    with_state(|s| {
+        let team_ids: Vec<Uuid> = s
+            .user_team_index
+            .range((user_id, Uuid::MIN)..=(user_id, Uuid::MAX))
+            .map(|(_, team_id)| team_id)
+            .collect();
+
+        let mut perms = OrgPermissions::EMPTY;
+        for team_id in team_ids {
+            if let Some(p) = s
+                .organization_team_permissions_index
+                .get(&(org_id, team_id))
+            {
+                perms = perms.union(p);
+            }
+        }
+        perms
+    })
+}
+
+// Invariant check: at least one team in the org has ORG_ADMIN AND at least
+// one member. Called after any mutation that could break this (team
+// deletion, permission revocation, member removal).
+pub fn org_admin_is_populated(org_id: Uuid) -> bool {
+    with_state(|s| {
+        s.organization_team_permissions_index
+            .range((org_id, Uuid::MIN)..=(org_id, Uuid::MAX))
+            .any(|entry| {
+                let (_, team_id) = *entry.key();
+                entry.value().contains(OrgPermissions::ORG_ADMIN)
+                    && s.team_user_index
+                        .range((team_id, Uuid::MIN)..=(team_id, Uuid::MAX))
+                        .next()
+                        .is_some()
+            })
+    })
+}
+
 pub fn add_user_to_team(user_id: Uuid, team_id: Uuid) {
     mutate_state(|s| {
         s.team_user_index.insert((team_id, user_id));
@@ -170,6 +219,20 @@ pub fn list_user_team_ids(user_id: Uuid) -> Vec<Uuid> {
         s.user_team_index
             .range((user_id, Uuid::MIN)..=(user_id, Uuid::MAX))
             .map(|(_, team_id)| team_id)
+            .collect()
+    })
+}
+
+// All teams in `org_id` that `user_id` belongs to.
+pub fn list_user_teams_in_org(user_id: Uuid, org_id: Uuid) -> Vec<Uuid> {
+    with_state(|s| {
+        s.user_team_index
+            .range((user_id, Uuid::MIN)..=(user_id, Uuid::MAX))
+            .filter_map(|(_, team_id)| {
+                s.organization_team_permissions_index
+                    .get(&(org_id, team_id))
+                    .map(|_| team_id)
+            })
             .collect()
     })
 }

--- a/src/backend/src/service/access_control_service.rs
+++ b/src/backend/src/service/access_control_service.rs
@@ -241,11 +241,16 @@ pub fn require_team_access(
     Ok((team, auth))
 }
 
-// Invariant: after any mutation that could break it, assert that at least
-// one team in the org still holds ORG_ADMIN and has at least one member.
-// Without this the org becomes unadministrable.
-pub fn assert_org_admin_populated(org_id: Uuid) -> ApiResult {
-    if !team_repository::org_admin_is_populated(org_id) {
+// Pre-mutation invariant: reject a team deletion that would leave the org
+// without any ORG_ADMIN-holding team with at least one member. Must be
+// called before the repository write — on the IC, returning Err after a
+// mutation does not roll back state, so a post-mutation check would leave
+// the org unadministrable on failure.
+pub fn assert_org_admin_populated_after_removing_team(
+    org_id: Uuid,
+    team_id: Uuid,
+) -> ApiResult {
+    if !team_repository::org_admin_is_populated_excluding_team(org_id, team_id) {
         return Err(ApiError::client_error(format!(
             "Organization with id {org_id} must retain at least one team with \
              ORG_ADMIN and at least one member."

--- a/src/backend/src/service/access_control_service.rs
+++ b/src/backend/src/service/access_control_service.rs
@@ -77,7 +77,19 @@ pub struct OrgAuth {
 impl OrgAuth {
     pub fn require(caller: &Principal, org_id: Uuid, needed: OrgPermissions) -> ApiResult<Self> {
         let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-        organization_repository::assert_user_in_org(user_id, org_id)?;
+        Self::require_for_user(user_id, org_id, needed)
+    }
+
+    // Same checks as `require`, but skips the principal-to-user lookup
+    // because the caller has already resolved it. Used by helpers like
+    // `require_team_access` that perform the lookup up front so they can
+    // surface resource-specific errors before the membership check runs.
+    fn require_for_user(user_id: Uuid, org_id: Uuid, needed: OrgPermissions) -> ApiResult<Self> {
+        if !organization_repository::is_user_in_org(user_id, org_id) {
+            return Err(ApiError::unauthorized(format!(
+                "User with id {user_id} does not belong to org with id {org_id}"
+            )));
+        }
 
         let perms = team_repository::aggregate_user_org_permissions(user_id, org_id);
         if !perms.contains(needed) {
@@ -102,9 +114,22 @@ impl OrgAuth {
         self.org_id
     }
 
-    #[allow(dead_code)]
     pub fn perms(&self) -> OrgPermissions {
         self.perms
+    }
+
+    // Assert that another user is a member of the same org this token
+    // authorizes. For use in endpoints that manipulate a peer user
+    // (e.g. add_user_to_team) without re-deriving the org_id from the
+    // peer's identity.
+    pub fn assert_member(&self, target_user_id: Uuid) -> ApiResult {
+        if !organization_repository::is_user_in_org(target_user_id, self.org_id) {
+            return Err(ApiError::unauthorized(format!(
+                "User with id {target_user_id} does not belong to org with id {}",
+                self.org_id
+            )));
+        }
+        Ok(())
     }
 }
 
@@ -212,7 +237,7 @@ pub fn require_team_access(
         return Err(team_not_found_or_no_access(team_id));
     }
 
-    let auth = OrgAuth::require(caller, team.org_id, needed)?;
+    let auth = OrgAuth::require_for_user(user_id, team.org_id, needed)?;
     Ok((team, auth))
 }
 

--- a/src/backend/src/service/access_control_service.rs
+++ b/src/backend/src/service/access_control_service.rs
@@ -1,10 +1,28 @@
 use crate::data::{
-    terms_and_conditions_repository, trusted_partner_repository, user_profile_repository,
-    UserStatus,
+    organization_repository, project_repository, team_repository, terms_and_conditions_repository,
+    trusted_partner_repository, user_profile_repository, OrgPermissions, Project,
+    ProjectPermissions, Team, UserStatus,
 };
 use candid::Principal;
-use canister_utils::{assert_authenticated, ApiError, ApiResult};
+use canister_utils::{assert_authenticated, ApiError, ApiResult, Uuid};
 use ic_cdk::api::is_controller;
+
+// Generic "not found or no access" errors. A caller who is not allowed to
+// know that a resource exists (or which org owns it) gets this same message
+// whether the id refers to a real resource in another org or to a non-
+// existent id. This prevents probing for resource existence or mapping ids
+// to orgs by observing error messages.
+pub fn project_not_found_or_no_access(project_id: Uuid) -> ApiError {
+    ApiError::client_error(format!(
+        "Project with id {project_id} does not exist or you do not have access."
+    ))
+}
+
+pub fn team_not_found_or_no_access(team_id: Uuid) -> ApiError {
+    ApiError::client_error(format!(
+        "Team with id {team_id} does not exist or you do not have access."
+    ))
+}
 
 pub fn assert_trusted_partner(caller: &Principal) -> ApiResult {
     assert_authenticated(caller)?;
@@ -40,5 +58,173 @@ pub fn assert_has_platform_access(caller: &Principal) -> ApiResult {
         ));
     }
 
+    Ok(())
+}
+
+// Proof that the caller has been resolved to a user, is a member of `org_id`,
+// and holds at least the permissions implied by the construction call. The
+// only way to obtain an `OrgAuth` is via `require`, which performs the check.
+//
+// Use `OrgPermissions::EMPTY` as the `needed` argument for read-only endpoints
+// that require org membership but no specific capability.
+#[derive(Debug, Clone, Copy)]
+pub struct OrgAuth {
+    user_id: Uuid,
+    org_id: Uuid,
+    perms: OrgPermissions,
+}
+
+impl OrgAuth {
+    pub fn require(caller: &Principal, org_id: Uuid, needed: OrgPermissions) -> ApiResult<Self> {
+        let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
+        organization_repository::assert_user_in_org(user_id, org_id)?;
+
+        let perms = team_repository::aggregate_user_org_permissions(user_id, org_id);
+        if !perms.contains(needed) {
+            return Err(ApiError::unauthorized(format!(
+                "User with id {user_id} lacks required permissions on org \
+                 with id {org_id}: {needed}"
+            )));
+        }
+
+        Ok(Self {
+            user_id,
+            org_id,
+            perms,
+        })
+    }
+
+    pub fn user_id(&self) -> Uuid {
+        self.user_id
+    }
+
+    pub fn org_id(&self) -> Uuid {
+        self.org_id
+    }
+
+    #[allow(dead_code)]
+    pub fn perms(&self) -> OrgPermissions {
+        self.perms
+    }
+}
+
+// Proof that the caller has been resolved to a user, has at least one team
+// linked to `project_id`, and that team (or the union across their teams)
+// holds at least the permissions implied by the construction call. The only
+// way to obtain a `ProjectAuth` is via `require`.
+//
+// Use `ProjectPermissions::EMPTY` as the `needed` argument for read-only
+// endpoints that require project access but no specific capability.
+#[derive(Debug, Clone, Copy)]
+pub struct ProjectAuth {
+    #[allow(dead_code)]
+    user_id: Uuid,
+    project_id: Uuid,
+    org_id: Uuid,
+    perms: ProjectPermissions,
+}
+
+impl ProjectAuth {
+    pub fn require(
+        caller: &Principal,
+        project_id: Uuid,
+        needed: ProjectPermissions,
+    ) -> ApiResult<Self> {
+        let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
+
+        // Collapse "project does not exist" and "caller is not in project's
+        // org" into the same generic error. A caller outside the org must
+        // not be able to tell whether a project id is real or learn which
+        // org owns it.
+        let Project { org_id, .. } = project_repository::get_project(&project_id)
+            .ok_or_else(|| project_not_found_or_no_access(project_id))?;
+
+        if !organization_repository::is_user_in_org(user_id, org_id) {
+            return Err(project_not_found_or_no_access(project_id));
+        }
+
+        let team_ids = team_repository::list_user_team_ids(user_id);
+        let (perms, has_link) =
+            project_repository::aggregate_team_project_permissions(&team_ids, project_id);
+
+        if !has_link {
+            return Err(ApiError::unauthorized(format!(
+                "User with id {user_id} does not have access to project \
+                 with id {project_id}"
+            )));
+        }
+
+        if !perms.contains(needed) {
+            return Err(ApiError::unauthorized(format!(
+                "User with id {user_id} lacks required permissions on project \
+                 with id {project_id}: {needed}"
+            )));
+        }
+
+        Ok(Self {
+            user_id,
+            project_id,
+            org_id,
+            perms,
+        })
+    }
+
+    #[allow(dead_code)]
+    pub fn user_id(&self) -> Uuid {
+        self.user_id
+    }
+
+    pub fn project_id(&self) -> Uuid {
+        self.project_id
+    }
+
+    pub fn org_id(&self) -> Uuid {
+        self.org_id
+    }
+
+    #[allow(dead_code)]
+    pub fn perms(&self) -> ProjectPermissions {
+        self.perms
+    }
+}
+
+// Resolve a team id and enforce that the caller has org-level access to it
+// with the required permissions. Returns the team together with the
+// resulting `OrgAuth` (useful when the caller needs both the team record
+// and proof of org membership).
+//
+// Non-existent team ids and teams in orgs the caller can't see both return
+// the same generic error so the caller cannot probe for team existence or
+// map team ids to orgs.
+pub fn require_team_access(
+    caller: &Principal,
+    team_id: Uuid,
+    needed: OrgPermissions,
+) -> ApiResult<(Team, OrgAuth)> {
+    // Profile check first so that a caller without a profile still gets the
+    // canonical no-profile error (they need to sign up, not retry).
+    let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
+
+    let team =
+        team_repository::get_team(team_id).ok_or_else(|| team_not_found_or_no_access(team_id))?;
+
+    if !organization_repository::is_user_in_org(user_id, team.org_id) {
+        return Err(team_not_found_or_no_access(team_id));
+    }
+
+    let auth = OrgAuth::require(caller, team.org_id, needed)?;
+    Ok((team, auth))
+}
+
+// Invariant: after any mutation that could break it, assert that at least
+// one team in the org still holds ORG_ADMIN and has at least one member.
+// Without this the org becomes unadministrable.
+pub fn assert_org_admin_populated(org_id: Uuid) -> ApiResult {
+    if !team_repository::org_admin_is_populated(org_id) {
+        return Err(ApiError::client_error(format!(
+            "Organization with id {org_id} must retain at least one team with \
+             ORG_ADMIN and at least one member."
+        )));
+    }
     Ok(())
 }

--- a/src/backend/src/service/access_control_service.rs
+++ b/src/backend/src/service/access_control_service.rs
@@ -246,10 +246,7 @@ pub fn require_team_access(
 // called before the repository write — on the IC, returning Err after a
 // mutation does not roll back state, so a post-mutation check would leave
 // the org unadministrable on failure.
-pub fn assert_org_admin_populated_after_removing_team(
-    org_id: Uuid,
-    team_id: Uuid,
-) -> ApiResult {
+pub fn assert_org_admin_populated_after_removing_team(org_id: Uuid, team_id: Uuid) -> ApiResult {
     if !team_repository::org_admin_is_populated_excluding_team(org_id, team_id) {
         return Err(ApiError::client_error(format!(
             "Organization with id {org_id} must retain at least one team with \

--- a/src/backend/src/service/approval_policy_service.rs
+++ b/src/backend/src/service/approval_policy_service.rs
@@ -1,9 +1,8 @@
 use crate::{
-    data::{
-        approval_policy_repository, project_repository, team_repository, user_profile_repository,
-    },
+    data::{approval_policy_repository, ProjectPermissions},
     dto::{ListProjectApprovalPoliciesRequest, ListProjectApprovalPoliciesResponse},
     mapping::map_list_project_approval_policies_response,
+    service::access_control_service::ProjectAuth,
 };
 use candid::Principal;
 use canister_utils::{ApiResult, Uuid};
@@ -13,12 +12,9 @@ pub fn list_project_approval_policies(
     request: ListProjectApprovalPoliciesRequest,
 ) -> ApiResult<ListProjectApprovalPoliciesResponse> {
     let project_id = Uuid::try_from(request.project_id.as_str())?;
+    let auth = ProjectAuth::require(caller, project_id, ProjectPermissions::EMPTY)?;
 
-    let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-    let team_ids = team_repository::list_user_team_ids(user_id);
-    project_repository::assert_any_team_has_project(&user_id, &team_ids, project_id)?;
-
-    let policies = approval_policy_repository::list_project_approval_policies(project_id);
+    let policies = approval_policy_repository::list_project_approval_policies(auth.project_id());
 
     Ok(map_list_project_approval_policies_response(policies))
 }

--- a/src/backend/src/service/canister_service.rs
+++ b/src/backend/src/service/canister_service.rs
@@ -5,13 +5,14 @@ use crate::{
     },
     data::{
         canister_repository, organization_repository, project_repository, team_repository,
-        user_profile_repository, Canister,
+        user_profile_repository, Canister, ProjectPermissions,
     },
     dto::{
         self, CanisterState, ListMyCanistersRequest, ListMyCanistersResponse,
         ListUserCanistersRequest, ListUserCanistersResponse,
     },
     mapping::{map_canister_info, map_canister_response},
+    service::access_control_service::ProjectAuth,
 };
 use candid::Principal;
 use canister_utils::{is_destination_invalid, ApiError, ApiResult, Uuid, MAX_CALLS_PER_BATCH};
@@ -28,11 +29,9 @@ pub async fn list_my_canisters(
     caller: Principal,
     request: ListMyCanistersRequest,
 ) -> ApiResult<ListMyCanistersResponse> {
-    let user_id = user_profile_repository::assert_user_id_by_principal(&caller)?;
     let project_id = request.project_id.as_str().try_into()?;
-    let team_ids = team_repository::list_user_team_ids(user_id);
-    project_repository::assert_any_team_has_project(&user_id, &team_ids, project_id)?;
-    list_canisters_by_project_internal(project_id).await
+    let auth = ProjectAuth::require(&caller, project_id, ProjectPermissions::EMPTY)?;
+    list_canisters_by_project_internal(auth.project_id()).await
 }
 
 pub async fn list_user_canisters(
@@ -115,15 +114,12 @@ fn classify_canister_status_error(err: CallError) -> CanisterState {
 }
 
 pub async fn remove_my_canister(caller: Principal, canister_id: Uuid) -> ApiResult<()> {
-    let user_id = user_profile_repository::assert_user_id_by_principal(&caller)?;
-
     let project_id = canister_repository::get_canister_project_id(canister_id)
         .ok_or_else(|| ApiError::client_error(format!("Canister {canister_id} not found.")))?;
 
-    let team_ids = team_repository::list_user_team_ids(user_id);
-    project_repository::assert_any_team_has_project(&user_id, &team_ids, project_id)?;
+    let auth = ProjectAuth::require(&caller, project_id, ProjectPermissions::CANISTER_MANAGE)?;
 
-    let canister = canister_repository::get_canister_in_project(project_id, canister_id)
+    let canister = canister_repository::get_canister_in_project(auth.project_id(), canister_id)
         .ok_or_else(|| {
             ApiError::client_error(format!(
                 "Canister {canister_id} not found in user's project."
@@ -132,7 +128,7 @@ pub async fn remove_my_canister(caller: Principal, canister_id: Uuid) -> ApiResu
 
     match fetch_canister_state(canister.principal).await {
         CanisterState::Deleted => {
-            canister_repository::remove_canister(project_id, canister_id);
+            canister_repository::remove_canister(auth.project_id(), canister_id);
             Ok(())
         }
         CanisterState::Accessible(_) | CanisterState::Inaccessible => {

--- a/src/backend/src/service/invite_service.rs
+++ b/src/backend/src/service/invite_service.rs
@@ -2,7 +2,7 @@ use crate::{
     constants::{INVITE_TTL_NS, MAX_PENDING_INVITES_PER_ORG},
     data::{
         self, invite_repository, organization_repository, user_profile_repository, InviteStatus,
-        OrgInvite,
+        OrgInvite, OrgPermissions,
     },
     dto::{
         AcceptOrgInviteRequest, AcceptOrgInviteResponse, CreateOrgInviteRequest,
@@ -11,6 +11,7 @@ use crate::{
         RevokeOrgInviteRequest, RevokeOrgInviteResponse,
     },
     mapping::{map_invite_target_to_data, map_invite_to_dto},
+    service::access_control_service::OrgAuth,
     validation::Email,
 };
 use candid::Principal;
@@ -19,17 +20,14 @@ use canister_utils::{ApiError, ApiResult, Uuid};
 // Creates an org invite. Intentionally does not leak whether the target
 // (email / user_id / principal) refers to an existing user, so that
 // sending an invite cannot be used to enumerate app accounts.
-//
-// TODO: any org member can invite. Restrict to org owner/admin once
-// roles exist.
 pub fn create_org_invite(
     caller: &Principal,
     req: CreateOrgInviteRequest,
     now_ns: u64,
 ) -> ApiResult<CreateOrgInviteResponse> {
     let org_id = Uuid::try_from(req.org_id.as_str())?;
-    let caller_user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-    organization_repository::assert_user_in_org(caller_user_id, org_id)?;
+    let auth = OrgAuth::require(caller, org_id, OrgPermissions::MEMBER_MANAGE)?;
+    let caller_user_id = auth.user_id();
 
     let target = map_invite_target_to_data(req.target)
         .map_err(ApiError::client_error)
@@ -47,7 +45,7 @@ pub fn create_org_invite(
         data::InviteTarget::Email(_) => None,
     };
     if let Some(target_user_id) = already_member_user_id {
-        if organization_repository::assert_user_in_org(target_user_id, org_id).is_ok() {
+        if organization_repository::is_user_in_org(target_user_id, org_id) {
             return Err(ApiError::client_error(
                 "User is already a member of this organization.".to_string(),
             ));
@@ -87,21 +85,20 @@ pub fn list_org_invites(
     now_ns: u64,
 ) -> ApiResult<ListOrgInvitesResponse> {
     let org_id = Uuid::try_from(req.org_id.as_str())?;
-    let caller_user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-    organization_repository::assert_user_in_org(caller_user_id, org_id)?;
+    let auth = OrgAuth::require(caller, org_id, OrgPermissions::EMPTY)?;
 
-    let org_name = organization_repository::get_org(org_id)
+    let org_name = organization_repository::get_org(auth.org_id())
         .map(|o| o.name)
         .unwrap_or_default();
 
     // Only show invites the caller created, to avoid leaking invitee
-    // emails/principals to other org members. Once an org permission
-    // model exists, this should gate on an "invite manage" permission
-    // so admins can see all org invites.
-    let invites = invite_repository::list_org_invites_by_creator(org_id, caller_user_id, now_ns)
-        .into_iter()
-        .map(|(id, inv)| map_invite_to_dto(id, inv, org_name.clone()))
-        .collect();
+    // emails/principals to other org members. A MEMBER_MANAGE-gated
+    // "see all org invites" variant is deferred to a follow-up PR.
+    let invites =
+        invite_repository::list_org_invites_by_creator(auth.org_id(), auth.user_id(), now_ns)
+            .into_iter()
+            .map(|(id, inv)| map_invite_to_dto(id, inv, org_name.clone()))
+            .collect();
 
     Ok(invites)
 }
@@ -111,18 +108,18 @@ pub fn revoke_org_invite(
     req: RevokeOrgInviteRequest,
 ) -> ApiResult<RevokeOrgInviteResponse> {
     let invite_id = Uuid::try_from(req.invite_id.as_str())?;
-    let caller_user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
 
     let mut invite = invite_repository::get_invite(invite_id).ok_or_else(|| {
         ApiError::client_error(format!("Invite with id {invite_id} does not exist."))
     })?;
-    organization_repository::assert_user_in_org(caller_user_id, invite.org_id)?;
+    let auth = OrgAuth::require(caller, invite.org_id, OrgPermissions::EMPTY)?;
 
-    // Only the inviter can revoke. Once org admin roles exist, admins
-    // should be allowed too.
-    if invite.created_by != caller_user_id {
+    // The inviter can always revoke their own invite. Other org members
+    // need MEMBER_MANAGE to revoke invites they did not create.
+    if invite.created_by != auth.user_id() && !auth.perms().contains(OrgPermissions::MEMBER_MANAGE)
+    {
         return Err(ApiError::unauthorized(
-            "Only the inviter can revoke this invite.".to_string(),
+            "Only the inviter or a member manager can revoke this invite.".to_string(),
         ));
     }
 
@@ -201,7 +198,7 @@ pub fn accept_org_invite(
     // Adding the user to the org is idempotent: if they are already a
     // member (e.g. double-accept race), we still mark the invite as
     // Accepted.
-    if organization_repository::assert_user_in_org(caller_user_id, invite.org_id).is_err() {
+    if !organization_repository::is_user_in_org(caller_user_id, invite.org_id) {
         organization_repository::add_user_to_org(caller_user_id, invite.org_id);
     }
 

--- a/src/backend/src/service/organization_service.rs
+++ b/src/backend/src/service/organization_service.rs
@@ -1,7 +1,8 @@
 use crate::{
     data::{
         approval_policy_repository, organization_repository, project_repository, team_repository,
-        user_profile_repository, ApprovalPolicy, OperationType, Organization, PolicyType,
+        user_profile_repository, ApprovalPolicy, OperationType, OrgPermissions, Organization,
+        PolicyType,
     },
     dto::{
         CreateOrganizationRequest, CreateOrganizationResponse, DeleteOrganizationRequest,
@@ -13,6 +14,7 @@ use crate::{
         map_list_my_organizations_response, map_list_org_users_response,
         map_organization_to_response,
     },
+    service::access_control_service::OrgAuth,
     validation::OrgName,
 };
 use candid::Principal;
@@ -32,8 +34,7 @@ pub fn list_org_users(
     req: ListOrgUsersRequest,
 ) -> ApiResult<ListOrgUsersResponse> {
     let org_id = Uuid::try_from(req.org_id.as_str())?;
-    let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-    organization_repository::assert_user_in_org(user_id, org_id)?;
+    OrgAuth::require(caller, org_id, OrgPermissions::EMPTY)?;
 
     let users = organization_repository::list_org_users(org_id)
         .into_iter()
@@ -84,57 +85,48 @@ pub fn get_organization(
     req: GetOrganizationRequest,
 ) -> ApiResult<GetOrganizationResponse> {
     let org_id = Uuid::try_from(req.org_id.as_str())?;
-    let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-    organization_repository::assert_user_in_org(user_id, org_id)?;
+    let auth = OrgAuth::require(caller, org_id, OrgPermissions::EMPTY)?;
 
     let org =
-        organization_repository::get_org(org_id).expect("org must exist after assert_user_in_org");
+        organization_repository::get_org(auth.org_id()).expect("org must exist after OrgAuth");
 
-    Ok(map_organization_to_response(org_id, org))
+    Ok(map_organization_to_response(auth.org_id(), org))
 }
 
-// TODO: any org member can update. Restrict to org owner/admin once
-// roles or ownership tracking exists.
 pub fn update_organization(
     caller: &Principal,
     req: UpdateOrganizationRequest,
 ) -> ApiResult<UpdateOrganizationResponse> {
     let org_id = Uuid::try_from(req.org_id.as_str())?;
-    let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-    organization_repository::assert_user_in_org(user_id, org_id)?;
+    let auth = OrgAuth::require(caller, org_id, OrgPermissions::ORG_ADMIN)?;
     let name = OrgName::try_from(req.name)?;
 
     let org = Organization {
         name: name.into_inner(),
     };
-    organization_repository::update_org(org_id, org.clone())?;
+    organization_repository::update_org(auth.org_id(), org.clone())?;
 
-    Ok(map_organization_to_response(org_id, org))
+    Ok(map_organization_to_response(auth.org_id(), org))
 }
 
-// TODO: any org member can delete. Restrict to org owner/admin once
-// roles or ownership tracking exists.
-//
-// Deleting an org requires all projects to be removed first.
-// Since create_organization always creates a default project, this
-// means "delete project" must be implemented before org deletion is
-// usable. Once delete_project exists, it must also clean up approval
-// policies and proposals for that project to avoid orphaned data.
+// Deleting an org requires all projects to be removed first. Since
+// create_organization always creates a default project, the user must first
+// delete the default project (which itself requires PROJECT_ADMIN on the
+// project) before delete_organization can succeed.
 pub fn delete_organization(
     caller: &Principal,
     req: DeleteOrganizationRequest,
 ) -> ApiResult<DeleteOrganizationResponse> {
     let org_id = Uuid::try_from(req.org_id.as_str())?;
-    let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-    organization_repository::assert_user_in_org(user_id, org_id)?;
+    let auth = OrgAuth::require(caller, org_id, OrgPermissions::ORG_ADMIN)?;
 
-    if !organization_repository::has_at_least_n_user_orgs(user_id, 2) {
+    if !organization_repository::has_at_least_n_user_orgs(auth.user_id(), 2) {
         return Err(ApiError::client_error(
             "Cannot delete your last organization.".to_string(),
         ));
     }
 
-    if project_repository::org_has_projects(org_id) {
+    if project_repository::org_has_projects(auth.org_id()) {
         return Err(ApiError::client_error(
             "Cannot delete an organization that still has projects. Remove all projects first."
                 .to_string(),
@@ -143,8 +135,8 @@ pub fn delete_organization(
 
     // Safe to delete: no projects remain, so no canisters, approval
     // policies, or proposals are linked to this org.
-    team_repository::delete_org_teams(org_id);
-    organization_repository::delete_org(org_id)?;
+    team_repository::delete_org_teams(auth.org_id());
+    organization_repository::delete_org(auth.org_id())?;
 
     Ok(DeleteOrganizationResponse {})
 }

--- a/src/backend/src/service/project_service.rs
+++ b/src/backend/src/service/project_service.rs
@@ -1,7 +1,7 @@
 use crate::{
     data::{
-        canister_repository, organization_repository, project_repository, team_repository,
-        user_profile_repository, Project,
+        canister_repository, project_repository, team_repository, user_profile_repository,
+        OrgPermissions, Project, ProjectPermissions,
     },
     dto::{
         AddTeamToProjectRequest, AddTeamToProjectResponse, CreateProjectRequest,
@@ -15,6 +15,7 @@ use crate::{
         map_list_my_projects_response, map_list_org_projects_response, map_list_teams_response,
         map_project_to_response,
     },
+    service::access_control_service::{team_not_found_or_no_access, OrgAuth, ProjectAuth},
     validation::ProjectName,
 };
 use candid::Principal;
@@ -35,10 +36,9 @@ pub fn list_org_projects(
     req: ListOrgProjectsRequest,
 ) -> ApiResult<ListOrgProjectsResponse> {
     let org_id = Uuid::try_from(req.org_id.as_str())?;
-    let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-    organization_repository::assert_user_in_org(user_id, org_id)?;
+    let auth = OrgAuth::require(caller, org_id, OrgPermissions::EMPTY)?;
 
-    let projects = project_repository::list_org_projects(org_id);
+    let projects = project_repository::list_org_projects(auth.org_id());
     Ok(map_list_org_projects_response(projects))
 }
 
@@ -47,34 +47,40 @@ pub fn create_project(
     req: CreateProjectRequest,
 ) -> ApiResult<CreateProjectResponse> {
     let org_id = Uuid::try_from(req.org_id.as_str())?;
-    let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-    organization_repository::assert_user_in_org(user_id, org_id)?;
+    let auth = OrgAuth::require(caller, org_id, OrgPermissions::PROJECT_CREATE)?;
     let name = ProjectName::try_from(req.name)?;
 
-    if project_repository::has_at_least_n_org_projects(org_id, MAX_PROJECTS_PER_ORG) {
+    if project_repository::has_at_least_n_org_projects(auth.org_id(), MAX_PROJECTS_PER_ORG) {
         return Err(ApiError::client_error(format!(
             "Cannot create more than {MAX_PROJECTS_PER_ORG} projects per organization."
         )));
     }
 
     let project = Project {
-        org_id,
+        org_id: auth.org_id(),
         name: name.into_inner(),
     };
-    let project_id = project_repository::create_project(org_id, project.clone());
+    let project_id = project_repository::create_project(auth.org_id(), project.clone());
+
+    // Link every team the creator belongs to in this org with full project
+    // permissions. Bootstraps the project-level access chain so the creator
+    // (and anyone who already shares a team with them) can immediately
+    // manage the new project. Matches the auto-link behavior of the default
+    // project created during org setup.
+    for team_id in team_repository::list_user_teams_in_org(auth.user_id(), auth.org_id()) {
+        project_repository::add_team_to_project(team_id, project_id);
+    }
 
     Ok(map_project_to_response(project_id, project))
 }
 
 pub fn get_project(caller: &Principal, req: GetProjectRequest) -> ApiResult<GetProjectResponse> {
     let project_id = Uuid::try_from(req.project_id.as_str())?;
-    let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-    let project = project_repository::get_project(&project_id).ok_or_else(|| {
-        ApiError::client_error(format!("Project with id {project_id} does not exist."))
-    })?;
-    organization_repository::assert_user_in_org(user_id, project.org_id)?;
+    let auth = ProjectAuth::require(caller, project_id, ProjectPermissions::EMPTY)?;
+    let project = project_repository::get_project(&auth.project_id())
+        .expect("project must exist after ProjectAuth");
 
-    Ok(map_project_to_response(project_id, project))
+    Ok(map_project_to_response(auth.project_id(), project))
 }
 
 pub fn update_project(
@@ -82,20 +88,16 @@ pub fn update_project(
     req: UpdateProjectRequest,
 ) -> ApiResult<UpdateProjectResponse> {
     let project_id = Uuid::try_from(req.project_id.as_str())?;
-    let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-    let existing = project_repository::get_project(&project_id).ok_or_else(|| {
-        ApiError::client_error(format!("Project with id {project_id} does not exist."))
-    })?;
-    organization_repository::assert_user_in_org(user_id, existing.org_id)?;
+    let auth = ProjectAuth::require(caller, project_id, ProjectPermissions::PROJECT_SETTINGS)?;
     let name = ProjectName::try_from(req.name)?;
 
     let project = Project {
-        org_id: existing.org_id,
+        org_id: auth.org_id(),
         name: name.into_inner(),
     };
-    project_repository::update_project(project_id, project.clone())?;
+    project_repository::update_project(auth.project_id(), project.clone())?;
 
-    Ok(map_project_to_response(project_id, project))
+    Ok(map_project_to_response(auth.project_id(), project))
 }
 
 pub fn delete_project(
@@ -103,26 +105,22 @@ pub fn delete_project(
     req: DeleteProjectRequest,
 ) -> ApiResult<DeleteProjectResponse> {
     let project_id = Uuid::try_from(req.project_id.as_str())?;
-    let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-    let project = project_repository::get_project(&project_id).ok_or_else(|| {
-        ApiError::client_error(format!("Project with id {project_id} does not exist."))
-    })?;
-    organization_repository::assert_user_in_org(user_id, project.org_id)?;
+    let auth = ProjectAuth::require(caller, project_id, ProjectPermissions::PROJECT_ADMIN)?;
 
-    if !project_repository::has_at_least_n_org_projects(project.org_id, 2) {
+    if !project_repository::has_at_least_n_org_projects(auth.org_id(), 2) {
         return Err(ApiError::client_error(
             "Cannot delete the last project in an organization.".to_string(),
         ));
     }
 
-    if canister_repository::project_has_canisters(project_id) {
+    if canister_repository::project_has_canisters(auth.project_id()) {
         return Err(ApiError::client_error(
             "Cannot delete a project that still has canisters. Remove all canisters first."
                 .to_string(),
         ));
     }
 
-    project_repository::delete_project(project_id, project.org_id)?;
+    project_repository::delete_project(auth.project_id(), auth.org_id())?;
 
     Ok(DeleteProjectResponse {})
 }
@@ -132,13 +130,9 @@ pub fn list_project_teams(
     req: ListProjectTeamsRequest,
 ) -> ApiResult<ListTeamsResponse> {
     let project_id = Uuid::try_from(req.project_id.as_str())?;
-    let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-    let project = project_repository::get_project(&project_id).ok_or_else(|| {
-        ApiError::client_error(format!("Project with id {project_id} does not exist."))
-    })?;
-    organization_repository::assert_user_in_org(user_id, project.org_id)?;
+    let auth = ProjectAuth::require(caller, project_id, ProjectPermissions::EMPTY)?;
 
-    let teams = project_repository::list_project_team_ids(project_id)
+    let teams = project_repository::list_project_team_ids(auth.project_id())
         .into_iter()
         .filter_map(|tid| team_repository::get_team(tid).map(|team| (tid, team)))
         .collect::<Vec<_>>();
@@ -152,26 +146,22 @@ pub fn add_team_to_project(
 ) -> ApiResult<AddTeamToProjectResponse> {
     let project_id = Uuid::try_from(req.project_id.as_str())?;
     let team_id = Uuid::try_from(req.team_id.as_str())?;
-    let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-    let project = project_repository::get_project(&project_id).ok_or_else(|| {
-        ApiError::client_error(format!("Project with id {project_id} does not exist."))
-    })?;
-    organization_repository::assert_user_in_org(user_id, project.org_id)?;
+    let auth = ProjectAuth::require(caller, project_id, ProjectPermissions::PROJECT_ADMIN)?;
 
-    let team = team_repository::get_team(team_id)
-        .ok_or_else(|| ApiError::client_error(format!("Team with id {team_id} does not exist.")))?;
-
-    if team.org_id != project.org_id {
-        return Err(ApiError::client_error(
-            "Team and project must belong to the same organization.".to_string(),
-        ));
+    // Collapse "team does not exist" and "team in another org" into the same
+    // error: the caller, as a project admin, must not be able to probe team
+    // ids across orgs.
+    let team_in_scope =
+        team_repository::get_team(team_id).is_some_and(|t| t.org_id == auth.org_id());
+    if !team_in_scope {
+        return Err(team_not_found_or_no_access(team_id));
     }
 
-    if project_repository::is_team_in_project(team_id, project_id) {
+    if project_repository::is_team_in_project(team_id, auth.project_id()) {
         return Ok(AddTeamToProjectResponse {});
     }
 
-    project_repository::add_team_to_project(team_id, project_id);
+    project_repository::add_team_to_project(team_id, auth.project_id());
 
     Ok(AddTeamToProjectResponse {})
 }
@@ -182,23 +172,19 @@ pub fn remove_team_from_project(
 ) -> ApiResult<RemoveTeamFromProjectResponse> {
     let project_id = Uuid::try_from(req.project_id.as_str())?;
     let team_id = Uuid::try_from(req.team_id.as_str())?;
-    let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-    let project = project_repository::get_project(&project_id).ok_or_else(|| {
-        ApiError::client_error(format!("Project with id {project_id} does not exist."))
-    })?;
-    organization_repository::assert_user_in_org(user_id, project.org_id)?;
+    let auth = ProjectAuth::require(caller, project_id, ProjectPermissions::PROJECT_ADMIN)?;
 
-    if !project_repository::is_team_in_project(team_id, project_id) {
+    if !project_repository::is_team_in_project(team_id, auth.project_id()) {
         return Ok(RemoveTeamFromProjectResponse {});
     }
 
-    if project_repository::project_team_count(project_id) < 2 {
+    if project_repository::project_team_count(auth.project_id()) < 2 {
         return Err(ApiError::client_error(
             "Cannot remove the last team from a project.".to_string(),
         ));
     }
 
-    project_repository::remove_team_from_project(team_id, project_id);
+    project_repository::remove_team_from_project(team_id, auth.project_id());
 
     Ok(RemoveTeamFromProjectResponse {})
 }

--- a/src/backend/src/service/proposal_service.rs
+++ b/src/backend/src/service/proposal_service.rs
@@ -1,11 +1,11 @@
 use crate::{
     data::{
-        approval_policy_repository, project_repository, proposal_repository, team_repository,
-        user_profile_repository, OperationType, PolicyType, Proposal, ProposalOperation,
+        approval_policy_repository, proposal_repository, OperationType, PolicyType,
+        ProjectPermissions, Proposal, ProposalOperation,
     },
     dto::{CreateProposalRequest, CreateProposalResponse},
     mapping::{map_create_proposal_request, map_create_proposal_response},
-    service::canister_service,
+    service::{access_control_service::ProjectAuth, canister_service},
 };
 use candid::Principal;
 use canister_utils::{ApiError, ApiResult, Uuid};
@@ -16,9 +16,7 @@ pub async fn create_proposal(
 ) -> ApiResult<CreateProposalResponse> {
     let (project_id, proposal) = map_create_proposal_request(req)?;
 
-    let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-    let team_ids = team_repository::list_user_team_ids(user_id);
-    project_repository::assert_any_team_has_project(&user_id, &team_ids, project_id)?;
+    ProjectAuth::require(caller, project_id, ProjectPermissions::PROPOSAL_CREATE)?;
 
     let proposal_id = proposal_repository::create_proposal(project_id, proposal.clone());
 

--- a/src/backend/src/service/team_service.rs
+++ b/src/backend/src/service/team_service.rs
@@ -120,7 +120,7 @@ pub fn add_user_to_team(
     let team_id = Uuid::try_from(req.team_id.as_str())?;
     let target_user_id = Uuid::try_from(req.user_id.as_str())?;
     let (_team, auth) = require_team_access(caller, team_id, OrgPermissions::MEMBER_MANAGE)?;
-    crate::data::organization_repository::assert_user_in_org(target_user_id, auth.org_id())?;
+    auth.assert_member(target_user_id)?;
 
     if team_repository::is_user_in_team(target_user_id, team_id) {
         return Ok(AddUserToTeamResponse {});

--- a/src/backend/src/service/team_service.rs
+++ b/src/backend/src/service/team_service.rs
@@ -7,7 +7,9 @@ use crate::{
         UpdateTeamRequest, UpdateTeamResponse,
     },
     mapping::{map_list_team_users_response, map_list_teams_response, map_team_to_response},
-    service::access_control_service::{assert_org_admin_populated, require_team_access, OrgAuth},
+    service::access_control_service::{
+        assert_org_admin_populated_after_removing_team, require_team_access, OrgAuth,
+    },
     validation::TeamName,
 };
 use candid::Principal;
@@ -90,10 +92,10 @@ pub fn delete_team(caller: &Principal, req: DeleteTeamRequest) -> ApiResult<Dele
         ));
     }
 
+    assert_org_admin_populated_after_removing_team(auth.org_id(), team_id)?;
+
     project_repository::remove_team_project_links(team_id);
     team_repository::delete_team(team_id, auth.org_id())?;
-
-    assert_org_admin_populated(auth.org_id())?;
 
     Ok(DeleteTeamResponse {})
 }

--- a/src/backend/src/service/team_service.rs
+++ b/src/backend/src/service/team_service.rs
@@ -1,7 +1,5 @@
 use crate::{
-    data::{
-        organization_repository, project_repository, team_repository, user_profile_repository, Team,
-    },
+    data::{project_repository, team_repository, user_profile_repository, OrgPermissions, Team},
     dto::{
         AddUserToTeamRequest, AddUserToTeamResponse, CreateTeamRequest, CreateTeamResponse,
         DeleteTeamRequest, DeleteTeamResponse, GetTeamRequest, GetTeamResponse,
@@ -9,6 +7,7 @@ use crate::{
         UpdateTeamRequest, UpdateTeamResponse,
     },
     mapping::{map_list_team_users_response, map_list_teams_response, map_team_to_response},
+    service::access_control_service::{assert_org_admin_populated, require_team_access, OrgAuth},
     validation::TeamName,
 };
 use candid::Principal;
@@ -28,50 +27,42 @@ pub fn list_org_teams(
     req: ListOrgTeamsRequest,
 ) -> ApiResult<ListTeamsResponse> {
     let org_id = Uuid::try_from(req.org_id.as_str())?;
-    let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-    organization_repository::assert_user_in_org(user_id, org_id)?;
+    let auth = OrgAuth::require(caller, org_id, OrgPermissions::EMPTY)?;
 
-    let teams = team_repository::list_org_teams(org_id);
+    let teams = team_repository::list_org_teams(auth.org_id());
     Ok(map_list_teams_response(teams))
 }
 
 pub fn create_team(caller: &Principal, req: CreateTeamRequest) -> ApiResult<CreateTeamResponse> {
     let org_id = Uuid::try_from(req.org_id.as_str())?;
-    let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-    organization_repository::assert_user_in_org(user_id, org_id)?;
+    let auth = OrgAuth::require(caller, org_id, OrgPermissions::TEAM_MANAGE)?;
     let name = TeamName::try_from(req.name)?;
 
-    if team_repository::has_at_least_n_org_teams(org_id, MAX_TEAMS_PER_ORG) {
+    if team_repository::has_at_least_n_org_teams(auth.org_id(), MAX_TEAMS_PER_ORG) {
         return Err(ApiError::client_error(format!(
             "Cannot create more than {MAX_TEAMS_PER_ORG} teams per organization."
         )));
     }
 
     let team = Team {
-        org_id,
+        org_id: auth.org_id(),
         name: name.into_inner(),
     };
-    let team_id = team_repository::create_team(user_id, org_id, team.clone());
+    let team_id = team_repository::create_team(auth.user_id(), auth.org_id(), team.clone());
 
     Ok(map_team_to_response(team_id, team))
 }
 
 pub fn get_team(caller: &Principal, req: GetTeamRequest) -> ApiResult<GetTeamResponse> {
     let team_id = Uuid::try_from(req.team_id.as_str())?;
-    let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-    let team = team_repository::get_team(team_id)
-        .ok_or_else(|| ApiError::client_error(format!("Team with id {team_id} does not exist.")))?;
-    organization_repository::assert_user_in_org(user_id, team.org_id)?;
+    let (team, _auth) = require_team_access(caller, team_id, OrgPermissions::EMPTY)?;
 
     Ok(map_team_to_response(team_id, team))
 }
 
 pub fn update_team(caller: &Principal, req: UpdateTeamRequest) -> ApiResult<UpdateTeamResponse> {
     let team_id = Uuid::try_from(req.team_id.as_str())?;
-    let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-    let existing = team_repository::get_team(team_id)
-        .ok_or_else(|| ApiError::client_error(format!("Team with id {team_id} does not exist.")))?;
-    organization_repository::assert_user_in_org(user_id, existing.org_id)?;
+    let (existing, _auth) = require_team_access(caller, team_id, OrgPermissions::TEAM_MANAGE)?;
     let name = TeamName::try_from(req.name)?;
 
     let team = Team {
@@ -85,12 +76,9 @@ pub fn update_team(caller: &Principal, req: UpdateTeamRequest) -> ApiResult<Upda
 
 pub fn delete_team(caller: &Principal, req: DeleteTeamRequest) -> ApiResult<DeleteTeamResponse> {
     let team_id = Uuid::try_from(req.team_id.as_str())?;
-    let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-    let team = team_repository::get_team(team_id)
-        .ok_or_else(|| ApiError::client_error(format!("Team with id {team_id} does not exist.")))?;
-    organization_repository::assert_user_in_org(user_id, team.org_id)?;
+    let (_team, auth) = require_team_access(caller, team_id, OrgPermissions::TEAM_MANAGE)?;
 
-    if !team_repository::has_at_least_n_org_teams(team.org_id, 2) {
+    if !team_repository::has_at_least_n_org_teams(auth.org_id(), 2) {
         return Err(ApiError::client_error(
             "Cannot delete the last team in an organization.".to_string(),
         ));
@@ -103,7 +91,9 @@ pub fn delete_team(caller: &Principal, req: DeleteTeamRequest) -> ApiResult<Dele
     }
 
     project_repository::remove_team_project_links(team_id);
-    team_repository::delete_team(team_id, team.org_id)?;
+    team_repository::delete_team(team_id, auth.org_id())?;
+
+    assert_org_admin_populated(auth.org_id())?;
 
     Ok(DeleteTeamResponse {})
 }
@@ -113,10 +103,7 @@ pub fn list_team_users(
     req: ListTeamUsersRequest,
 ) -> ApiResult<ListTeamUsersResponse> {
     let team_id = Uuid::try_from(req.team_id.as_str())?;
-    let caller_user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-    let team = team_repository::get_team(team_id)
-        .ok_or_else(|| ApiError::client_error(format!("Team with id {team_id} does not exist.")))?;
-    organization_repository::assert_user_in_org(caller_user_id, team.org_id)?;
+    let (_team, _auth) = require_team_access(caller, team_id, OrgPermissions::EMPTY)?;
 
     let users = team_repository::list_team_user_ids(team_id)
         .into_iter()
@@ -132,11 +119,8 @@ pub fn add_user_to_team(
 ) -> ApiResult<AddUserToTeamResponse> {
     let team_id = Uuid::try_from(req.team_id.as_str())?;
     let target_user_id = Uuid::try_from(req.user_id.as_str())?;
-    let caller_user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
-    let team = team_repository::get_team(team_id)
-        .ok_or_else(|| ApiError::client_error(format!("Team with id {team_id} does not exist.")))?;
-    organization_repository::assert_user_in_org(caller_user_id, team.org_id)?;
-    organization_repository::assert_user_in_org(target_user_id, team.org_id)?;
+    let (_team, auth) = require_team_access(caller, team_id, OrgPermissions::MEMBER_MANAGE)?;
+    crate::data::organization_repository::assert_user_in_org(target_user_id, auth.org_id())?;
 
     if team_repository::is_user_in_team(target_user_id, team_id) {
         return Ok(AddUserToTeamResponse {});


### PR DESCRIPTION
Introduce OrgAuth and ProjectAuth in access_control_service as the only way to prove a caller has org membership or project access with the required permission bitflags. Services (organization, project, team, canister, proposal) now route authorization through these tokens instead of ad-hoc checks.