### PR TITLE
feat: add FixedQuorum approval policy and expose upsert/vote endpoints

### DIFF
--- a/src/backend-api/candid/approval_policies.did
+++ b/src/backend-api/candid/approval_policies.did
@@ -11,12 +11,34 @@ type ListProjectApprovalPoliciesRequest = record {
   project_id : text;
 };
 
+type UpsertApprovalPolicyRequest = record {
+  project_id : text;
+  operation_type : OperationType;
+  policy_type : PolicyType;
+};
+
+type UpsertApprovalPolicyResponse = variant {
+  Ok : ApprovalPolicy;
+  Err : ApiError;
+};
+
 type ApprovalPolicy = record {
   id : text;
-  operation_type : text;
-  policy_type : text;
+  operation_type : OperationType;
+  policy_type : PolicyType;
+};
+
+type OperationType = variant {
+  CreateCanister : record {};
+  AddCanisterController : record {};
+};
+
+type PolicyType = variant {
+  AutoApprove : record {};
+  FixedQuorum : record { threshold : nat32 };
 };
 
 service : {
   list_project_approval_policies : (ListProjectApprovalPoliciesRequest) -> (ListProjectApprovalPoliciesResponse) query;
+  upsert_approval_policy : (UpsertApprovalPolicyRequest) -> (UpsertApprovalPolicyResponse);
 };

--- a/src/backend-api/candid/proposal.did
+++ b/src/backend-api/candid/proposal.did
@@ -10,6 +10,16 @@ type CreateProposalResponse = variant {
   Err : ApiError;
 };
 
+type VoteProposalRequest = record {
+  proposal_id : text;
+  vote : Vote;
+};
+
+type VoteProposalResponse = variant {
+  Ok : Proposal;
+  Err : ApiError;
+};
+
 type Proposal = record {
   id : text;
   project_id : text;
@@ -52,4 +62,5 @@ type ProposalOperation = variant {
 
 service : {
   create_proposal : (CreateProposalRequest) -> (CreateProposalResponse);
+  vote_proposal : (VoteProposalRequest) -> (VoteProposalResponse);
 };

--- a/src/backend-tests/src/support/user-driver.ts
+++ b/src/backend-tests/src/support/user-driver.ts
@@ -4,13 +4,20 @@ import {
   type PocketIc,
 } from '@dfinity/pic';
 import type { Principal } from '@icp-sdk/core/principal';
-import { idlFactory, type _SERVICE, type UserProfile } from '@ssn/backend-api';
+import {
+  idlFactory,
+  type _SERVICE,
+  type Organization,
+  type UserProfile,
+} from '@ssn/backend-api';
 import type { Identity } from '@icp-sdk/core/agent';
 import {
   anonymousIdentity,
   controllerIdentity,
   extractOkResponse,
 } from '@ssn/test-utils';
+
+export type ActivatedUser = [Identity, UserProfile, Organization];
 
 export class UserDriver {
   private readonly actor: Actor<_SERVICE>;
@@ -19,12 +26,18 @@ export class UserDriver {
     this.actor = pic.createActor<_SERVICE>(idlFactory, canisterId);
   }
 
-  public async createUser(): Promise<[Identity, UserProfile]> {
+  public async createUser(): Promise<ActivatedUser> {
     const identity = generateRandomIdentity();
     this.actor.setIdentity(identity);
 
     const profileRes = await this.actor.create_my_user_profile();
     const profile = extractOkResponse(profileRes);
+
+    const orgsRes = await this.actor.list_my_organizations();
+    const [org] = extractOkResponse(orgsRes);
+    if (!org) {
+      throw new Error('Expected default organization after signup');
+    }
 
     this.actor.setIdentity(controllerIdentity);
     await this.actor.update_user_profile({
@@ -34,6 +47,38 @@ export class UserDriver {
 
     this.actor.setIdentity(anonymousIdentity);
 
-    return [identity, profile];
+    return [identity, profile, org];
+  }
+
+  public async inviteIntoOrgAndDefaultTeam(
+    host: ActivatedUser,
+    guest: ActivatedUser,
+  ): Promise<void> {
+    const [hostIdentity, , hostOrg] = host;
+    const [guestIdentity, guestProfile] = guest;
+
+    this.actor.setIdentity(hostIdentity);
+    const teamsRes = await this.actor.list_org_teams({ org_id: hostOrg.id });
+    const [defaultTeam] = extractOkResponse(teamsRes);
+    if (!defaultTeam) {
+      throw new Error('Expected default team after signup');
+    }
+
+    const inviteRes = await this.actor.create_org_invite({
+      org_id: hostOrg.id,
+      target: { UserId: guestProfile.id },
+    });
+    const { invite } = extractOkResponse(inviteRes);
+
+    this.actor.setIdentity(guestIdentity);
+    await this.actor.accept_org_invite({ invite_id: invite.id });
+
+    this.actor.setIdentity(hostIdentity);
+    await this.actor.add_user_to_team({
+      team_id: defaultTeam.id,
+      user_id: guestProfile.id,
+    });
+
+    this.actor.setIdentity(anonymousIdentity);
   }
 }

--- a/src/backend-tests/src/tests/approval-policy.spec.ts
+++ b/src/backend-tests/src/tests/approval-policy.spec.ts
@@ -1,0 +1,349 @@
+import { generateRandomIdentity } from '@dfinity/pic';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { TestDriver } from '../support';
+import {
+  anonymousIdentity,
+  controllerIdentity,
+  extractOkResponse,
+} from '@ssn/test-utils';
+import type { ApprovalPolicy, Proposal } from '@ssn/backend-api';
+
+async function createActivatedUser(driver: TestDriver) {
+  const identity = generateRandomIdentity();
+  driver.actor.setIdentity(identity);
+  const profileRes = await driver.actor.create_my_user_profile();
+  const profile = extractOkResponse(profileRes);
+  const orgsRes = await driver.actor.list_my_organizations();
+  const [org] = extractOkResponse(orgsRes);
+  if (!org) {
+    throw new Error('Expected default organization after signup');
+  }
+
+  driver.actor.setIdentity(controllerIdentity);
+  await driver.actor.update_user_profile({
+    user_id: profile.id,
+    status: [{ Active: null }],
+  });
+
+  driver.actor.setIdentity(identity);
+  return { identity, profile, org };
+}
+
+async function inviteUserIntoOrgAndDefaultTeam(
+  driver: TestDriver,
+  host: Awaited<ReturnType<typeof createActivatedUser>>,
+  guest: Awaited<ReturnType<typeof createActivatedUser>>,
+) {
+  driver.actor.setIdentity(host.identity);
+  const teamsRes = await driver.actor.list_org_teams({ org_id: host.org.id });
+  const [defaultTeam] = extractOkResponse(teamsRes);
+  if (!defaultTeam) {
+    throw new Error('Expected default team after signup');
+  }
+
+  const inviteRes = await driver.actor.create_org_invite({
+    org_id: host.org.id,
+    target: { UserId: guest.profile.id },
+  });
+  const { invite } = extractOkResponse(inviteRes);
+
+  driver.actor.setIdentity(guest.identity);
+  await driver.actor.accept_org_invite({ invite_id: invite.id });
+
+  driver.actor.setIdentity(host.identity);
+  await driver.actor.add_user_to_team({
+    team_id: defaultTeam.id,
+    user_id: guest.profile.id,
+  });
+}
+
+async function expectPendingApproval(
+  proposal: Proposal,
+  expected: { threshold: number; approverCount: number; voteCount: number },
+): Promise<void> {
+  const [status] = proposal.status;
+  if (!status || !('PendingApproval' in status)) {
+    throw new Error(
+      `expected PendingApproval, got ${JSON.stringify(proposal.status)}`,
+    );
+  }
+  expect(status.PendingApproval.threshold).toBe(expected.threshold);
+  expect(status.PendingApproval.approvers.length).toBe(expected.approverCount);
+  expect(status.PendingApproval.votes.length).toBe(expected.voteCount);
+}
+
+function expectStatusTag(proposal: Proposal, tag: string): void {
+  const [status] = proposal.status;
+  if (!status || !(tag in status)) {
+    throw new Error(
+      `expected status ${tag}, got ${JSON.stringify(proposal.status)}`,
+    );
+  }
+}
+
+describe('Approval Policy + Proposal Voting', () => {
+  let driver: TestDriver;
+
+  beforeEach(async () => {
+    driver = await TestDriver.create();
+  });
+
+  afterEach(async () => {
+    await driver.tearDown();
+  });
+
+  describe('upsert_approval_policy', () => {
+    it('should reject FixedQuorum with threshold 0', async () => {
+      const alice = await createActivatedUser(driver);
+      const project = await driver.getDefaultProject();
+
+      driver.actor.setIdentity(alice.identity);
+      const res = await driver.actor.upsert_approval_policy({
+        project_id: project.id,
+        operation_type: { CreateCanister: {} },
+        policy_type: { FixedQuorum: { threshold: 0 } },
+      });
+      expect(res).toEqual({
+        Err: {
+          code: [{ ClientError: {} }],
+          message: 'FixedQuorum threshold must be at least 1.',
+        },
+      });
+    });
+
+    it('should reject an unauthenticated caller', async () => {
+      driver.actor.setIdentity(anonymousIdentity);
+      const res = await driver.actor.upsert_approval_policy({
+        project_id: 'does-not-matter',
+        operation_type: { CreateCanister: {} },
+        policy_type: { AutoApprove: {} },
+      });
+      expect(res).toEqual({
+        Err: {
+          code: [{ Unauthenticated: {} }],
+          message:
+            'Anonymous principals are not allowed to perform this action.',
+        },
+      });
+    });
+
+    it('should persist FixedQuorum and surface it via list_project_approval_policies', async () => {
+      const alice = await createActivatedUser(driver);
+      const project = await driver.getDefaultProject();
+
+      driver.actor.setIdentity(alice.identity);
+      const upsertRes = await driver.actor.upsert_approval_policy({
+        project_id: project.id,
+        operation_type: { CreateCanister: {} },
+        policy_type: { FixedQuorum: { threshold: 2 } },
+      });
+      const policy = extractOkResponse(upsertRes);
+      expect(policy.policy_type).toEqual({ FixedQuorum: { threshold: 2 } });
+      expect(policy.operation_type).toEqual({ CreateCanister: {} });
+
+      const listRes = await driver.actor.list_project_approval_policies({
+        project_id: project.id,
+      });
+      const { approval_policies } = extractOkResponse(listRes);
+      const createCanisterPolicy = approval_policies.find(
+        (p: ApprovalPolicy) => 'CreateCanister' in p.operation_type,
+      );
+      expect(createCanisterPolicy?.policy_type).toEqual({
+        FixedQuorum: { threshold: 2 },
+      });
+    });
+  });
+
+  describe('FixedQuorum end-to-end', () => {
+    it('should drive a proposal through approvals to Executed', async () => {
+      const alice = await createActivatedUser(driver);
+      const bob = await createActivatedUser(driver);
+      await inviteUserIntoOrgAndDefaultTeam(driver, alice, bob);
+
+      driver.actor.setIdentity(alice.identity);
+      const project = await driver.getDefaultProject();
+
+      await driver.actor.upsert_approval_policy({
+        project_id: project.id,
+        operation_type: { CreateCanister: {} },
+        policy_type: { FixedQuorum: { threshold: 2 } },
+      });
+
+      const createRes = await driver.actor.create_proposal({
+        project_id: project.id,
+        operation: [{ CreateCanister: {} }],
+      });
+      const pending = extractOkResponse(createRes);
+      await expectPendingApproval(pending, {
+        threshold: 2,
+        approverCount: 2,
+        voteCount: 0,
+      });
+
+      driver.actor.setIdentity(alice.identity);
+      const aliceVote = await driver.actor.vote_proposal({
+        proposal_id: pending.id,
+        vote: { Approve: {} },
+      });
+      const afterAlice = extractOkResponse(aliceVote);
+      await expectPendingApproval(afterAlice, {
+        threshold: 2,
+        approverCount: 2,
+        voteCount: 1,
+      });
+
+      driver.actor.setIdentity(bob.identity);
+      const bobVote = await driver.actor.vote_proposal({
+        proposal_id: pending.id,
+        vote: { Approve: {} },
+      });
+      const executed = extractOkResponse(bobVote);
+      expectStatusTag(executed, 'Executed');
+    });
+
+    it('should flip to Rejected once the threshold becomes unreachable', async () => {
+      const alice = await createActivatedUser(driver);
+      const bob = await createActivatedUser(driver);
+      await inviteUserIntoOrgAndDefaultTeam(driver, alice, bob);
+
+      driver.actor.setIdentity(alice.identity);
+      const project = await driver.getDefaultProject();
+      await driver.actor.upsert_approval_policy({
+        project_id: project.id,
+        operation_type: { CreateCanister: {} },
+        policy_type: { FixedQuorum: { threshold: 2 } },
+      });
+
+      const createRes = await driver.actor.create_proposal({
+        project_id: project.id,
+        operation: [{ CreateCanister: {} }],
+      });
+      const pending = extractOkResponse(createRes);
+
+      // With 2 approvers and threshold 2, any single reject makes the
+      // threshold unreachable (rejections > N - threshold = 0).
+      driver.actor.setIdentity(alice.identity);
+      const aliceVote = await driver.actor.vote_proposal({
+        proposal_id: pending.id,
+        vote: { Reject: {} },
+      });
+      const rejected = extractOkResponse(aliceVote);
+      expectStatusTag(rejected, 'Rejected');
+
+      // A subsequent vote from Bob must be rejected — proposal is no longer
+      // in PendingApproval.
+      driver.actor.setIdentity(bob.identity);
+      const bobVote = await driver.actor.vote_proposal({
+        proposal_id: pending.id,
+        vote: { Reject: {} },
+      });
+      expect(bobVote).toEqual({
+        Err: {
+          code: [{ ClientError: {} }],
+          message: `Proposal ${pending.id} is not pending approval.`,
+        },
+      });
+    });
+
+    it('should reject proposal creation when FixedQuorum requires more approvers than exist', async () => {
+      const alice = await createActivatedUser(driver);
+      const project = await driver.getDefaultProject();
+
+      driver.actor.setIdentity(alice.identity);
+      await driver.actor.upsert_approval_policy({
+        project_id: project.id,
+        operation_type: { CreateCanister: {} },
+        policy_type: { FixedQuorum: { threshold: 2 } },
+      });
+
+      const res = await driver.actor.create_proposal({
+        project_id: project.id,
+        operation: [{ CreateCanister: {} }],
+      });
+      expect(res).toEqual({
+        Err: {
+          code: [{ ClientError: {} }],
+          message: `FixedQuorum policy requires 2 approvers but project ${project.id} only has 1.`,
+        },
+      });
+    });
+
+    it('should reject a vote from a principal without PROPOSAL_APPROVE on the project', async () => {
+      const alice = await createActivatedUser(driver);
+      const bob = await createActivatedUser(driver);
+      await inviteUserIntoOrgAndDefaultTeam(driver, alice, bob);
+
+      driver.actor.setIdentity(alice.identity);
+      const project = await driver.getDefaultProject();
+      await driver.actor.upsert_approval_policy({
+        project_id: project.id,
+        operation_type: { CreateCanister: {} },
+        policy_type: { FixedQuorum: { threshold: 2 } },
+      });
+
+      const createRes = await driver.actor.create_proposal({
+        project_id: project.id,
+        operation: [{ CreateCanister: {} }],
+      });
+      const pending = extractOkResponse(createRes);
+
+      // Carol is in Alice's org but on a team with no project link.
+      const carol = await createActivatedUser(driver);
+      driver.actor.setIdentity(alice.identity);
+      const inviteRes = await driver.actor.create_org_invite({
+        org_id: alice.org.id,
+        target: { UserId: carol.profile.id },
+      });
+      const { invite } = extractOkResponse(inviteRes);
+      driver.actor.setIdentity(carol.identity);
+      await driver.actor.accept_org_invite({ invite_id: invite.id });
+
+      const carolVote = await driver.actor.vote_proposal({
+        proposal_id: pending.id,
+        vote: { Approve: {} },
+      });
+      expect(carolVote).toEqual({
+        Err: {
+          code: [{ Unauthorized: {} }],
+          message: `User with id ${carol.profile.id} does not have access to project with id ${project.id}`,
+        },
+      });
+    });
+
+    it('should reject a duplicate vote from the same approver', async () => {
+      const alice = await createActivatedUser(driver);
+      const bob = await createActivatedUser(driver);
+      await inviteUserIntoOrgAndDefaultTeam(driver, alice, bob);
+
+      driver.actor.setIdentity(alice.identity);
+      const project = await driver.getDefaultProject();
+      await driver.actor.upsert_approval_policy({
+        project_id: project.id,
+        operation_type: { CreateCanister: {} },
+        policy_type: { FixedQuorum: { threshold: 2 } },
+      });
+
+      const createRes = await driver.actor.create_proposal({
+        project_id: project.id,
+        operation: [{ CreateCanister: {} }],
+      });
+      const pending = extractOkResponse(createRes);
+
+      driver.actor.setIdentity(alice.identity);
+      await driver.actor.vote_proposal({
+        proposal_id: pending.id,
+        vote: { Approve: {} },
+      });
+      const second = await driver.actor.vote_proposal({
+        proposal_id: pending.id,
+        vote: { Reject: {} },
+      });
+      expect(second).toEqual({
+        Err: {
+          code: [{ ClientError: {} }],
+          message: `Principal ${alice.identity.getPrincipal()} has already voted on proposal ${pending.id}.`,
+        },
+      });
+    });
+  });
+});

--- a/src/backend-tests/src/tests/approval-policy.spec.ts
+++ b/src/backend-tests/src/tests/approval-policy.spec.ts
@@ -1,61 +1,7 @@
-import { generateRandomIdentity } from '@dfinity/pic';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { TestDriver } from '../support';
-import {
-  anonymousIdentity,
-  controllerIdentity,
-  extractOkResponse,
-} from '@ssn/test-utils';
+import { anonymousIdentity, extractOkResponse } from '@ssn/test-utils';
 import type { ApprovalPolicy, Proposal } from '@ssn/backend-api';
-
-async function createActivatedUser(driver: TestDriver) {
-  const identity = generateRandomIdentity();
-  driver.actor.setIdentity(identity);
-  const profileRes = await driver.actor.create_my_user_profile();
-  const profile = extractOkResponse(profileRes);
-  const orgsRes = await driver.actor.list_my_organizations();
-  const [org] = extractOkResponse(orgsRes);
-  if (!org) {
-    throw new Error('Expected default organization after signup');
-  }
-
-  driver.actor.setIdentity(controllerIdentity);
-  await driver.actor.update_user_profile({
-    user_id: profile.id,
-    status: [{ Active: null }],
-  });
-
-  driver.actor.setIdentity(identity);
-  return { identity, profile, org };
-}
-
-async function inviteUserIntoOrgAndDefaultTeam(
-  driver: TestDriver,
-  host: Awaited<ReturnType<typeof createActivatedUser>>,
-  guest: Awaited<ReturnType<typeof createActivatedUser>>,
-) {
-  driver.actor.setIdentity(host.identity);
-  const teamsRes = await driver.actor.list_org_teams({ org_id: host.org.id });
-  const [defaultTeam] = extractOkResponse(teamsRes);
-  if (!defaultTeam) {
-    throw new Error('Expected default team after signup');
-  }
-
-  const inviteRes = await driver.actor.create_org_invite({
-    org_id: host.org.id,
-    target: { UserId: guest.profile.id },
-  });
-  const { invite } = extractOkResponse(inviteRes);
-
-  driver.actor.setIdentity(guest.identity);
-  await driver.actor.accept_org_invite({ invite_id: invite.id });
-
-  driver.actor.setIdentity(host.identity);
-  await driver.actor.add_user_to_team({
-    team_id: defaultTeam.id,
-    user_id: guest.profile.id,
-  });
-}
 
 async function expectPendingApproval(
   proposal: Proposal,
@@ -94,10 +40,10 @@ describe('Approval Policy + Proposal Voting', () => {
 
   describe('upsert_approval_policy', () => {
     it('should reject FixedQuorum with threshold 0', async () => {
-      const alice = await createActivatedUser(driver);
+      const [aliceIdentity] = await driver.users.createUser();
+      driver.actor.setIdentity(aliceIdentity);
       const project = await driver.getDefaultProject();
 
-      driver.actor.setIdentity(alice.identity);
       const res = await driver.actor.upsert_approval_policy({
         project_id: project.id,
         operation_type: { CreateCanister: {} },
@@ -128,10 +74,10 @@ describe('Approval Policy + Proposal Voting', () => {
     });
 
     it('should persist FixedQuorum and surface it via list_project_approval_policies', async () => {
-      const alice = await createActivatedUser(driver);
+      const [aliceIdentity] = await driver.users.createUser();
+      driver.actor.setIdentity(aliceIdentity);
       const project = await driver.getDefaultProject();
 
-      driver.actor.setIdentity(alice.identity);
       const upsertRes = await driver.actor.upsert_approval_policy({
         project_id: project.id,
         operation_type: { CreateCanister: {} },
@@ -156,11 +102,13 @@ describe('Approval Policy + Proposal Voting', () => {
 
   describe('FixedQuorum end-to-end', () => {
     it('should drive a proposal through approvals to Executed', async () => {
-      const alice = await createActivatedUser(driver);
-      const bob = await createActivatedUser(driver);
-      await inviteUserIntoOrgAndDefaultTeam(driver, alice, bob);
+      const alice = await driver.users.createUser();
+      const bob = await driver.users.createUser();
+      await driver.users.inviteIntoOrgAndDefaultTeam(alice, bob);
 
-      driver.actor.setIdentity(alice.identity);
+      const [aliceIdentity] = alice;
+      const [bobIdentity] = bob;
+      driver.actor.setIdentity(aliceIdentity);
       const project = await driver.getDefaultProject();
 
       await driver.actor.upsert_approval_policy({
@@ -180,7 +128,7 @@ describe('Approval Policy + Proposal Voting', () => {
         voteCount: 0,
       });
 
-      driver.actor.setIdentity(alice.identity);
+      driver.actor.setIdentity(aliceIdentity);
       const aliceVote = await driver.actor.vote_proposal({
         proposal_id: pending.id,
         vote: { Approve: {} },
@@ -192,7 +140,7 @@ describe('Approval Policy + Proposal Voting', () => {
         voteCount: 1,
       });
 
-      driver.actor.setIdentity(bob.identity);
+      driver.actor.setIdentity(bobIdentity);
       const bobVote = await driver.actor.vote_proposal({
         proposal_id: pending.id,
         vote: { Approve: {} },
@@ -202,11 +150,13 @@ describe('Approval Policy + Proposal Voting', () => {
     });
 
     it('should flip to Rejected once the threshold becomes unreachable', async () => {
-      const alice = await createActivatedUser(driver);
-      const bob = await createActivatedUser(driver);
-      await inviteUserIntoOrgAndDefaultTeam(driver, alice, bob);
+      const alice = await driver.users.createUser();
+      const bob = await driver.users.createUser();
+      await driver.users.inviteIntoOrgAndDefaultTeam(alice, bob);
 
-      driver.actor.setIdentity(alice.identity);
+      const [aliceIdentity] = alice;
+      const [bobIdentity] = bob;
+      driver.actor.setIdentity(aliceIdentity);
       const project = await driver.getDefaultProject();
       await driver.actor.upsert_approval_policy({
         project_id: project.id,
@@ -222,7 +172,7 @@ describe('Approval Policy + Proposal Voting', () => {
 
       // With 2 approvers and threshold 2, any single reject makes the
       // threshold unreachable (rejections > N - threshold = 0).
-      driver.actor.setIdentity(alice.identity);
+      driver.actor.setIdentity(aliceIdentity);
       const aliceVote = await driver.actor.vote_proposal({
         proposal_id: pending.id,
         vote: { Reject: {} },
@@ -232,7 +182,7 @@ describe('Approval Policy + Proposal Voting', () => {
 
       // A subsequent vote from Bob must be rejected — proposal is no longer
       // in PendingApproval.
-      driver.actor.setIdentity(bob.identity);
+      driver.actor.setIdentity(bobIdentity);
       const bobVote = await driver.actor.vote_proposal({
         proposal_id: pending.id,
         vote: { Reject: {} },
@@ -246,10 +196,10 @@ describe('Approval Policy + Proposal Voting', () => {
     });
 
     it('should reject proposal creation when FixedQuorum requires more approvers than exist', async () => {
-      const alice = await createActivatedUser(driver);
+      const [aliceIdentity] = await driver.users.createUser();
+      driver.actor.setIdentity(aliceIdentity);
       const project = await driver.getDefaultProject();
 
-      driver.actor.setIdentity(alice.identity);
       await driver.actor.upsert_approval_policy({
         project_id: project.id,
         operation_type: { CreateCanister: {} },
@@ -269,11 +219,12 @@ describe('Approval Policy + Proposal Voting', () => {
     });
 
     it('should reject a vote from a principal without PROPOSAL_APPROVE on the project', async () => {
-      const alice = await createActivatedUser(driver);
-      const bob = await createActivatedUser(driver);
-      await inviteUserIntoOrgAndDefaultTeam(driver, alice, bob);
+      const alice = await driver.users.createUser();
+      const bob = await driver.users.createUser();
+      await driver.users.inviteIntoOrgAndDefaultTeam(alice, bob);
 
-      driver.actor.setIdentity(alice.identity);
+      const [aliceIdentity, , aliceOrg] = alice;
+      driver.actor.setIdentity(aliceIdentity);
       const project = await driver.getDefaultProject();
       await driver.actor.upsert_approval_policy({
         project_id: project.id,
@@ -288,14 +239,14 @@ describe('Approval Policy + Proposal Voting', () => {
       const pending = extractOkResponse(createRes);
 
       // Carol is in Alice's org but on a team with no project link.
-      const carol = await createActivatedUser(driver);
-      driver.actor.setIdentity(alice.identity);
+      const [carolIdentity, carolProfile] = await driver.users.createUser();
+      driver.actor.setIdentity(aliceIdentity);
       const inviteRes = await driver.actor.create_org_invite({
-        org_id: alice.org.id,
-        target: { UserId: carol.profile.id },
+        org_id: aliceOrg.id,
+        target: { UserId: carolProfile.id },
       });
       const { invite } = extractOkResponse(inviteRes);
-      driver.actor.setIdentity(carol.identity);
+      driver.actor.setIdentity(carolIdentity);
       await driver.actor.accept_org_invite({ invite_id: invite.id });
 
       const carolVote = await driver.actor.vote_proposal({
@@ -305,17 +256,18 @@ describe('Approval Policy + Proposal Voting', () => {
       expect(carolVote).toEqual({
         Err: {
           code: [{ Unauthorized: {} }],
-          message: `User with id ${carol.profile.id} does not have access to project with id ${project.id}`,
+          message: `User with id ${carolProfile.id} does not have access to project with id ${project.id}`,
         },
       });
     });
 
     it('should reject a duplicate vote from the same approver', async () => {
-      const alice = await createActivatedUser(driver);
-      const bob = await createActivatedUser(driver);
-      await inviteUserIntoOrgAndDefaultTeam(driver, alice, bob);
+      const alice = await driver.users.createUser();
+      const bob = await driver.users.createUser();
+      await driver.users.inviteIntoOrgAndDefaultTeam(alice, bob);
 
-      driver.actor.setIdentity(alice.identity);
+      const [aliceIdentity] = alice;
+      driver.actor.setIdentity(aliceIdentity);
       const project = await driver.getDefaultProject();
       await driver.actor.upsert_approval_policy({
         project_id: project.id,
@@ -329,7 +281,7 @@ describe('Approval Policy + Proposal Voting', () => {
       });
       const pending = extractOkResponse(createRes);
 
-      driver.actor.setIdentity(alice.identity);
+      driver.actor.setIdentity(aliceIdentity);
       await driver.actor.vote_proposal({
         proposal_id: pending.id,
         vote: { Approve: {} },
@@ -341,7 +293,7 @@ describe('Approval Policy + Proposal Voting', () => {
       expect(second).toEqual({
         Err: {
           code: [{ ClientError: {} }],
-          message: `Principal ${alice.identity.getPrincipal()} has already voted on proposal ${pending.id}.`,
+          message: `Principal ${aliceIdentity.getPrincipal()} has already voted on proposal ${pending.id}.`,
         },
       });
     });

--- a/src/backend-tests/src/tests/user-profile.spec.ts
+++ b/src/backend-tests/src/tests/user-profile.spec.ts
@@ -295,13 +295,13 @@ describe('User Profile', () => {
       expect(approvalPolicies.approval_policies).toHaveLength(2);
       expect(approvalPolicies.approval_policies).toContainEqual({
         id: expect.any(String),
-        operation_type: 'CreateCanister',
-        policy_type: 'AutoApprove',
+        operation_type: { CreateCanister: {} },
+        policy_type: { AutoApprove: {} },
       });
       expect(approvalPolicies.approval_policies).toContainEqual({
         id: expect.any(String),
-        operation_type: 'AddCanisterController',
-        policy_type: 'AutoApprove',
+        operation_type: { AddCanisterController: {} },
+        policy_type: { AutoApprove: {} },
       });
     });
 
@@ -357,13 +357,13 @@ describe('User Profile', () => {
       expect(approvalPolicies.approval_policies).toHaveLength(2);
       expect(approvalPolicies.approval_policies).toContainEqual({
         id: expect.any(String),
-        operation_type: 'CreateCanister',
-        policy_type: 'AutoApprove',
+        operation_type: { CreateCanister: {} },
+        policy_type: { AutoApprove: {} },
       });
       expect(approvalPolicies.approval_policies).toContainEqual({
         id: expect.any(String),
-        operation_type: 'AddCanisterController',
-        policy_type: 'AutoApprove',
+        operation_type: { AddCanisterController: {} },
+        policy_type: { AutoApprove: {} },
       });
     });
 

--- a/src/backend/src/controller/approval_policy.rs
+++ b/src/backend/src/controller/approval_policy.rs
@@ -1,6 +1,9 @@
 use crate::{
-    dto::{ListProjectApprovalPoliciesRequest, ListProjectApprovalPoliciesResponse},
-    service::approval_policy_service,
+    dto::{
+        ListProjectApprovalPoliciesRequest, ListProjectApprovalPoliciesResponse,
+        UpsertApprovalPolicyRequest, UpsertApprovalPolicyResponse,
+    },
+    service::{access_control_service, approval_policy_service},
 };
 use canister_utils::{assert_authenticated, ApiResultDto};
 use ic_cdk::{api::msg_caller, *};
@@ -15,4 +18,16 @@ fn list_project_approval_policies(
     }
 
     approval_policy_service::list_project_approval_policies(&caller, request).into()
+}
+
+#[update]
+fn upsert_approval_policy(
+    request: UpsertApprovalPolicyRequest,
+) -> ApiResultDto<UpsertApprovalPolicyResponse> {
+    let caller = msg_caller();
+    if let Err(err) = access_control_service::assert_has_platform_access(&caller) {
+        return ApiResultDto::Err(err);
+    }
+
+    approval_policy_service::upsert_approval_policy(&caller, request).into()
 }

--- a/src/backend/src/controller/proposal.rs
+++ b/src/backend/src/controller/proposal.rs
@@ -1,5 +1,7 @@
 use crate::{
-    dto::{CreateProposalRequest, CreateProposalResponse},
+    dto::{
+        CreateProposalRequest, CreateProposalResponse, VoteProposalRequest, VoteProposalResponse,
+    },
     service::{access_control_service, proposal_service},
 };
 use canister_utils::ApiResultDto;
@@ -13,6 +15,18 @@ async fn create_proposal(request: CreateProposalRequest) -> ApiResultDto<CreateP
     }
 
     proposal_service::create_proposal(&caller, request)
+        .await
+        .into()
+}
+
+#[update]
+async fn vote_proposal(request: VoteProposalRequest) -> ApiResultDto<VoteProposalResponse> {
+    let caller = msg_caller();
+    if let Err(err) = access_control_service::assert_has_platform_access(&caller) {
+        return ApiResultDto::Err(err);
+    }
+
+    proposal_service::vote_proposal(&caller, request)
         .await
         .into()
 }

--- a/src/backend/src/data/model/approval_policy.rs
+++ b/src/backend/src/data/model/approval_policy.rs
@@ -19,6 +19,7 @@ impl Default for ApprovalPolicy {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum PolicyType {
     AutoApprove,
+    FixedQuorum { threshold: u32 },
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/src/backend/src/data/proposal_repository.rs
+++ b/src/backend/src/data/proposal_repository.rs
@@ -31,7 +31,6 @@ pub fn get_proposal(proposal_id: &Uuid) -> Option<Proposal> {
     with_state(|s| s.proposals.get(proposal_id))
 }
 
-#[allow(dead_code)]
 pub fn set_proposal_pending_approval(
     proposal_id: Uuid,
     threshold: u32,

--- a/src/backend/src/dto/approval_policy.rs
+++ b/src/backend/src/dto/approval_policy.rs
@@ -12,8 +12,29 @@ pub struct ListProjectApprovalPoliciesResponse {
 }
 
 #[derive(Debug, Clone, Serialize, CandidType, Deserialize)]
+pub struct UpsertApprovalPolicyRequest {
+    pub project_id: String,
+    pub operation_type: OperationType,
+    pub policy_type: PolicyType,
+}
+
+pub type UpsertApprovalPolicyResponse = ApprovalPolicy;
+
+#[derive(Debug, Clone, Serialize, CandidType, Deserialize)]
 pub struct ApprovalPolicy {
     pub id: String,
-    pub operation_type: String,
-    pub policy_type: String,
+    pub operation_type: OperationType,
+    pub policy_type: PolicyType,
+}
+
+#[derive(Debug, Clone, Serialize, CandidType, Deserialize, PartialEq, Eq)]
+pub enum OperationType {
+    CreateCanister {},
+    AddCanisterController {},
+}
+
+#[derive(Debug, Clone, Serialize, CandidType, Deserialize, PartialEq, Eq)]
+pub enum PolicyType {
+    AutoApprove {},
+    FixedQuorum { threshold: u32 },
 }

--- a/src/backend/src/dto/proposal.rs
+++ b/src/backend/src/dto/proposal.rs
@@ -10,6 +10,14 @@ pub struct CreateProposalRequest {
 pub type CreateProposalResponse = Proposal;
 
 #[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct VoteProposalRequest {
+    pub proposal_id: String,
+    pub vote: Vote,
+}
+
+pub type VoteProposalResponse = Proposal;
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
 pub struct Proposal {
     pub id: String,
     pub project_id: String,

--- a/src/backend/src/mapping/approval_policy.rs
+++ b/src/backend/src/mapping/approval_policy.rs
@@ -1,8 +1,11 @@
 use crate::{
     data,
-    dto::{ApprovalPolicy, ListProjectApprovalPoliciesResponse},
+    dto::{
+        ApprovalPolicy, ListProjectApprovalPoliciesResponse, OperationType, PolicyType,
+        UpsertApprovalPolicyRequest,
+    },
 };
-use canister_utils::Uuid;
+use canister_utils::{ApiError, ApiResult, Uuid};
 
 pub fn map_list_project_approval_policies_response(
     policies: Vec<(Uuid, data::OperationType, data::ApprovalPolicy)>,
@@ -20,7 +23,89 @@ pub fn map_approval_policy_response(
 ) -> ApprovalPolicy {
     ApprovalPolicy {
         id: id.to_string(),
-        operation_type: format!("{:?}", operation_type),
-        policy_type: format!("{:?}", policy.policy_type),
+        operation_type: map_operation_type_out(operation_type),
+        policy_type: map_policy_type_out(policy.policy_type),
+    }
+}
+
+pub fn map_upsert_approval_policy_request(
+    req: UpsertApprovalPolicyRequest,
+) -> ApiResult<(Uuid, data::OperationType, data::ApprovalPolicy)> {
+    let project_id = Uuid::try_from(req.project_id.as_str())?;
+    let operation_type = map_operation_type_in(req.operation_type);
+    let policy_type = map_policy_type_in(req.policy_type)?;
+    Ok((
+        project_id,
+        operation_type,
+        data::ApprovalPolicy { policy_type },
+    ))
+}
+
+fn map_operation_type_out(op: data::OperationType) -> OperationType {
+    match op {
+        data::OperationType::CreateCanister => OperationType::CreateCanister {},
+        data::OperationType::AddCanisterController => OperationType::AddCanisterController {},
+        // Noop is an internal sentinel used for index-range bounds and is
+        // never persisted as a real policy's operation_type.
+        data::OperationType::Noop => OperationType::CreateCanister {},
+    }
+}
+
+fn map_operation_type_in(op: OperationType) -> data::OperationType {
+    match op {
+        OperationType::CreateCanister {} => data::OperationType::CreateCanister,
+        OperationType::AddCanisterController {} => data::OperationType::AddCanisterController,
+    }
+}
+
+fn map_policy_type_out(policy: data::PolicyType) -> PolicyType {
+    match policy {
+        data::PolicyType::AutoApprove => PolicyType::AutoApprove {},
+        data::PolicyType::FixedQuorum { threshold } => PolicyType::FixedQuorum { threshold },
+    }
+}
+
+fn map_policy_type_in(policy: PolicyType) -> ApiResult<data::PolicyType> {
+    match policy {
+        PolicyType::AutoApprove {} => Ok(data::PolicyType::AutoApprove),
+        PolicyType::FixedQuorum { threshold } => {
+            if threshold < 1 {
+                return Err(ApiError::client_error(
+                    "FixedQuorum threshold must be at least 1.".to_string(),
+                ));
+            }
+            Ok(data::PolicyType::FixedQuorum { threshold })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use canister_utils::Uuid;
+
+    #[test]
+    fn upsert_request_rejects_zero_threshold() {
+        let err = map_upsert_approval_policy_request(UpsertApprovalPolicyRequest {
+            project_id: Uuid::new().to_string(),
+            operation_type: OperationType::CreateCanister {},
+            policy_type: PolicyType::FixedQuorum { threshold: 0 },
+        })
+        .unwrap_err();
+        assert!(err.message().contains("at least 1"));
+    }
+
+    #[test]
+    fn upsert_request_accepts_valid_fixed_quorum() {
+        let result = map_upsert_approval_policy_request(UpsertApprovalPolicyRequest {
+            project_id: Uuid::new().to_string(),
+            operation_type: OperationType::AddCanisterController {},
+            policy_type: PolicyType::FixedQuorum { threshold: 2 },
+        })
+        .unwrap();
+        assert_eq!(
+            result.2.policy_type,
+            data::PolicyType::FixedQuorum { threshold: 2 }
+        );
     }
 }

--- a/src/backend/src/mapping/proposal.rs
+++ b/src/backend/src/mapping/proposal.rs
@@ -2,7 +2,7 @@ use crate::{
     data,
     dto::{
         CreateProposalRequest, CreateProposalResponse, ProposalOperation, ProposalStatus,
-        ProposalVote, Vote,
+        ProposalVote, Vote, VoteProposalRequest,
     },
 };
 use canister_utils::{ApiError, ApiResult, Uuid};
@@ -12,6 +12,15 @@ fn map_vote(vote: data::Vote) -> Vote {
         data::Vote::Approve => Vote::Approve {},
         data::Vote::Reject => Vote::Reject {},
     }
+}
+
+pub fn map_vote_proposal_request(req: VoteProposalRequest) -> ApiResult<(Uuid, data::Vote)> {
+    let proposal_id = Uuid::try_from(req.proposal_id.as_str())?;
+    let vote = match req.vote {
+        Vote::Approve {} => data::Vote::Approve,
+        Vote::Reject {} => data::Vote::Reject,
+    };
+    Ok((proposal_id, vote))
 }
 
 pub fn map_create_proposal_request(

--- a/src/backend/src/service/access_control_service.rs
+++ b/src/backend/src/service/access_control_service.rs
@@ -213,6 +213,39 @@ impl ProjectAuth {
     }
 }
 
+// Collect the set of principals that currently hold a given permission on a
+// project, by walking all teams linked to the project, keeping those whose
+// team-project permissions include `needed`, and unioning the principals
+// registered against each member user. Used when snapshotting approvers onto
+// a proposal at the moment it transitions to PendingApproval.
+pub fn list_project_principals_with_permission(
+    project_id: Uuid,
+    needed: ProjectPermissions,
+) -> Vec<Principal> {
+    let mut principals = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    for team_id in project_repository::list_project_team_ids(project_id) {
+        let Some(perms) = project_repository::get_project_team_permissions(project_id, team_id)
+        else {
+            continue;
+        };
+        if !perms.contains(needed) {
+            continue;
+        }
+
+        for user_id in team_repository::list_team_user_ids(team_id) {
+            for principal in user_profile_repository::get_principals_by_user_id(user_id) {
+                if seen.insert(principal) {
+                    principals.push(principal);
+                }
+            }
+        }
+    }
+
+    principals
+}
+
 // Resolve a team id and enforce that the caller has org-level access to it
 // with the required permissions. Returns the team together with the
 // resulting `OrgAuth` (useful when the caller needs both the team record

--- a/src/backend/src/service/approval_policy_service.rs
+++ b/src/backend/src/service/approval_policy_service.rs
@@ -1,7 +1,13 @@
 use crate::{
-    data::{approval_policy_repository, ProjectPermissions},
-    dto::{ListProjectApprovalPoliciesRequest, ListProjectApprovalPoliciesResponse},
-    mapping::map_list_project_approval_policies_response,
+    data::{approval_policy_repository, ApprovalPolicy, ProjectPermissions},
+    dto::{
+        ListProjectApprovalPoliciesRequest, ListProjectApprovalPoliciesResponse,
+        UpsertApprovalPolicyRequest, UpsertApprovalPolicyResponse,
+    },
+    mapping::{
+        map_approval_policy_response, map_list_project_approval_policies_response,
+        map_upsert_approval_policy_request,
+    },
     service::access_control_service::ProjectAuth,
 };
 use candid::Principal;
@@ -17,4 +23,31 @@ pub fn list_project_approval_policies(
     let policies = approval_policy_repository::list_project_approval_policies(auth.project_id());
 
     Ok(map_list_project_approval_policies_response(policies))
+}
+
+pub fn upsert_approval_policy(
+    caller: &Principal,
+    request: UpsertApprovalPolicyRequest,
+) -> ApiResult<UpsertApprovalPolicyResponse> {
+    let (project_id, operation_type, policy) = map_upsert_approval_policy_request(request)?;
+
+    let auth = ProjectAuth::require(
+        caller,
+        project_id,
+        ProjectPermissions::APPROVAL_POLICY_MANAGE,
+    )?;
+
+    let policy_id = approval_policy_repository::upsert_approval_policy(
+        auth.project_id(),
+        operation_type,
+        ApprovalPolicy {
+            policy_type: policy.policy_type.clone(),
+        },
+    );
+
+    Ok(map_approval_policy_response((
+        policy_id,
+        operation_type,
+        policy,
+    )))
 }

--- a/src/backend/src/service/proposal_service.rs
+++ b/src/backend/src/service/proposal_service.rs
@@ -1,11 +1,15 @@
 use crate::{
     data::{
         approval_policy_repository, proposal_repository, proposal_repository::VoteOutcome,
-        OperationType, PolicyType, ProjectPermissions, Proposal, ProposalOperation, Vote,
+        OperationType, PolicyType, ProjectPermissions, Proposal, ProposalOperation,
     },
-    dto::{CreateProposalRequest, CreateProposalResponse},
-    mapping::{map_create_proposal_request, map_create_proposal_response},
-    service::{access_control_service::ProjectAuth, canister_service},
+    dto::{
+        CreateProposalRequest, CreateProposalResponse, VoteProposalRequest, VoteProposalResponse,
+    },
+    mapping::{
+        map_create_proposal_request, map_create_proposal_response, map_vote_proposal_request,
+    },
+    service::{access_control_service, access_control_service::ProjectAuth, canister_service},
 };
 use candid::Principal;
 use canister_utils::{ApiError, ApiResult, Uuid};
@@ -43,6 +47,27 @@ async fn process_proposal(project_id: Uuid, proposal_id: Uuid, proposal: Proposa
         PolicyType::AutoApprove => {
             execute_operation(project_id, proposal_id, proposal.operation).await
         }
+        PolicyType::FixedQuorum { threshold } => {
+            if threshold < 1 {
+                return Err(ApiError::client_error(format!(
+                    "FixedQuorum policy on project {project_id} has invalid threshold 0."
+                )));
+            }
+
+            let approvers = access_control_service::list_project_principals_with_permission(
+                project_id,
+                ProjectPermissions::PROPOSAL_APPROVE,
+            );
+
+            if (approvers.len() as u32) < threshold {
+                return Err(ApiError::client_error(format!(
+                    "FixedQuorum policy requires {threshold} approvers but project {project_id} only has {}.",
+                    approvers.len()
+                )));
+            }
+
+            proposal_repository::set_proposal_pending_approval(proposal_id, threshold, approvers)
+        }
     }
 }
 
@@ -74,12 +99,12 @@ async fn execute_operation(
     }
 }
 
-#[allow(dead_code)]
 pub async fn vote_proposal(
     caller: &Principal,
-    proposal_id: Uuid,
-    vote: Vote,
-) -> ApiResult<Proposal> {
+    req: VoteProposalRequest,
+) -> ApiResult<VoteProposalResponse> {
+    let (proposal_id, vote) = map_vote_proposal_request(req)?;
+
     let proposal = proposal_repository::get_proposal(&proposal_id)
         .ok_or_else(|| ApiError::client_error(format!("Proposal {proposal_id} does not exist.")))?;
 
@@ -95,9 +120,11 @@ pub async fn vote_proposal(
         execute_operation(proposal.project_id, proposal_id, proposal.operation.clone()).await?;
     }
 
-    proposal_repository::get_proposal(&proposal_id).ok_or_else(|| {
+    let updated = proposal_repository::get_proposal(&proposal_id).ok_or_else(|| {
         ApiError::internal_error(format!(
             "Could not find proposal {proposal_id} after voting"
         ))
-    })
+    })?;
+
+    Ok(map_create_proposal_response(proposal_id, updated))
 }


### PR DESCRIPTION
Introduce a FixedQuorum policy type that snapshots the set of project principals with PROPOSAL_APPROVE at proposal creation and moves the proposal to PendingApproval with the configured threshold. Add the upsert_approval_policy and vote_proposal endpoints, and switch the ApprovalPolicy candid shape from text fields to typed OperationType and PolicyType variants.