### PR TITLE
feat: Allow deletion of canisters by admin

### DIFF
--- a/src/frontend/src/lib/api-models/management-canister.ts
+++ b/src/frontend/src/lib/api-models/management-canister.ts
@@ -6,6 +6,7 @@ import type {
   update_settings_args as ApiUpdateSettingsRequest,
   start_canister_args as ApiStartCanisterRequest,
   stop_canister_args as ApiStopCanisterRequest,
+  delete_canister_args as ApiDeleteCanisterRequest,
 } from '@ssn/management-canister';
 
 export interface ApiCanisterStatusRequest {
@@ -185,6 +186,18 @@ export interface StopCanisterRequest {
 export function mapStopCanisterRequest(
   req: StopCanisterRequest,
 ): ApiStopCanisterRequest {
+  return {
+    canister_id: Principal.fromText(req.canisterId),
+  };
+}
+
+export interface DeleteCanisterRequest {
+  canisterId: string;
+}
+
+export function mapDeleteCanisterRequest(
+  req: DeleteCanisterRequest,
+): ApiDeleteCanisterRequest {
   return {
     canister_id: Principal.fromText(req.canisterId),
   };

--- a/src/frontend/src/lib/api/management-canister.ts
+++ b/src/frontend/src/lib/api/management-canister.ts
@@ -4,11 +4,13 @@ import {
   mapUpdateSettingsRequest,
   mapStartCanisterRequest,
   mapStopCanisterRequest,
+  mapDeleteCanisterRequest,
   type CanisterStatusRequest,
   type CanisterStatusResponse,
   type UpdateSettingsRequest,
   type StartCanisterRequest,
   type StopCanisterRequest,
+  type DeleteCanisterRequest,
 } from '@/lib/api-models';
 import { type ActorSubclass } from '@icp-sdk/core/agent';
 import type { _SERVICE } from '@ssn/management-canister';
@@ -48,6 +50,14 @@ export class ManagementCanisterApi {
     const apiReq = mapStopCanisterRequest(req);
 
     await this.actor.stop_canister.withOptions({
+      effectiveCanisterId: apiReq.canister_id,
+    })(apiReq);
+  }
+
+  public async deleteCanister(req: DeleteCanisterRequest): Promise<void> {
+    const apiReq = mapDeleteCanisterRequest(req);
+
+    await this.actor.delete_canister.withOptions({
       effectiveCanisterId: apiReq.canister_id,
     })(apiReq);
   }

--- a/src/frontend/src/routes/admin/user-canister-card.tsx
+++ b/src/frontend/src/routes/admin/user-canister-card.tsx
@@ -103,24 +103,24 @@ export const UserCanisterCard: FC<UserCanisterCardProps> = ({
         {info && (
           <CardAction className="flex items-center gap-2">
             {info.status === CanisterStatus.Stopped && (
-              <LoadingButton
-                variant="outline"
-                size="xs"
-                onClick={handleStart}
-                isLoading={isActionLoading}
-              >
-                Start
-              </LoadingButton>
-            )}
-            {info.status === CanisterStatus.Stopped && (
-              <LoadingButton
-                variant="outline"
-                size="xs"
-                onClick={handleDelete}
-                isLoading={isActionLoading}
-              >
-                Delete
-              </LoadingButton>
+              <>
+                <LoadingButton
+                  variant="outline"
+                  size="xs"
+                  onClick={handleStart}
+                  isLoading={isActionLoading}
+                >
+                  Start
+                </LoadingButton>
+                <LoadingButton
+                  variant="outline"
+                  size="xs"
+                  onClick={handleDelete}
+                  isLoading={isActionLoading}
+                >
+                  Delete
+                </LoadingButton>
+              </>
             )}
             {info.status === CanisterStatus.Running && (
               <LoadingButton

--- a/src/frontend/src/routes/admin/user-canister-card.tsx
+++ b/src/frontend/src/routes/admin/user-canister-card.tsx
@@ -78,6 +78,21 @@ export const UserCanisterCard: FC<UserCanisterCardProps> = ({
     }
   };
 
+  const handleDelete = async () => {
+    try {
+      setIsActionLoading(true);
+      await managementCanisterApi.deleteCanister({
+        canisterId: canister.principal,
+      });
+      await onStatusChange?.();
+      showSuccessToast('Canister deleted successfully');
+    } catch (err) {
+      showErrorToast('Failed to delete canister', err);
+    } finally {
+      setIsActionLoading(false);
+    }
+  };
+
   return (
     <Card size="sm">
       <CardHeader>
@@ -97,6 +112,16 @@ export const UserCanisterCard: FC<UserCanisterCardProps> = ({
                 Start
               </LoadingButton>
             )}
+            {info.status === CanisterStatus.Stopped && (
+              <LoadingButton
+                variant="outline"
+                size="xs"
+                onClick={handleDelete}
+                isLoading={isActionLoading}
+              >
+                Delete
+              </LoadingButton>
+            )}
             {info.status === CanisterStatus.Running && (
               <LoadingButton
                 variant="outline"
@@ -110,6 +135,11 @@ export const UserCanisterCard: FC<UserCanisterCardProps> = ({
             <Badge variant={statusBadgeVariant(info.status)}>
               {info.status}
             </Badge>
+          </CardAction>
+        )}
+        {canister.state.availability === CanisterAvailability.Deleted && (
+          <CardAction className="flex items-center gap-2">
+            <Badge variant="destructive">Deleted</Badge>
           </CardAction>
         )}
       </CardHeader>


### PR DESCRIPTION
Allow deletion of canisters by the subnet admin. After a canister is stopped (prerequisite for canister deletion based on ICP protocol), a button to delete it appears (next to "start"). If the admin opts to delete the canister, on success, the card of the canister is updated to mark it's deleted.

The user will get a prompt on their view that the canister is deleted, if they opt to remove it from the dashboard, then it gets removed in the admin's view as well. We do not immediately remove it after successful deletion by the admin so that the end user can get this notification that their canister was deleted and decide how to act on it.