### PR TITLE
feat: add proposal voting state machine

### DIFF
--- a/src/backend-api/candid/proposal.did
+++ b/src/backend-api/candid/proposal.did
@@ -19,12 +19,27 @@ type Proposal = record {
 
 type ProposalStatus = variant {
   Open : record {};
+  PendingApproval : record {
+    threshold : nat32;
+    approvers : vec principal;
+    votes : vec ProposalVote;
+  };
   Rejected : record {};
   Executing : record {};
   Executed : record {};
   Failed : record {
     message : text;
   };
+};
+
+type ProposalVote = record {
+  voter : principal;
+  vote : Vote;
+};
+
+type Vote = variant {
+  Approve : record {};
+  Reject : record {};
 };
 
 type ProposalOperation = variant {

--- a/src/backend/src/data/model/proposal.rs
+++ b/src/backend/src/data/model/proposal.rs
@@ -14,10 +14,21 @@ pub struct Proposal {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ProposalStatus {
     Open,
+    PendingApproval {
+        threshold: u32,
+        approvers: Vec<Principal>,
+        votes: Vec<(Principal, Vote)>,
+    },
     Rejected,
     Executing,
     Executed,
     Failed(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Vote {
+    Approve,
+    Reject,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/backend/src/data/proposal_repository.rs
+++ b/src/backend/src/data/proposal_repository.rs
@@ -3,10 +3,18 @@ use crate::data::{
     memory::{
         init_project_proposal_index, init_proposals, ProjectProposalIndexMemory, ProposalMemory,
     },
-    ProposalStatus,
+    ProposalStatus, Vote,
 };
+use candid::Principal;
 use canister_utils::{ApiError, ApiResult, Uuid};
 use std::cell::RefCell;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VoteOutcome {
+    ReachedApproval,
+    ReachedRejection,
+    StillPending,
+}
 
 pub fn create_proposal(project_id: Uuid, proposal: Proposal) -> Uuid {
     let proposal_id = Uuid::new();
@@ -21,6 +29,98 @@ pub fn create_proposal(project_id: Uuid, proposal: Proposal) -> Uuid {
 
 pub fn get_proposal(proposal_id: &Uuid) -> Option<Proposal> {
     with_state(|s| s.proposals.get(proposal_id))
+}
+
+#[allow(dead_code)]
+pub fn set_proposal_pending_approval(
+    proposal_id: Uuid,
+    threshold: u32,
+    approvers: Vec<Principal>,
+) -> ApiResult {
+    mutate_state(|s| {
+        let mut proposal = s.proposals.get(&proposal_id).ok_or_else(|| {
+            ApiError::client_error(format!(
+                "Failed to set status for proposal {proposal_id}, proposal does not exist."
+            ))
+        })?;
+
+        if !matches!(proposal.status, ProposalStatus::Open) {
+            return Err(ApiError::client_error(format!(
+                "Proposal {proposal_id} is not open; cannot move to pending approval."
+            )));
+        }
+
+        proposal.status = ProposalStatus::PendingApproval {
+            threshold,
+            approvers,
+            votes: Vec::new(),
+        };
+        s.proposals.insert(proposal_id, proposal);
+
+        Ok(())
+    })
+}
+
+pub fn record_proposal_vote(
+    proposal_id: Uuid,
+    voter: Principal,
+    vote: Vote,
+) -> ApiResult<VoteOutcome> {
+    mutate_state(|s| {
+        let mut proposal = s.proposals.get(&proposal_id).ok_or_else(|| {
+            ApiError::client_error(format!(
+                "Failed to record vote for proposal {proposal_id}, proposal does not exist."
+            ))
+        })?;
+
+        let ProposalStatus::PendingApproval {
+            threshold,
+            approvers,
+            mut votes,
+        } = proposal.status.clone()
+        else {
+            return Err(ApiError::client_error(format!(
+                "Proposal {proposal_id} is not pending approval."
+            )));
+        };
+
+        if !approvers.contains(&voter) {
+            return Err(ApiError::client_error(format!(
+                "Principal {voter} is not an approver for proposal {proposal_id}."
+            )));
+        }
+
+        if votes.iter().any(|(v, _)| v == &voter) {
+            return Err(ApiError::client_error(format!(
+                "Principal {voter} has already voted on proposal {proposal_id}."
+            )));
+        }
+
+        votes.push((voter, vote));
+
+        let approvals = votes.iter().filter(|(_, v)| *v == Vote::Approve).count() as u32;
+        let rejections = votes.iter().filter(|(_, v)| *v == Vote::Reject).count() as u32;
+        let total = approvers.len() as u32;
+        let outcome = if approvals >= threshold {
+            VoteOutcome::ReachedApproval
+        } else if rejections > total.saturating_sub(threshold) {
+            VoteOutcome::ReachedRejection
+        } else {
+            VoteOutcome::StillPending
+        };
+
+        proposal.status = match outcome {
+            VoteOutcome::ReachedRejection => ProposalStatus::Rejected,
+            _ => ProposalStatus::PendingApproval {
+                threshold,
+                approvers,
+                votes,
+            },
+        };
+        s.proposals.insert(proposal_id, proposal);
+
+        Ok(outcome)
+    })
 }
 
 pub fn set_proposal_executing(proposal_id: Uuid) -> ApiResult {
@@ -74,4 +174,151 @@ fn with_state<R>(f: impl FnOnce(&ProposalState) -> R) -> R {
 
 fn mutate_state<R>(f: impl FnOnce(&mut ProposalState) -> R) -> R {
     STATE.with(|s| f(&mut s.borrow_mut()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::ProposalOperation;
+
+    fn principal(byte: u8) -> Principal {
+        Principal::from_slice(&[byte])
+    }
+
+    fn seed_pending_proposal(threshold: u32, approvers: Vec<Principal>) -> Uuid {
+        let project_id = Uuid::new();
+        let proposal_id = create_proposal(
+            project_id,
+            Proposal {
+                project_id,
+                status: ProposalStatus::Open,
+                operation: ProposalOperation::CreateCanister,
+            },
+        );
+        set_proposal_pending_approval(proposal_id, threshold, approvers).unwrap();
+        proposal_id
+    }
+
+    #[test]
+    fn set_pending_approval_rejects_non_open_status() {
+        let id = seed_pending_proposal(2, vec![principal(1), principal(2)]);
+        let err = set_proposal_pending_approval(id, 2, vec![principal(1)]).unwrap_err();
+        assert!(err.message().contains("not open"));
+    }
+
+    #[test]
+    fn vote_approve_reaches_threshold_but_leaves_status_pending() {
+        let a = principal(1);
+        let b = principal(2);
+        let c = principal(3);
+        let id = seed_pending_proposal(2, vec![a, b, c]);
+
+        assert_eq!(
+            record_proposal_vote(id, a, Vote::Approve).unwrap(),
+            VoteOutcome::StillPending
+        );
+        assert_eq!(
+            record_proposal_vote(id, b, Vote::Approve).unwrap(),
+            VoteOutcome::ReachedApproval
+        );
+
+        // Repository must not flip to Executing — that's the service layer's job.
+        let proposal = get_proposal(&id).unwrap();
+        match proposal.status {
+            ProposalStatus::PendingApproval { votes, .. } => assert_eq!(votes.len(), 2),
+            other => panic!("expected PendingApproval, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn vote_reject_flips_to_rejected_when_threshold_unreachable() {
+        let a = principal(1);
+        let b = principal(2);
+        let c = principal(3);
+        // threshold 2 of 3 → only 1 reject allowed before unreachable.
+        let id = seed_pending_proposal(2, vec![a, b, c]);
+
+        assert_eq!(
+            record_proposal_vote(id, a, Vote::Reject).unwrap(),
+            VoteOutcome::StillPending
+        );
+        assert_eq!(
+            record_proposal_vote(id, b, Vote::Reject).unwrap(),
+            VoteOutcome::ReachedRejection
+        );
+        assert!(matches!(
+            get_proposal(&id).unwrap().status,
+            ProposalStatus::Rejected
+        ));
+    }
+
+    #[test]
+    fn unanimous_threshold_rejects_on_first_reject() {
+        let a = principal(1);
+        let b = principal(2);
+        let id = seed_pending_proposal(2, vec![a, b]);
+
+        assert_eq!(
+            record_proposal_vote(id, a, Vote::Reject).unwrap(),
+            VoteOutcome::ReachedRejection
+        );
+    }
+
+    #[test]
+    fn mixed_votes_can_still_reach_approval() {
+        let a = principal(1);
+        let b = principal(2);
+        let c = principal(3);
+        let id = seed_pending_proposal(2, vec![a, b, c]);
+
+        record_proposal_vote(id, a, Vote::Approve).unwrap();
+        record_proposal_vote(id, b, Vote::Reject).unwrap();
+        assert_eq!(
+            record_proposal_vote(id, c, Vote::Approve).unwrap(),
+            VoteOutcome::ReachedApproval
+        );
+    }
+
+    #[test]
+    fn vote_from_non_approver_is_rejected() {
+        let a = principal(1);
+        let outsider = principal(99);
+        let id = seed_pending_proposal(1, vec![a]);
+
+        let err = record_proposal_vote(id, outsider, Vote::Approve).unwrap_err();
+        assert!(err.message().contains("is not an approver"));
+    }
+
+    #[test]
+    fn duplicate_vote_is_rejected() {
+        let a = principal(1);
+        let b = principal(2);
+        let id = seed_pending_proposal(2, vec![a, b]);
+
+        record_proposal_vote(id, a, Vote::Approve).unwrap();
+        let err = record_proposal_vote(id, a, Vote::Reject).unwrap_err();
+        assert!(err.message().contains("already voted"));
+    }
+
+    #[test]
+    fn vote_on_non_pending_proposal_is_rejected() {
+        let project_id = Uuid::new();
+        let id = create_proposal(
+            project_id,
+            Proposal {
+                project_id,
+                status: ProposalStatus::Open,
+                operation: ProposalOperation::CreateCanister,
+            },
+        );
+
+        let err = record_proposal_vote(id, principal(1), Vote::Approve).unwrap_err();
+        assert!(err.message().contains("not pending approval"));
+    }
+
+    #[test]
+    fn vote_on_missing_proposal_is_rejected() {
+        let err = record_proposal_vote(Uuid::new(), principal(1), Vote::Approve).unwrap_err();
+        assert!(err.message().contains("does not exist"));
+    }
 }

--- a/src/backend/src/dto/proposal.rs
+++ b/src/backend/src/dto/proposal.rs
@@ -20,10 +20,29 @@ pub struct Proposal {
 #[derive(Debug, Clone, CandidType, Deserialize)]
 pub enum ProposalStatus {
     Open {},
+    PendingApproval {
+        threshold: u32,
+        approvers: Vec<Principal>,
+        votes: Vec<ProposalVote>,
+    },
     Rejected {},
     Executing {},
     Executed {},
-    Failed { message: String },
+    Failed {
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct ProposalVote {
+    pub voter: Principal,
+    pub vote: Vote,
+}
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub enum Vote {
+    Approve {},
+    Reject {},
 }
 
 #[derive(Debug, Clone, CandidType, Deserialize)]

--- a/src/backend/src/mapping/proposal.rs
+++ b/src/backend/src/mapping/proposal.rs
@@ -1,8 +1,18 @@
 use crate::{
     data,
-    dto::{CreateProposalRequest, CreateProposalResponse, ProposalOperation, ProposalStatus},
+    dto::{
+        CreateProposalRequest, CreateProposalResponse, ProposalOperation, ProposalStatus,
+        ProposalVote, Vote,
+    },
 };
 use canister_utils::{ApiError, ApiResult, Uuid};
+
+fn map_vote(vote: data::Vote) -> Vote {
+    match vote {
+        data::Vote::Approve => Vote::Approve {},
+        data::Vote::Reject => Vote::Reject {},
+    }
+}
 
 pub fn map_create_proposal_request(
     req: CreateProposalRequest,
@@ -44,6 +54,21 @@ pub fn map_create_proposal_response(
         project_id: proposal.project_id.to_string(),
         status: match proposal.status {
             data::ProposalStatus::Open => Some(ProposalStatus::Open {}),
+            data::ProposalStatus::PendingApproval {
+                threshold,
+                approvers,
+                votes,
+            } => Some(ProposalStatus::PendingApproval {
+                threshold,
+                approvers,
+                votes: votes
+                    .into_iter()
+                    .map(|(voter, vote)| ProposalVote {
+                        voter,
+                        vote: map_vote(vote),
+                    })
+                    .collect(),
+            }),
             data::ProposalStatus::Rejected => Some(ProposalStatus::Rejected {}),
             data::ProposalStatus::Executing => Some(ProposalStatus::Executing {}),
             data::ProposalStatus::Executed => Some(ProposalStatus::Executed {}),

--- a/src/backend/src/service/proposal_service.rs
+++ b/src/backend/src/service/proposal_service.rs
@@ -1,7 +1,7 @@
 use crate::{
     data::{
-        approval_policy_repository, proposal_repository, OperationType, PolicyType,
-        ProjectPermissions, Proposal, ProposalOperation,
+        approval_policy_repository, proposal_repository, proposal_repository::VoteOutcome,
+        OperationType, PolicyType, ProjectPermissions, Proposal, ProposalOperation, Vote,
     },
     dto::{CreateProposalRequest, CreateProposalResponse},
     mapping::{map_create_proposal_request, map_create_proposal_response},
@@ -32,57 +32,72 @@ pub async fn create_proposal(
 }
 
 async fn process_proposal(project_id: Uuid, proposal_id: Uuid, proposal: Proposal) -> ApiResult {
-    match proposal.operation {
-        ProposalOperation::CreateCanister => {
-            let approval_policy =
-                approval_policy_repository::get_project_approval_policy_by_operation_type(
-                    project_id,
-                    OperationType::CreateCanister,
-                )
-                .unwrap_or_default();
+    let approval_policy =
+        approval_policy_repository::get_project_approval_policy_by_operation_type(
+            project_id,
+            operation_type_of(&proposal.operation),
+        )
+        .unwrap_or_default();
 
-            match approval_policy.policy_type {
-                PolicyType::AutoApprove => {
-                    proposal_repository::set_proposal_executing(proposal_id)?;
-                    match canister_service::create_my_canister(project_id).await {
-                        Ok(_) => {
-                            proposal_repository::set_proposal_executed(proposal_id)?;
-                        }
-                        Err(err) => {
-                            proposal_repository::set_proposal_failed(proposal_id, err)?;
-                        }
-                    }
-                }
-            }
+    match approval_policy.policy_type {
+        PolicyType::AutoApprove => {
+            execute_operation(project_id, proposal_id, proposal.operation).await
         }
+    }
+}
+
+fn operation_type_of(operation: &ProposalOperation) -> OperationType {
+    match operation {
+        ProposalOperation::CreateCanister => OperationType::CreateCanister,
+        ProposalOperation::AddCanisterController { .. } => OperationType::AddCanisterController,
+    }
+}
+
+async fn execute_operation(
+    project_id: Uuid,
+    proposal_id: Uuid,
+    operation: ProposalOperation,
+) -> ApiResult {
+    proposal_repository::set_proposal_executing(proposal_id)?;
+
+    let result = match operation {
+        ProposalOperation::CreateCanister => canister_service::create_my_canister(project_id).await,
         ProposalOperation::AddCanisterController {
             canister_id,
             controller_id,
-        } => {
-            let approval_policy =
-                approval_policy_repository::get_project_approval_policy_by_operation_type(
-                    project_id,
-                    OperationType::AddCanisterController,
-                )
-                .unwrap_or_default();
+        } => canister_service::add_canister_controller(canister_id, controller_id).await,
+    };
 
-            match approval_policy.policy_type {
-                PolicyType::AutoApprove => {
-                    proposal_repository::set_proposal_executing(proposal_id)?;
-                    match canister_service::add_canister_controller(canister_id, controller_id)
-                        .await
-                    {
-                        Ok(()) => {
-                            proposal_repository::set_proposal_executed(proposal_id)?;
-                        }
-                        Err(err) => {
-                            proposal_repository::set_proposal_failed(proposal_id, err)?;
-                        }
-                    }
-                }
-            }
-        }
+    match result {
+        Ok(()) => proposal_repository::set_proposal_executed(proposal_id),
+        Err(err) => proposal_repository::set_proposal_failed(proposal_id, err),
+    }
+}
+
+#[allow(dead_code)]
+pub async fn vote_proposal(
+    caller: &Principal,
+    proposal_id: Uuid,
+    vote: Vote,
+) -> ApiResult<Proposal> {
+    let proposal = proposal_repository::get_proposal(&proposal_id)
+        .ok_or_else(|| ApiError::client_error(format!("Proposal {proposal_id} does not exist.")))?;
+
+    ProjectAuth::require(
+        caller,
+        proposal.project_id,
+        ProjectPermissions::PROPOSAL_APPROVE,
+    )?;
+
+    let outcome = proposal_repository::record_proposal_vote(proposal_id, *caller, vote)?;
+
+    if let VoteOutcome::ReachedApproval = outcome {
+        execute_operation(proposal.project_id, proposal_id, proposal.operation.clone()).await?;
     }
 
-    Ok(())
+    proposal_repository::get_proposal(&proposal_id).ok_or_else(|| {
+        ApiError::internal_error(format!(
+            "Could not find proposal {proposal_id} after voting"
+        ))
+    })
 }


### PR DESCRIPTION
Extend ProposalStatus with PendingApproval { threshold, approvers, votes } and add a Vote enum. Approvers are snapshotted onto the proposal at transition time so mid-vote policy changes can't race.