### PR TITLE
feat: add proposal query/cancel endpoints and principal-to-profile lookup

### DIFF
--- a/src/backend-api/candid/proposal.did
+++ b/src/backend-api/candid/proposal.did
@@ -10,6 +10,37 @@ type CreateProposalResponse = variant {
   Err : ApiError;
 };
 
+type GetProposalRequest = record {
+  proposal_id : text;
+};
+
+type GetProposalResponse = variant {
+  Ok : Proposal;
+  Err : ApiError;
+};
+
+type ListProjectProposalsRequest = record {
+  project_id : text;
+  status_filter : opt vec ProposalStatusFilter;
+  after : opt text;
+  limit : opt nat32;
+};
+
+type ListProjectProposalsResponse = variant {
+  Ok : record { proposals : vec Proposal; next_cursor : opt text };
+  Err : ApiError;
+};
+
+type ProposalStatusFilter = variant {
+  Open : record {};
+  PendingApproval : record {};
+  Rejected : record {};
+  Cancelled : record {};
+  Executing : record {};
+  Executed : record {};
+  Failed : record {};
+};
+
 type VoteProposalRequest = record {
   proposal_id : text;
   vote : Vote;
@@ -20,9 +51,19 @@ type VoteProposalResponse = variant {
   Err : ApiError;
 };
 
+type CancelProposalRequest = record {
+  proposal_id : text;
+};
+
+type CancelProposalResponse = variant {
+  Ok : Proposal;
+  Err : ApiError;
+};
+
 type Proposal = record {
   id : text;
   project_id : text;
+  proposer_id : text;
   status : opt ProposalStatus;
   operation : opt ProposalOperation;
 };
@@ -35,6 +76,7 @@ type ProposalStatus = variant {
     votes : vec ProposalVote;
   };
   Rejected : record {};
+  Cancelled : record {};
   Executing : record {};
   Executed : record {};
   Failed : record {
@@ -62,5 +104,8 @@ type ProposalOperation = variant {
 
 service : {
   create_proposal : (CreateProposalRequest) -> (CreateProposalResponse);
+  get_proposal : (GetProposalRequest) -> (GetProposalResponse) query;
+  list_project_proposals : (ListProjectProposalsRequest) -> (ListProjectProposalsResponse) query;
   vote_proposal : (VoteProposalRequest) -> (VoteProposalResponse);
+  cancel_proposal : (CancelProposalRequest) -> (CancelProposalResponse);
 };

--- a/src/backend-api/candid/proposal.did
+++ b/src/backend-api/candid/proposal.did
@@ -23,7 +23,7 @@ type ListProjectProposalsRequest = record {
   project_id : text;
   status_filter : opt vec ProposalStatusFilter;
   after : opt text;
-  limit : opt nat32;
+  limit : opt nat64;
 };
 
 type ListProjectProposalsResponse = variant {

--- a/src/backend-api/candid/user_profile.did
+++ b/src/backend-api/candid/user_profile.did
@@ -11,7 +11,7 @@ type GetUserProfilesByPrincipalsRequest = record {
 };
 
 type GetUserProfilesByPrincipalsResponse = variant {
-  Ok : vec UserProfileByPrincipal;
+  Ok : record { profiles : vec UserProfileByPrincipal };
   Err : ApiError;
 };
 

--- a/src/backend-api/candid/user_profile.did
+++ b/src/backend-api/candid/user_profile.did
@@ -5,6 +5,27 @@ type ListUserProfilesResponse = variant {
   Err : ApiError;
 };
 
+type GetUserProfilesByPrincipalsRequest = record {
+  project_id : text;
+  principals : vec principal;
+};
+
+type GetUserProfilesByPrincipalsResponse = variant {
+  Ok : vec UserProfileByPrincipal;
+  Err : ApiError;
+};
+
+type UserProfileByPrincipal = record {
+  subject_principal : principal;
+  profile : opt UserProfileBrief;
+};
+
+type UserProfileBrief = record {
+  id : text;
+  email : opt text;
+  email_verified : bool;
+};
+
 type GetMyUserProfileResponse = variant {
   Ok : opt UserProfile;
   Err : ApiError;
@@ -67,6 +88,7 @@ type VerifyEmailResponse = variant {
 
 service : {
   list_user_profiles : () -> (ListUserProfilesResponse) query;
+  get_user_profiles_by_principals : (GetUserProfilesByPrincipalsRequest) -> (GetUserProfilesByPrincipalsResponse) query;
   update_user_profile : (UpdateUserProfileRequest) -> (UpdateUserProfileResponse);
   get_user_stats : () -> (GetUserStatsResponse) query;
 

--- a/src/backend-tests/src/support/user-driver.ts
+++ b/src/backend-tests/src/support/user-driver.ts
@@ -50,7 +50,7 @@ export class UserDriver {
     return [identity, profile, org];
   }
 
-  public async inviteIntoOrgAndDefaultTeam(
+  public async inviteIntoOrg(
     host: ActivatedUser,
     guest: ActivatedUser,
   ): Promise<void> {
@@ -58,12 +58,6 @@ export class UserDriver {
     const [guestIdentity, guestProfile] = guest;
 
     this.actor.setIdentity(hostIdentity);
-    const teamsRes = await this.actor.list_org_teams({ org_id: hostOrg.id });
-    const [defaultTeam] = extractOkResponse(teamsRes);
-    if (!defaultTeam) {
-      throw new Error('Expected default team after signup');
-    }
-
     const inviteRes = await this.actor.create_org_invite({
       org_id: hostOrg.id,
       target: { UserId: guestProfile.id },
@@ -73,7 +67,25 @@ export class UserDriver {
     this.actor.setIdentity(guestIdentity);
     await this.actor.accept_org_invite({ invite_id: invite.id });
 
+    this.actor.setIdentity(anonymousIdentity);
+  }
+
+  public async inviteIntoOrgAndDefaultTeam(
+    host: ActivatedUser,
+    guest: ActivatedUser,
+  ): Promise<void> {
+    await this.inviteIntoOrg(host, guest);
+
+    const [hostIdentity, , hostOrg] = host;
+    const [, guestProfile] = guest;
+
     this.actor.setIdentity(hostIdentity);
+    const teamsRes = await this.actor.list_org_teams({ org_id: hostOrg.id });
+    const [defaultTeam] = extractOkResponse(teamsRes);
+    if (!defaultTeam) {
+      throw new Error('Expected default team after signup');
+    }
+
     await this.actor.add_user_to_team({
       team_id: defaultTeam.id,
       user_id: guestProfile.id,

--- a/src/backend-tests/src/tests/approval-policy.spec.ts
+++ b/src/backend-tests/src/tests/approval-policy.spec.ts
@@ -623,9 +623,7 @@ describe('Proposal queries and lifecycle', () => {
       expect(lookups.length).toBe(3);
 
       const findBy = (principal: Principal) =>
-        lookups.find(
-          (l) => l.subject_principal.toText() === principal.toText(),
-        );
+        lookups.find(l => l.subject_principal.toText() === principal.toText());
 
       const bobLookup = findBy(bobIdentity.getPrincipal());
       expect(bobLookup?.profile[0]?.id).toBe(bobProfile.id);

--- a/src/backend-tests/src/tests/approval-policy.spec.ts
+++ b/src/backend-tests/src/tests/approval-policy.spec.ts
@@ -225,7 +225,7 @@ describe('Approval Policy + Proposal Voting', () => {
       const bob = await driver.users.createUser();
       await driver.users.inviteIntoOrgAndDefaultTeam(alice, bob);
 
-      const [aliceIdentity, , aliceOrg] = alice;
+      const [aliceIdentity] = alice;
       driver.actor.setIdentity(aliceIdentity);
       const project = await driver.getDefaultProject();
       await driver.actor.upsert_approval_policy({
@@ -241,16 +241,11 @@ describe('Approval Policy + Proposal Voting', () => {
       const pending = extractOkResponse(createRes);
 
       // Carol is in Alice's org but on a team with no project link.
-      const [carolIdentity, carolProfile] = await driver.users.createUser();
-      driver.actor.setIdentity(aliceIdentity);
-      const inviteRes = await driver.actor.create_org_invite({
-        org_id: aliceOrg.id,
-        target: { UserId: carolProfile.id },
-      });
-      const { invite } = extractOkResponse(inviteRes);
-      driver.actor.setIdentity(carolIdentity);
-      await driver.actor.accept_org_invite({ invite_id: invite.id });
+      const carol = await driver.users.createUser();
+      await driver.users.inviteIntoOrg(alice, carol);
 
+      const [carolIdentity] = carol;
+      driver.actor.setIdentity(carolIdentity);
       const carolVote = await driver.actor.vote_proposal({
         proposal_id: pending.id,
         vote: { Approve: {} },
@@ -477,6 +472,31 @@ describe('Proposal queries and lifecycle', () => {
         },
       });
     });
+
+    it('rejects a caller in the org but not on the project', async () => {
+      const alice = await driver.users.createUser();
+      const [aliceIdentity] = alice;
+      driver.actor.setIdentity(aliceIdentity);
+      const project = await driver.getDefaultProject();
+
+      const carol = await driver.users.createUser();
+      await driver.users.inviteIntoOrg(alice, carol);
+
+      const [carolIdentity, carolProfile] = carol;
+      driver.actor.setIdentity(carolIdentity);
+      const res = await driver.actor.list_project_proposals({
+        project_id: project.id,
+        status_filter: [],
+        after: [],
+        limit: [],
+      });
+      expect(res).toEqual({
+        Err: {
+          code: [{ Unauthorized: {} }],
+          message: `User with id ${carolProfile.id} does not have access to project with id ${project.id}`,
+        },
+      });
+    });
   });
 
   describe('cancel_proposal', () => {
@@ -595,6 +615,40 @@ describe('Proposal queries and lifecycle', () => {
         },
       });
     });
+
+    it('hides cancellation from a caller in the org but not on the project', async () => {
+      const alice = await driver.users.createUser();
+      const [aliceIdentity] = alice;
+      driver.actor.setIdentity(aliceIdentity);
+      const project = await driver.getDefaultProject();
+      await driver.actor.upsert_approval_policy({
+        project_id: project.id,
+        operation_type: { CreateCanister: {} },
+        policy_type: { FixedQuorum: { threshold: 2 } },
+      });
+      const bob = await driver.users.createUser();
+      await driver.users.inviteIntoOrgAndDefaultTeam(alice, bob);
+      driver.actor.setIdentity(aliceIdentity);
+      const createRes = await driver.actor.create_proposal({
+        project_id: project.id,
+        operation: [{ CreateCanister: {} }],
+      });
+      const pending = extractOkResponse(createRes);
+
+      const carol = await driver.users.createUser();
+      await driver.users.inviteIntoOrg(alice, carol);
+      const [carolIdentity] = carol;
+      driver.actor.setIdentity(carolIdentity);
+      const res = await driver.actor.cancel_proposal({
+        proposal_id: pending.id,
+      });
+      expect(res).toEqual({
+        Err: {
+          code: [{ ClientError: {} }],
+          message: `Proposal with id ${pending.id} does not exist or you do not have access.`,
+        },
+      });
+    });
   });
 
   describe('get_user_profiles_by_principals', () => {
@@ -619,7 +673,7 @@ describe('Proposal queries and lifecycle', () => {
           ghost,
         ],
       });
-      const lookups = extractOkResponse(res);
+      const { profiles: lookups } = extractOkResponse(res);
       expect(lookups.length).toBe(3);
 
       const findBy = (principal: Principal) =>
@@ -650,6 +704,29 @@ describe('Proposal queries and lifecycle', () => {
         Err: {
           code: [{ ClientError: {} }],
           message: `Project with id ${project.id} does not exist or you do not have access.`,
+        },
+      });
+    });
+
+    it('rejects a caller in the org but not on the project', async () => {
+      const alice = await driver.users.createUser();
+      const [aliceIdentity] = alice;
+      driver.actor.setIdentity(aliceIdentity);
+      const project = await driver.getDefaultProject();
+
+      const carol = await driver.users.createUser();
+      await driver.users.inviteIntoOrg(alice, carol);
+
+      const [carolIdentity, carolProfile] = carol;
+      driver.actor.setIdentity(carolIdentity);
+      const res = await driver.actor.get_user_profiles_by_principals({
+        project_id: project.id,
+        principals: [aliceIdentity.getPrincipal()],
+      });
+      expect(res).toEqual({
+        Err: {
+          code: [{ Unauthorized: {} }],
+          message: `User with id ${carolProfile.id} does not have access to project with id ${project.id}`,
         },
       });
     });

--- a/src/backend-tests/src/tests/approval-policy.spec.ts
+++ b/src/backend-tests/src/tests/approval-policy.spec.ts
@@ -1,7 +1,9 @@
+import { generateRandomIdentity } from '@dfinity/pic';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { TestDriver } from '../support';
 import { anonymousIdentity, extractOkResponse } from '@ssn/test-utils';
 import type { ApprovalPolicy, Proposal } from '@ssn/backend-api';
+import { Principal } from '@icp-sdk/core/principal';
 
 async function expectPendingApproval(
   proposal: Proposal,
@@ -255,8 +257,8 @@ describe('Approval Policy + Proposal Voting', () => {
       });
       expect(carolVote).toEqual({
         Err: {
-          code: [{ Unauthorized: {} }],
-          message: `User with id ${carolProfile.id} does not have access to project with id ${project.id}`,
+          code: [{ ClientError: {} }],
+          message: `Proposal with id ${pending.id} does not exist or you do not have access.`,
         },
       });
     });
@@ -294,6 +296,362 @@ describe('Approval Policy + Proposal Voting', () => {
         Err: {
           code: [{ ClientError: {} }],
           message: `Principal ${aliceIdentity.getPrincipal()} has already voted on proposal ${pending.id}.`,
+        },
+      });
+    });
+  });
+});
+
+describe('Proposal queries and lifecycle', () => {
+  let driver: TestDriver;
+
+  beforeEach(async () => {
+    driver = await TestDriver.create();
+  });
+
+  afterEach(async () => {
+    await driver.tearDown();
+  });
+
+  describe('proposer_id', () => {
+    it('records the caller as proposer on creation', async () => {
+      const [aliceIdentity, aliceProfile] = await driver.users.createUser();
+      driver.actor.setIdentity(aliceIdentity);
+      const project = await driver.getDefaultProject();
+
+      const createRes = await driver.actor.create_proposal({
+        project_id: project.id,
+        operation: [{ CreateCanister: {} }],
+      });
+      const proposal = extractOkResponse(createRes);
+      expect(proposal.proposer_id).toBe(aliceProfile.id);
+    });
+  });
+
+  describe('get_proposal', () => {
+    it('fetches a proposal for a project member', async () => {
+      const alice = await driver.users.createUser();
+      const bob = await driver.users.createUser();
+      await driver.users.inviteIntoOrgAndDefaultTeam(alice, bob);
+
+      const [aliceIdentity, aliceProfile] = alice;
+      const [bobIdentity] = bob;
+      driver.actor.setIdentity(aliceIdentity);
+      const project = await driver.getDefaultProject();
+      await driver.actor.upsert_approval_policy({
+        project_id: project.id,
+        operation_type: { CreateCanister: {} },
+        policy_type: { FixedQuorum: { threshold: 2 } },
+      });
+      const createRes = await driver.actor.create_proposal({
+        project_id: project.id,
+        operation: [{ CreateCanister: {} }],
+      });
+      const created = extractOkResponse(createRes);
+
+      driver.actor.setIdentity(bobIdentity);
+      const getRes = await driver.actor.get_proposal({
+        proposal_id: created.id,
+      });
+      const fetched = extractOkResponse(getRes);
+      expect(fetched.id).toBe(created.id);
+      expect(fetched.project_id).toBe(project.id);
+      expect(fetched.proposer_id).toBe(aliceProfile.id);
+      expectStatusTag(fetched, 'PendingApproval');
+    });
+
+    it('returns a generic error for a non-existent proposal id', async () => {
+      const [aliceIdentity] = await driver.users.createUser();
+      driver.actor.setIdentity(aliceIdentity);
+
+      const ghost = '00000000-0000-0000-0000-000000000000';
+      const res = await driver.actor.get_proposal({ proposal_id: ghost });
+      expect(res).toEqual({
+        Err: {
+          code: [{ ClientError: {} }],
+          message: `Proposal with id ${ghost} does not exist or you do not have access.`,
+        },
+      });
+    });
+
+    it('hides proposal existence from a caller outside the project org', async () => {
+      const [aliceIdentity] = await driver.users.createUser();
+      driver.actor.setIdentity(aliceIdentity);
+      const project = await driver.getDefaultProject();
+      const createRes = await driver.actor.create_proposal({
+        project_id: project.id,
+        operation: [{ CreateCanister: {} }],
+      });
+      const created = extractOkResponse(createRes);
+
+      const [strangerIdentity] = await driver.users.createUser();
+      driver.actor.setIdentity(strangerIdentity);
+      const res = await driver.actor.get_proposal({ proposal_id: created.id });
+      expect(res).toEqual({
+        Err: {
+          code: [{ ClientError: {} }],
+          message: `Proposal with id ${created.id} does not exist or you do not have access.`,
+        },
+      });
+    });
+  });
+
+  describe('list_project_proposals', () => {
+    it('returns an empty list for a fresh project', async () => {
+      const [aliceIdentity] = await driver.users.createUser();
+      driver.actor.setIdentity(aliceIdentity);
+      const project = await driver.getDefaultProject();
+
+      const res = await driver.actor.list_project_proposals({
+        project_id: project.id,
+        status_filter: [],
+        after: [],
+        limit: [],
+      });
+      const { proposals } = extractOkResponse(res);
+      expect(proposals).toEqual([]);
+    });
+
+    it('lists proposals for the project and filters by status', async () => {
+      const alice = await driver.users.createUser();
+      const bob = await driver.users.createUser();
+      await driver.users.inviteIntoOrgAndDefaultTeam(alice, bob);
+
+      const [aliceIdentity] = alice;
+      driver.actor.setIdentity(aliceIdentity);
+      const project = await driver.getDefaultProject();
+      // First proposal auto-approves and ends in Executed.
+      await driver.actor.create_proposal({
+        project_id: project.id,
+        operation: [{ CreateCanister: {} }],
+      });
+      // Switch the policy to FixedQuorum so the next one stays pending.
+      await driver.actor.upsert_approval_policy({
+        project_id: project.id,
+        operation_type: { CreateCanister: {} },
+        policy_type: { FixedQuorum: { threshold: 2 } },
+      });
+      const pendingRes = await driver.actor.create_proposal({
+        project_id: project.id,
+        operation: [{ CreateCanister: {} }],
+      });
+      const pending = extractOkResponse(pendingRes);
+
+      const allRes = await driver.actor.list_project_proposals({
+        project_id: project.id,
+        status_filter: [],
+        after: [],
+        limit: [],
+      });
+      const { proposals: all } = extractOkResponse(allRes);
+      expect(all.length).toBe(2);
+
+      const pendingOnlyRes = await driver.actor.list_project_proposals({
+        project_id: project.id,
+        status_filter: [[{ PendingApproval: {} }]],
+        after: [],
+        limit: [],
+      });
+      const { proposals: pendingOnly } = extractOkResponse(pendingOnlyRes);
+      expect(pendingOnly.length).toBe(1);
+      expect(pendingOnly[0]!.id).toBe(pending.id);
+    });
+
+    it('rejects a caller without project access', async () => {
+      const [aliceIdentity] = await driver.users.createUser();
+      driver.actor.setIdentity(aliceIdentity);
+      const project = await driver.getDefaultProject();
+
+      const [strangerIdentity] = await driver.users.createUser();
+      driver.actor.setIdentity(strangerIdentity);
+      const res = await driver.actor.list_project_proposals({
+        project_id: project.id,
+        status_filter: [],
+        after: [],
+        limit: [],
+      });
+      expect(res).toEqual({
+        Err: {
+          code: [{ ClientError: {} }],
+          message: `Project with id ${project.id} does not exist or you do not have access.`,
+        },
+      });
+    });
+  });
+
+  describe('cancel_proposal', () => {
+    it('lets the proposer cancel a pending proposal', async () => {
+      const alice = await driver.users.createUser();
+      const bob = await driver.users.createUser();
+      await driver.users.inviteIntoOrgAndDefaultTeam(alice, bob);
+
+      const [aliceIdentity] = alice;
+      driver.actor.setIdentity(aliceIdentity);
+      const project = await driver.getDefaultProject();
+      await driver.actor.upsert_approval_policy({
+        project_id: project.id,
+        operation_type: { CreateCanister: {} },
+        policy_type: { FixedQuorum: { threshold: 2 } },
+      });
+      const createRes = await driver.actor.create_proposal({
+        project_id: project.id,
+        operation: [{ CreateCanister: {} }],
+      });
+      const pending = extractOkResponse(createRes);
+
+      const cancelRes = await driver.actor.cancel_proposal({
+        proposal_id: pending.id,
+      });
+      const cancelled = extractOkResponse(cancelRes);
+      expectStatusTag(cancelled, 'Cancelled');
+    });
+
+    it('rejects a vote on a cancelled proposal', async () => {
+      const alice = await driver.users.createUser();
+      const bob = await driver.users.createUser();
+      await driver.users.inviteIntoOrgAndDefaultTeam(alice, bob);
+
+      const [aliceIdentity] = alice;
+      const [bobIdentity] = bob;
+      driver.actor.setIdentity(aliceIdentity);
+      const project = await driver.getDefaultProject();
+      await driver.actor.upsert_approval_policy({
+        project_id: project.id,
+        operation_type: { CreateCanister: {} },
+        policy_type: { FixedQuorum: { threshold: 2 } },
+      });
+      const createRes = await driver.actor.create_proposal({
+        project_id: project.id,
+        operation: [{ CreateCanister: {} }],
+      });
+      const pending = extractOkResponse(createRes);
+
+      await driver.actor.cancel_proposal({ proposal_id: pending.id });
+
+      driver.actor.setIdentity(bobIdentity);
+      const voteRes = await driver.actor.vote_proposal({
+        proposal_id: pending.id,
+        vote: { Approve: {} },
+      });
+      expect(voteRes).toEqual({
+        Err: {
+          code: [{ ClientError: {} }],
+          message: `Proposal ${pending.id} is not pending approval.`,
+        },
+      });
+    });
+
+    it('rejects cancelling an executed proposal', async () => {
+      const [aliceIdentity] = await driver.users.createUser();
+      driver.actor.setIdentity(aliceIdentity);
+      const project = await driver.getDefaultProject();
+      // AutoApprove default → goes straight to Executed.
+      const createRes = await driver.actor.create_proposal({
+        project_id: project.id,
+        operation: [{ CreateCanister: {} }],
+      });
+      const executed = extractOkResponse(createRes);
+      expectStatusTag(executed, 'Executed');
+
+      const cancelRes = await driver.actor.cancel_proposal({
+        proposal_id: executed.id,
+      });
+      expect(cancelRes).toEqual({
+        Err: {
+          code: [{ ClientError: {} }],
+          message: `Proposal ${executed.id} cannot be cancelled in its current state.`,
+        },
+      });
+    });
+
+    it('hides cancellation from a caller outside the project org', async () => {
+      const alice = await driver.users.createUser();
+      const [aliceIdentity] = alice;
+      driver.actor.setIdentity(aliceIdentity);
+      const project = await driver.getDefaultProject();
+      await driver.actor.upsert_approval_policy({
+        project_id: project.id,
+        operation_type: { CreateCanister: {} },
+        policy_type: { FixedQuorum: { threshold: 2 } },
+      });
+      const bob = await driver.users.createUser();
+      await driver.users.inviteIntoOrgAndDefaultTeam(alice, bob);
+      driver.actor.setIdentity(aliceIdentity);
+      const createRes = await driver.actor.create_proposal({
+        project_id: project.id,
+        operation: [{ CreateCanister: {} }],
+      });
+      const pending = extractOkResponse(createRes);
+
+      const [strangerIdentity] = await driver.users.createUser();
+      driver.actor.setIdentity(strangerIdentity);
+      const res = await driver.actor.cancel_proposal({
+        proposal_id: pending.id,
+      });
+      expect(res).toEqual({
+        Err: {
+          code: [{ ClientError: {} }],
+          message: `Proposal with id ${pending.id} does not exist or you do not have access.`,
+        },
+      });
+    });
+  });
+
+  describe('get_user_profiles_by_principals', () => {
+    it('resolves project members and returns no profile for non-members', async () => {
+      const alice = await driver.users.createUser();
+      const bob = await driver.users.createUser();
+      await driver.users.inviteIntoOrgAndDefaultTeam(alice, bob);
+
+      const [aliceIdentity] = alice;
+      const [bobIdentity, bobProfile] = bob;
+      driver.actor.setIdentity(aliceIdentity);
+      const project = await driver.getDefaultProject();
+      const [strangerIdentity] = await driver.users.createUser();
+      const ghost = generateRandomIdentity().getPrincipal();
+
+      driver.actor.setIdentity(aliceIdentity);
+      const res = await driver.actor.get_user_profiles_by_principals({
+        project_id: project.id,
+        principals: [
+          bobIdentity.getPrincipal(),
+          strangerIdentity.getPrincipal(),
+          ghost,
+        ],
+      });
+      const lookups = extractOkResponse(res);
+      expect(lookups.length).toBe(3);
+
+      const findBy = (principal: Principal) =>
+        lookups.find(
+          (l) => l.subject_principal.toText() === principal.toText(),
+        );
+
+      const bobLookup = findBy(bobIdentity.getPrincipal());
+      expect(bobLookup?.profile[0]?.id).toBe(bobProfile.id);
+
+      const strangerLookup = findBy(strangerIdentity.getPrincipal());
+      expect(strangerLookup?.profile).toEqual([]);
+
+      const ghostLookup = findBy(ghost);
+      expect(ghostLookup?.profile).toEqual([]);
+    });
+
+    it('rejects a caller without project access', async () => {
+      const [aliceIdentity] = await driver.users.createUser();
+      driver.actor.setIdentity(aliceIdentity);
+      const project = await driver.getDefaultProject();
+
+      const [strangerIdentity] = await driver.users.createUser();
+      driver.actor.setIdentity(strangerIdentity);
+      const res = await driver.actor.get_user_profiles_by_principals({
+        project_id: project.id,
+        principals: [aliceIdentity.getPrincipal()],
+      });
+      expect(res).toEqual({
+        Err: {
+          code: [{ ClientError: {} }],
+          message: `Project with id ${project.id} does not exist or you do not have access.`,
         },
       });
     });

--- a/src/backend/src/controller/proposal.rs
+++ b/src/backend/src/controller/proposal.rs
@@ -1,6 +1,9 @@
 use crate::{
     dto::{
-        CreateProposalRequest, CreateProposalResponse, VoteProposalRequest, VoteProposalResponse,
+        CancelProposalRequest, CancelProposalResponse, CreateProposalRequest,
+        CreateProposalResponse, GetProposalRequest, GetProposalResponse,
+        ListProjectProposalsRequest, ListProjectProposalsResponse, VoteProposalRequest,
+        VoteProposalResponse,
     },
     service::{access_control_service, proposal_service},
 };
@@ -19,6 +22,28 @@ async fn create_proposal(request: CreateProposalRequest) -> ApiResultDto<CreateP
         .into()
 }
 
+#[query]
+fn get_proposal(request: GetProposalRequest) -> ApiResultDto<GetProposalResponse> {
+    let caller = msg_caller();
+    if let Err(err) = access_control_service::assert_has_platform_access(&caller) {
+        return ApiResultDto::Err(err);
+    }
+
+    proposal_service::get_proposal(&caller, request).into()
+}
+
+#[query]
+fn list_project_proposals(
+    request: ListProjectProposalsRequest,
+) -> ApiResultDto<ListProjectProposalsResponse> {
+    let caller = msg_caller();
+    if let Err(err) = access_control_service::assert_has_platform_access(&caller) {
+        return ApiResultDto::Err(err);
+    }
+
+    proposal_service::list_project_proposals(&caller, request).into()
+}
+
 #[update]
 async fn vote_proposal(request: VoteProposalRequest) -> ApiResultDto<VoteProposalResponse> {
     let caller = msg_caller();
@@ -29,4 +54,14 @@ async fn vote_proposal(request: VoteProposalRequest) -> ApiResultDto<VoteProposa
     proposal_service::vote_proposal(&caller, request)
         .await
         .into()
+}
+
+#[update]
+fn cancel_proposal(request: CancelProposalRequest) -> ApiResultDto<CancelProposalResponse> {
+    let caller = msg_caller();
+    if let Err(err) = access_control_service::assert_has_platform_access(&caller) {
+        return ApiResultDto::Err(err);
+    }
+
+    proposal_service::cancel_proposal(&caller, request).into()
 }

--- a/src/backend/src/controller/user_profile.rs
+++ b/src/backend/src/controller/user_profile.rs
@@ -1,10 +1,10 @@
 use crate::{
     dto::{
-        CreateMyUserProfileResponse, GetMyUserProfileResponse, GetUserStatsResponse,
-        ListUserProfilesResponse, UpdateMyUserProfileRequest, UpdateUserProfileRequest,
-        VerifyEmailRequest,
+        CreateMyUserProfileResponse, GetMyUserProfileResponse, GetUserProfilesByPrincipalsRequest,
+        GetUserProfilesByPrincipalsResponse, GetUserStatsResponse, ListUserProfilesResponse,
+        UpdateMyUserProfileRequest, UpdateUserProfileRequest, VerifyEmailRequest,
     },
-    service::user_profile_service,
+    service::{access_control_service, user_profile_service},
 };
 use canister_utils::{assert_authenticated, assert_controller, ApiResultDto};
 use ic_cdk::{api::msg_caller, *};
@@ -17,6 +17,18 @@ fn list_user_profiles() -> ApiResultDto<ListUserProfilesResponse> {
     }
 
     ApiResultDto::Ok(user_profile_service::list_user_profiles())
+}
+
+#[query]
+fn get_user_profiles_by_principals(
+    request: GetUserProfilesByPrincipalsRequest,
+) -> ApiResultDto<GetUserProfilesByPrincipalsResponse> {
+    let caller = msg_caller();
+    if let Err(err) = access_control_service::assert_has_platform_access(&caller) {
+        return ApiResultDto::Err(err);
+    }
+
+    user_profile_service::get_user_profiles_by_principals(&caller, request).into()
 }
 
 #[update]

--- a/src/backend/src/data/model/proposal.rs
+++ b/src/backend/src/data/model/proposal.rs
@@ -7,6 +7,7 @@ use std::borrow::Cow;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Proposal {
     pub project_id: Uuid,
+    pub proposer_id: Uuid,
     pub status: ProposalStatus,
     pub operation: ProposalOperation,
 }
@@ -20,6 +21,7 @@ pub enum ProposalStatus {
         votes: Vec<(Principal, Vote)>,
     },
     Rejected,
+    Cancelled,
     Executing,
     Executed,
     Failed(String),

--- a/src/backend/src/data/proposal_repository.rs
+++ b/src/backend/src/data/proposal_repository.rs
@@ -31,6 +31,30 @@ pub fn get_proposal(proposal_id: &Uuid) -> Option<Proposal> {
     with_state(|s| s.proposals.get(proposal_id))
 }
 
+// Scan up to `limit` proposals for `project_id`, starting strictly after the
+// `after` cursor (or from the beginning when None). Bounded scan keeps query
+// instructions O(limit) regardless of total project proposal count.
+pub fn list_project_proposals(
+    project_id: Uuid,
+    after: Option<Uuid>,
+    limit: usize,
+) -> Vec<(Uuid, Proposal)> {
+    with_state(|s| {
+        let start = (project_id, after.unwrap_or(Uuid::MIN));
+        let end = (project_id, Uuid::MAX);
+        s.project_proposals_index
+            .range(start..=end)
+            .skip(usize::from(after.is_some()))
+            .take(limit)
+            .filter_map(|(_, proposal_id)| {
+                s.proposals
+                    .get(&proposal_id)
+                    .map(|proposal| (proposal_id, proposal))
+            })
+            .collect()
+    })
+}
+
 pub fn set_proposal_pending_approval(
     proposal_id: Uuid,
     threshold: u32,
@@ -122,6 +146,30 @@ pub fn record_proposal_vote(
     })
 }
 
+pub fn cancel_proposal(proposal_id: Uuid) -> ApiResult {
+    mutate_state(|s| {
+        let mut proposal = s.proposals.get(&proposal_id).ok_or_else(|| {
+            ApiError::client_error(format!(
+                "Failed to cancel proposal {proposal_id}, proposal does not exist."
+            ))
+        })?;
+
+        if !matches!(
+            proposal.status,
+            ProposalStatus::Open | ProposalStatus::PendingApproval { .. }
+        ) {
+            return Err(ApiError::client_error(format!(
+                "Proposal {proposal_id} cannot be cancelled in its current state."
+            )));
+        }
+
+        proposal.status = ProposalStatus::Cancelled;
+        s.proposals.insert(proposal_id, proposal);
+
+        Ok(())
+    })
+}
+
 pub fn set_proposal_executing(proposal_id: Uuid) -> ApiResult {
     set_proposal_status(proposal_id, ProposalStatus::Executing)
 }
@@ -190,6 +238,7 @@ mod tests {
             project_id,
             Proposal {
                 project_id,
+                proposer_id: Uuid::new(),
                 status: ProposalStatus::Open,
                 operation: ProposalOperation::CreateCanister,
             },
@@ -306,6 +355,7 @@ mod tests {
             project_id,
             Proposal {
                 project_id,
+                proposer_id: Uuid::new(),
                 status: ProposalStatus::Open,
                 operation: ProposalOperation::CreateCanister,
             },

--- a/src/backend/src/data/proposal_repository.rs
+++ b/src/backend/src/data/proposal_repository.rs
@@ -8,6 +8,7 @@ use crate::data::{
 use candid::Principal;
 use canister_utils::{ApiError, ApiResult, Uuid};
 use std::cell::RefCell;
+use std::ops::Bound::{Excluded, Included};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VoteOutcome {
@@ -31,26 +32,34 @@ pub fn get_proposal(proposal_id: &Uuid) -> Option<Proposal> {
     with_state(|s| s.proposals.get(proposal_id))
 }
 
-// Scan up to `limit` proposals for `project_id`, starting strictly after the
-// `after` cursor (or from the beginning when None). Bounded scan keeps query
-// instructions O(limit) regardless of total project proposal count.
-pub fn list_project_proposals(
+// Scan proposals for `project_id` starting strictly after the `after` cursor
+// (or from the beginning when None), keep those matching `filter`, and return
+// up to `limit` matches. Filtering happens before `take` so a sparse filter
+// still fills the page; the cursor advances by matched id, not scan position.
+pub fn list_project_proposals<F>(
     project_id: Uuid,
     after: Option<Uuid>,
     limit: usize,
-) -> Vec<(Uuid, Proposal)> {
+    filter: F,
+) -> Vec<(Uuid, Proposal)>
+where
+    F: Fn(&Proposal) -> bool,
+{
     with_state(|s| {
-        let start = (project_id, after.unwrap_or(Uuid::MIN));
-        let end = (project_id, Uuid::MAX);
+        let start = match after {
+            Some(cursor) => Excluded((project_id, cursor)),
+            None => Included((project_id, Uuid::MIN)),
+        };
+        let end = Included((project_id, Uuid::MAX));
         s.project_proposals_index
-            .range(start..=end)
-            .skip(usize::from(after.is_some()))
-            .take(limit)
+            .range((start, end))
             .filter_map(|(_, proposal_id)| {
                 s.proposals
                     .get(&proposal_id)
                     .map(|proposal| (proposal_id, proposal))
             })
+            .filter(|(_, proposal)| filter(proposal))
+            .take(limit)
             .collect()
     })
 }

--- a/src/backend/src/dto/proposal.rs
+++ b/src/backend/src/dto/proposal.rs
@@ -10,6 +10,38 @@ pub struct CreateProposalRequest {
 pub type CreateProposalResponse = Proposal;
 
 #[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct GetProposalRequest {
+    pub proposal_id: String,
+}
+
+pub type GetProposalResponse = Proposal;
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct ListProjectProposalsRequest {
+    pub project_id: String,
+    pub status_filter: Option<Vec<ProposalStatusFilter>>,
+    pub after: Option<String>,
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct ListProjectProposalsResponse {
+    pub proposals: Vec<Proposal>,
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, CandidType, Deserialize, PartialEq, Eq)]
+pub enum ProposalStatusFilter {
+    Open {},
+    PendingApproval {},
+    Rejected {},
+    Cancelled {},
+    Executing {},
+    Executed {},
+    Failed {},
+}
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
 pub struct VoteProposalRequest {
     pub proposal_id: String,
     pub vote: Vote,
@@ -18,9 +50,17 @@ pub struct VoteProposalRequest {
 pub type VoteProposalResponse = Proposal;
 
 #[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct CancelProposalRequest {
+    pub proposal_id: String,
+}
+
+pub type CancelProposalResponse = Proposal;
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
 pub struct Proposal {
     pub id: String,
     pub project_id: String,
+    pub proposer_id: String,
     pub status: Option<ProposalStatus>,
     pub operation: Option<ProposalOperation>,
 }
@@ -34,6 +74,7 @@ pub enum ProposalStatus {
         votes: Vec<ProposalVote>,
     },
     Rejected {},
+    Cancelled {},
     Executing {},
     Executed {},
     Failed {

--- a/src/backend/src/dto/proposal.rs
+++ b/src/backend/src/dto/proposal.rs
@@ -21,7 +21,7 @@ pub struct ListProjectProposalsRequest {
     pub project_id: String,
     pub status_filter: Option<Vec<ProposalStatusFilter>>,
     pub after: Option<String>,
-    pub limit: Option<u32>,
+    pub limit: Option<u64>,
 }
 
 #[derive(Debug, Clone, CandidType, Deserialize)]

--- a/src/backend/src/dto/user_profile.rs
+++ b/src/backend/src/dto/user_profile.rs
@@ -1,7 +1,28 @@
-use candid::CandidType;
+use candid::{CandidType, Principal};
 use serde::Deserialize;
 
 pub type ListUserProfilesResponse = Vec<UserProfile>;
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct GetUserProfilesByPrincipalsRequest {
+    pub project_id: String,
+    pub principals: Vec<Principal>,
+}
+
+pub type GetUserProfilesByPrincipalsResponse = Vec<UserProfileByPrincipal>;
+
+#[derive(Debug, Clone, CandidType)]
+pub struct UserProfileByPrincipal {
+    pub subject_principal: Principal,
+    pub profile: Option<UserProfileBrief>,
+}
+
+#[derive(Debug, Clone, CandidType)]
+pub struct UserProfileBrief {
+    pub id: String,
+    pub email: Option<String>,
+    pub email_verified: bool,
+}
 
 pub type GetMyUserProfileResponse = Option<UserProfile>;
 

--- a/src/backend/src/dto/user_profile.rs
+++ b/src/backend/src/dto/user_profile.rs
@@ -9,7 +9,10 @@ pub struct GetUserProfilesByPrincipalsRequest {
     pub principals: Vec<Principal>,
 }
 
-pub type GetUserProfilesByPrincipalsResponse = Vec<UserProfileByPrincipal>;
+#[derive(Debug, Clone, CandidType)]
+pub struct GetUserProfilesByPrincipalsResponse {
+    pub profiles: Vec<UserProfileByPrincipal>,
+}
 
 #[derive(Debug, Clone, CandidType)]
 pub struct UserProfileByPrincipal {

--- a/src/backend/src/mapping/proposal.rs
+++ b/src/backend/src/mapping/proposal.rs
@@ -69,11 +69,26 @@ pub fn proposal_matches_status_filter(
                 data::ProposalStatus::PendingApproval { .. },
                 ProposalStatusFilter::PendingApproval {}
             )
-            | (data::ProposalStatus::Rejected, ProposalStatusFilter::Rejected {})
-            | (data::ProposalStatus::Cancelled, ProposalStatusFilter::Cancelled {})
-            | (data::ProposalStatus::Executing, ProposalStatusFilter::Executing {})
-            | (data::ProposalStatus::Executed, ProposalStatusFilter::Executed {})
-            | (data::ProposalStatus::Failed(_), ProposalStatusFilter::Failed {})
+            | (
+                data::ProposalStatus::Rejected,
+                ProposalStatusFilter::Rejected {}
+            )
+            | (
+                data::ProposalStatus::Cancelled,
+                ProposalStatusFilter::Cancelled {}
+            )
+            | (
+                data::ProposalStatus::Executing,
+                ProposalStatusFilter::Executing {}
+            )
+            | (
+                data::ProposalStatus::Executed,
+                ProposalStatusFilter::Executed {}
+            )
+            | (
+                data::ProposalStatus::Failed(_),
+                ProposalStatusFilter::Failed {}
+            )
     )
 }
 

--- a/src/backend/src/mapping/proposal.rs
+++ b/src/backend/src/mapping/proposal.rs
@@ -1,8 +1,8 @@
 use crate::{
     data,
     dto::{
-        CreateProposalRequest, CreateProposalResponse, ProposalOperation, ProposalStatus,
-        ProposalVote, Vote, VoteProposalRequest,
+        CreateProposalRequest, ListProjectProposalsResponse, Proposal, ProposalOperation,
+        ProposalStatus, ProposalStatusFilter, ProposalVote, Vote, VoteProposalRequest,
     },
 };
 use canister_utils::{ApiError, ApiResult, Uuid};
@@ -25,42 +25,63 @@ pub fn map_vote_proposal_request(req: VoteProposalRequest) -> ApiResult<(Uuid, d
 
 pub fn map_create_proposal_request(
     req: CreateProposalRequest,
-) -> ApiResult<(Uuid, data::Proposal)> {
+) -> ApiResult<(Uuid, data::ProposalOperation)> {
     let project_uuid = Uuid::try_from(req.project_id.as_str())?;
-
-    Ok((
-        project_uuid,
-        data::Proposal {
-            project_id: project_uuid,
-            status: data::ProposalStatus::Open,
-            operation: match req.operation {
-                Some(ProposalOperation::CreateCanister {}) => {
-                    data::ProposalOperation::CreateCanister
-                }
-                Some(ProposalOperation::AddCanisterController {
-                    canister_id,
-                    controller_id,
-                }) => data::ProposalOperation::AddCanisterController {
-                    canister_id,
-                    controller_id,
-                },
-                None => {
-                    return Err(ApiError::client_error(
-                        "Failed to decode proposal request operation".to_string(),
-                    ))
-                }
-            },
+    let operation = match req.operation {
+        Some(ProposalOperation::CreateCanister {}) => data::ProposalOperation::CreateCanister,
+        Some(ProposalOperation::AddCanisterController {
+            canister_id,
+            controller_id,
+        }) => data::ProposalOperation::AddCanisterController {
+            canister_id,
+            controller_id,
         },
-    ))
+        None => {
+            return Err(ApiError::client_error(
+                "Failed to decode proposal request operation".to_string(),
+            ))
+        }
+    };
+    Ok((project_uuid, operation))
 }
 
-pub fn map_create_proposal_response(
-    proposal_id: Uuid,
-    proposal: data::Proposal,
-) -> CreateProposalResponse {
-    CreateProposalResponse {
+pub fn map_list_project_proposals_response(
+    proposals: Vec<(Uuid, data::Proposal)>,
+    next_cursor: Option<Uuid>,
+) -> ListProjectProposalsResponse {
+    ListProjectProposalsResponse {
+        proposals: proposals
+            .into_iter()
+            .map(|(id, p)| map_proposal_response(id, p))
+            .collect(),
+        next_cursor: next_cursor.map(|id| id.to_string()),
+    }
+}
+
+pub fn proposal_matches_status_filter(
+    proposal: &data::Proposal,
+    filter: &ProposalStatusFilter,
+) -> bool {
+    matches!(
+        (&proposal.status, filter),
+        (data::ProposalStatus::Open, ProposalStatusFilter::Open {})
+            | (
+                data::ProposalStatus::PendingApproval { .. },
+                ProposalStatusFilter::PendingApproval {}
+            )
+            | (data::ProposalStatus::Rejected, ProposalStatusFilter::Rejected {})
+            | (data::ProposalStatus::Cancelled, ProposalStatusFilter::Cancelled {})
+            | (data::ProposalStatus::Executing, ProposalStatusFilter::Executing {})
+            | (data::ProposalStatus::Executed, ProposalStatusFilter::Executed {})
+            | (data::ProposalStatus::Failed(_), ProposalStatusFilter::Failed {})
+    )
+}
+
+pub fn map_proposal_response(proposal_id: Uuid, proposal: data::Proposal) -> Proposal {
+    Proposal {
         id: proposal_id.to_string(),
         project_id: proposal.project_id.to_string(),
+        proposer_id: proposal.proposer_id.to_string(),
         status: match proposal.status {
             data::ProposalStatus::Open => Some(ProposalStatus::Open {}),
             data::ProposalStatus::PendingApproval {
@@ -79,6 +100,7 @@ pub fn map_create_proposal_response(
                     .collect(),
             }),
             data::ProposalStatus::Rejected => Some(ProposalStatus::Rejected {}),
+            data::ProposalStatus::Cancelled => Some(ProposalStatus::Cancelled {}),
             data::ProposalStatus::Executing => Some(ProposalStatus::Executing {}),
             data::ProposalStatus::Executed => Some(ProposalStatus::Executed {}),
             data::ProposalStatus::Failed(err) => Some(ProposalStatus::Failed { message: err }),

--- a/src/backend/src/mapping/user_profile.rs
+++ b/src/backend/src/mapping/user_profile.rs
@@ -1,7 +1,10 @@
 use crate::{
     data,
     data::UserStatsData,
-    dto::{GetUserStatsResponse, ListUserProfilesResponse, UserProfile, UserStatus},
+    dto::{
+        GetUserProfilesByPrincipalsResponse, GetUserStatsResponse, ListUserProfilesResponse,
+        UserProfile, UserProfileBrief, UserProfileByPrincipal, UserStatus,
+    },
 };
 use candid::Principal;
 use canister_utils::Uuid;
@@ -57,6 +60,22 @@ pub fn map_user_status_response(status: data::UserStatus) -> UserStatus {
         data::UserStatus::Active => UserStatus::Active,
         data::UserStatus::Inactive => UserStatus::Inactive,
     }
+}
+
+pub fn map_get_user_profiles_by_principals_response(
+    lookups: Vec<(Principal, Option<(Uuid, data::UserProfile)>)>,
+) -> GetUserProfilesByPrincipalsResponse {
+    lookups
+        .into_iter()
+        .map(|(subject_principal, found)| UserProfileByPrincipal {
+            subject_principal,
+            profile: found.map(|(id, profile)| UserProfileBrief {
+                id: id.to_string(),
+                email: profile.email,
+                email_verified: profile.email_verified,
+            }),
+        })
+        .collect()
 }
 
 pub fn map_get_user_stats_response(stats: UserStatsData) -> GetUserStatsResponse {

--- a/src/backend/src/mapping/user_profile.rs
+++ b/src/backend/src/mapping/user_profile.rs
@@ -65,17 +65,19 @@ pub fn map_user_status_response(status: data::UserStatus) -> UserStatus {
 pub fn map_get_user_profiles_by_principals_response(
     lookups: Vec<(Principal, Option<(Uuid, data::UserProfile)>)>,
 ) -> GetUserProfilesByPrincipalsResponse {
-    lookups
-        .into_iter()
-        .map(|(subject_principal, found)| UserProfileByPrincipal {
-            subject_principal,
-            profile: found.map(|(id, profile)| UserProfileBrief {
-                id: id.to_string(),
-                email: profile.email,
-                email_verified: profile.email_verified,
-            }),
-        })
-        .collect()
+    GetUserProfilesByPrincipalsResponse {
+        profiles: lookups
+            .into_iter()
+            .map(|(subject_principal, found)| UserProfileByPrincipal {
+                subject_principal,
+                profile: found.map(|(id, profile)| UserProfileBrief {
+                    id: id.to_string(),
+                    email: profile.email,
+                    email_verified: profile.email_verified,
+                }),
+            })
+            .collect(),
+    }
 }
 
 pub fn map_get_user_stats_response(stats: UserStatsData) -> GetUserStatsResponse {

--- a/src/backend/src/service/access_control_service.rs
+++ b/src/backend/src/service/access_control_service.rs
@@ -24,6 +24,12 @@ pub fn team_not_found_or_no_access(team_id: Uuid) -> ApiError {
     ))
 }
 
+pub fn proposal_not_found_or_no_access(proposal_id: Uuid) -> ApiError {
+    ApiError::client_error(format!(
+        "Proposal with id {proposal_id} does not exist or you do not have access."
+    ))
+}
+
 pub fn assert_trusted_partner(caller: &Principal) -> ApiResult {
     assert_authenticated(caller)?;
 
@@ -133,16 +139,16 @@ impl OrgAuth {
     }
 }
 
-// Proof that the caller has been resolved to a user, has at least one team
-// linked to `project_id`, and that team (or the union across their teams)
-// holds at least the permissions implied by the construction call. The only
-// way to obtain a `ProjectAuth` is via `require`.
+// Proof that a user has at least one team linked to `project_id`, and that
+// team (or the union across their teams) holds at least the permissions
+// implied by the construction call. Obtain via `require` (resolves the caller
+// principal first) or `for_user` (when the user id is already known, e.g.
+// when validating a peer user's membership).
 //
 // Use `ProjectPermissions::EMPTY` as the `needed` argument for read-only
 // endpoints that require project access but no specific capability.
 #[derive(Debug, Clone, Copy)]
 pub struct ProjectAuth {
-    #[allow(dead_code)]
     user_id: Uuid,
     project_id: Uuid,
     org_id: Uuid,
@@ -156,7 +162,17 @@ impl ProjectAuth {
         needed: ProjectPermissions,
     ) -> ApiResult<Self> {
         let user_id = user_profile_repository::assert_user_id_by_principal(caller)?;
+        Self::for_user(user_id, project_id, needed)
+    }
 
+    // Same checks as `require`, but skips the principal-to-user lookup
+    // because the caller has already resolved it. Used when validating that
+    // some other user (not the request caller) belongs to a project.
+    pub fn for_user(
+        user_id: Uuid,
+        project_id: Uuid,
+        needed: ProjectPermissions,
+    ) -> ApiResult<Self> {
         // Collapse "project does not exist" and "caller is not in project's
         // org" into the same generic error. A caller outside the org must
         // not be able to tell whether a project id is real or learn which
@@ -194,7 +210,6 @@ impl ProjectAuth {
         })
     }
 
-    #[allow(dead_code)]
     pub fn user_id(&self) -> Uuid {
         self.user_id
     }
@@ -207,7 +222,6 @@ impl ProjectAuth {
         self.org_id
     }
 
-    #[allow(dead_code)]
     pub fn perms(&self) -> ProjectPermissions {
         self.perms
     }

--- a/src/backend/src/service/proposal_service.rs
+++ b/src/backend/src/service/proposal_service.rs
@@ -1,15 +1,22 @@
 use crate::{
     data::{
         approval_policy_repository, proposal_repository, proposal_repository::VoteOutcome,
-        OperationType, PolicyType, ProjectPermissions, Proposal, ProposalOperation,
+        OperationType, PolicyType, ProjectPermissions, Proposal, ProposalOperation, ProposalStatus,
     },
     dto::{
-        CreateProposalRequest, CreateProposalResponse, VoteProposalRequest, VoteProposalResponse,
+        CancelProposalRequest, CancelProposalResponse, CreateProposalRequest,
+        CreateProposalResponse, GetProposalRequest, GetProposalResponse,
+        ListProjectProposalsRequest, ListProjectProposalsResponse, VoteProposalRequest,
+        VoteProposalResponse,
     },
     mapping::{
-        map_create_proposal_request, map_create_proposal_response, map_vote_proposal_request,
+        map_create_proposal_request, map_list_project_proposals_response, map_proposal_response,
+        map_vote_proposal_request, proposal_matches_status_filter,
     },
-    service::{access_control_service, access_control_service::ProjectAuth, canister_service},
+    service::{
+        access_control_service, access_control_service::proposal_not_found_or_no_access,
+        access_control_service::ProjectAuth, canister_service,
+    },
 };
 use candid::Principal;
 use canister_utils::{ApiError, ApiResult, Uuid};
@@ -18,10 +25,16 @@ pub async fn create_proposal(
     caller: &Principal,
     req: CreateProposalRequest,
 ) -> ApiResult<CreateProposalResponse> {
-    let (project_id, proposal) = map_create_proposal_request(req)?;
+    let (project_id, operation) = map_create_proposal_request(req)?;
 
-    ProjectAuth::require(caller, project_id, ProjectPermissions::PROPOSAL_CREATE)?;
+    let auth = ProjectAuth::require(caller, project_id, ProjectPermissions::PROPOSAL_CREATE)?;
 
+    let proposal = Proposal {
+        project_id,
+        proposer_id: auth.user_id(),
+        status: ProposalStatus::Open,
+        operation,
+    };
     let proposal_id = proposal_repository::create_proposal(project_id, proposal.clone());
 
     process_proposal(project_id, proposal_id, proposal.clone()).await?;
@@ -32,7 +45,62 @@ pub async fn create_proposal(
         ))
     })?;
 
-    Ok(map_create_proposal_response(proposal_id, proposal))
+    Ok(map_proposal_response(proposal_id, proposal))
+}
+
+pub fn get_proposal(
+    caller: &Principal,
+    req: GetProposalRequest,
+) -> ApiResult<GetProposalResponse> {
+    let proposal_id = Uuid::try_from(req.proposal_id.as_str())?;
+
+    let proposal = proposal_repository::get_proposal(&proposal_id)
+        .ok_or_else(|| proposal_not_found_or_no_access(proposal_id))?;
+
+    ProjectAuth::require(caller, proposal.project_id, ProjectPermissions::EMPTY)
+        .map_err(|_| proposal_not_found_or_no_access(proposal_id))?;
+
+    Ok(map_proposal_response(proposal_id, proposal))
+}
+
+const DEFAULT_PAGE_SIZE: u32 = 50;
+const MAX_PAGE_SIZE: u32 = 500;
+
+pub fn list_project_proposals(
+    caller: &Principal,
+    req: ListProjectProposalsRequest,
+) -> ApiResult<ListProjectProposalsResponse> {
+    let project_id = Uuid::try_from(req.project_id.as_str())?;
+    let auth = ProjectAuth::require(caller, project_id, ProjectPermissions::EMPTY)?;
+
+    let after = req.after.as_deref().map(Uuid::try_from).transpose()?;
+    let limit = req
+        .limit
+        .unwrap_or(DEFAULT_PAGE_SIZE)
+        .min(MAX_PAGE_SIZE) as usize;
+
+    let scanned = proposal_repository::list_project_proposals(auth.project_id(), after, limit);
+
+    // Cursor advances by scan position, not filter-matched position, so a
+    // sparse status filter doesn't force the next page to re-scan ids the
+    // current call already excluded.
+    let next_cursor = (scanned.len() == limit)
+        .then(|| scanned.last().map(|(id, _)| *id))
+        .flatten();
+
+    let proposals = match req.status_filter.as_ref() {
+        Some(filters) => scanned
+            .into_iter()
+            .filter(|(_, p)| {
+                filters
+                    .iter()
+                    .any(|f| proposal_matches_status_filter(p, f))
+            })
+            .collect(),
+        None => scanned,
+    };
+
+    Ok(map_list_project_proposals_response(proposals, next_cursor))
 }
 
 async fn process_proposal(project_id: Uuid, proposal_id: Uuid, proposal: Proposal) -> ApiResult {
@@ -106,13 +174,17 @@ pub async fn vote_proposal(
     let (proposal_id, vote) = map_vote_proposal_request(req)?;
 
     let proposal = proposal_repository::get_proposal(&proposal_id)
-        .ok_or_else(|| ApiError::client_error(format!("Proposal {proposal_id} does not exist.")))?;
+        .ok_or_else(|| proposal_not_found_or_no_access(proposal_id))?;
 
-    ProjectAuth::require(
-        caller,
-        proposal.project_id,
-        ProjectPermissions::PROPOSAL_APPROVE,
-    )?;
+    let auth = ProjectAuth::require(caller, proposal.project_id, ProjectPermissions::EMPTY)
+        .map_err(|_| proposal_not_found_or_no_access(proposal_id))?;
+    if !auth.perms().contains(ProjectPermissions::PROPOSAL_APPROVE) {
+        return Err(ApiError::unauthorized(format!(
+            "User {} lacks proposal_approve on project {}.",
+            auth.user_id(),
+            auth.project_id()
+        )));
+    }
 
     let outcome = proposal_repository::record_proposal_vote(proposal_id, *caller, vote)?;
 
@@ -126,5 +198,36 @@ pub async fn vote_proposal(
         ))
     })?;
 
-    Ok(map_create_proposal_response(proposal_id, updated))
+    Ok(map_proposal_response(proposal_id, updated))
+}
+
+pub fn cancel_proposal(
+    caller: &Principal,
+    req: CancelProposalRequest,
+) -> ApiResult<CancelProposalResponse> {
+    let proposal_id = Uuid::try_from(req.proposal_id.as_str())?;
+
+    let proposal = proposal_repository::get_proposal(&proposal_id)
+        .ok_or_else(|| proposal_not_found_or_no_access(proposal_id))?;
+
+    let auth = ProjectAuth::require(caller, proposal.project_id, ProjectPermissions::EMPTY)
+        .map_err(|_| proposal_not_found_or_no_access(proposal_id))?;
+    if auth.user_id() != proposal.proposer_id
+        && !auth.perms().contains(ProjectPermissions::PROJECT_ADMIN)
+    {
+        return Err(ApiError::unauthorized(format!(
+            "User {} cannot cancel proposal {proposal_id}: must be the proposer or a project admin.",
+            auth.user_id()
+        )));
+    }
+
+    proposal_repository::cancel_proposal(proposal_id)?;
+
+    let updated = proposal_repository::get_proposal(&proposal_id).ok_or_else(|| {
+        ApiError::internal_error(format!(
+            "Could not find proposal {proposal_id} after cancelling"
+        ))
+    })?;
+
+    Ok(map_proposal_response(proposal_id, updated))
 }

--- a/src/backend/src/service/proposal_service.rs
+++ b/src/backend/src/service/proposal_service.rs
@@ -48,10 +48,7 @@ pub async fn create_proposal(
     Ok(map_proposal_response(proposal_id, proposal))
 }
 
-pub fn get_proposal(
-    caller: &Principal,
-    req: GetProposalRequest,
-) -> ApiResult<GetProposalResponse> {
+pub fn get_proposal(caller: &Principal, req: GetProposalRequest) -> ApiResult<GetProposalResponse> {
     let proposal_id = Uuid::try_from(req.proposal_id.as_str())?;
 
     let proposal = proposal_repository::get_proposal(&proposal_id)
@@ -74,10 +71,7 @@ pub fn list_project_proposals(
     let auth = ProjectAuth::require(caller, project_id, ProjectPermissions::EMPTY)?;
 
     let after = req.after.as_deref().map(Uuid::try_from).transpose()?;
-    let limit = req
-        .limit
-        .unwrap_or(DEFAULT_PAGE_SIZE)
-        .min(MAX_PAGE_SIZE) as usize;
+    let limit = req.limit.unwrap_or(DEFAULT_PAGE_SIZE).min(MAX_PAGE_SIZE) as usize;
 
     let scanned = proposal_repository::list_project_proposals(auth.project_id(), after, limit);
 
@@ -91,11 +85,7 @@ pub fn list_project_proposals(
     let proposals = match req.status_filter.as_ref() {
         Some(filters) => scanned
             .into_iter()
-            .filter(|(_, p)| {
-                filters
-                    .iter()
-                    .any(|f| proposal_matches_status_filter(p, f))
-            })
+            .filter(|(_, p)| filters.iter().any(|f| proposal_matches_status_filter(p, f)))
             .collect(),
         None => scanned,
     };

--- a/src/backend/src/service/proposal_service.rs
+++ b/src/backend/src/service/proposal_service.rs
@@ -1,4 +1,5 @@
 use crate::{
+    constants::{DEFAULT_PAGINATION_LIMIT, MAX_PAGINATION_LIMIT, MIN_PAGINATION_LIMIT},
     data::{
         approval_policy_repository, proposal_repository, proposal_repository::VoteOutcome,
         OperationType, PolicyType, ProjectPermissions, Proposal, ProposalOperation, ProposalStatus,
@@ -60,9 +61,6 @@ pub fn get_proposal(caller: &Principal, req: GetProposalRequest) -> ApiResult<Ge
     Ok(map_proposal_response(proposal_id, proposal))
 }
 
-const DEFAULT_PAGE_SIZE: u32 = 50;
-const MAX_PAGE_SIZE: u32 = 500;
-
 pub fn list_project_proposals(
     caller: &Principal,
     req: ListProjectProposalsRequest,
@@ -71,24 +69,25 @@ pub fn list_project_proposals(
     let auth = ProjectAuth::require(caller, project_id, ProjectPermissions::EMPTY)?;
 
     let after = req.after.as_deref().map(Uuid::try_from).transpose()?;
-    let limit = req.limit.unwrap_or(DEFAULT_PAGE_SIZE).min(MAX_PAGE_SIZE) as usize;
+    let limit = req
+        .limit
+        .unwrap_or(DEFAULT_PAGINATION_LIMIT)
+        .clamp(MIN_PAGINATION_LIMIT, MAX_PAGINATION_LIMIT) as usize;
 
-    let scanned = proposal_repository::list_project_proposals(auth.project_id(), after, limit);
+    let status_filter = req.status_filter.as_ref();
+    let proposals =
+        proposal_repository::list_project_proposals(auth.project_id(), after, limit, |proposal| {
+            match status_filter {
+                Some(filters) => filters
+                    .iter()
+                    .any(|f| proposal_matches_status_filter(proposal, f)),
+                None => true,
+            }
+        });
 
-    // Cursor advances by scan position, not filter-matched position, so a
-    // sparse status filter doesn't force the next page to re-scan ids the
-    // current call already excluded.
-    let next_cursor = (scanned.len() == limit)
-        .then(|| scanned.last().map(|(id, _)| *id))
+    let next_cursor = (proposals.len() == limit)
+        .then(|| proposals.last().map(|(id, _)| *id))
         .flatten();
-
-    let proposals = match req.status_filter.as_ref() {
-        Some(filters) => scanned
-            .into_iter()
-            .filter(|(_, p)| filters.iter().any(|f| proposal_matches_status_filter(p, f)))
-            .collect(),
-        None => scanned,
-    };
 
     Ok(map_list_project_proposals_response(proposals, next_cursor))
 }

--- a/src/backend/src/service/user_profile_service.rs
+++ b/src/backend/src/service/user_profile_service.rs
@@ -44,10 +44,11 @@ pub fn get_user_profiles_by_principals(
         .principals
         .into_iter()
         .map(|principal| {
-            let found = user_profile_repository::get_user_profile_by_principal(&principal)
-                .filter(|(user_id, _)| {
+            let found = user_profile_repository::get_user_profile_by_principal(&principal).filter(
+                |(user_id, _)| {
                     ProjectAuth::for_user(*user_id, project_id, ProjectPermissions::EMPTY).is_ok()
-                });
+                },
+            );
             (principal, found)
         })
         .collect();

--- a/src/backend/src/service/user_profile_service.rs
+++ b/src/backend/src/service/user_profile_service.rs
@@ -1,20 +1,22 @@
 use crate::{
     data::{
         approval_policy_repository, organization_repository, project_repository, team_repository,
-        user_profile_repository, ApprovalPolicy, OperationType, PolicyType, UserProfile,
-        UserStatus,
+        user_profile_repository, ApprovalPolicy, OperationType, PolicyType, ProjectPermissions,
+        UserProfile, UserStatus,
     },
     dto::{
-        CreateMyUserProfileResponse, GetMyUserProfileResponse, GetUserStatsResponse,
-        ListUserProfilesResponse, UpdateMyUserProfileRequest, UpdateUserProfileRequest,
-        VerifyEmailRequest,
+        CreateMyUserProfileResponse, GetMyUserProfileResponse, GetUserProfilesByPrincipalsRequest,
+        GetUserProfilesByPrincipalsResponse, GetUserStatsResponse, ListUserProfilesResponse,
+        UpdateMyUserProfileRequest, UpdateUserProfileRequest, VerifyEmailRequest,
     },
     env,
     jwt::{extract_ed25519_public_key_from_pem, verify_jwt},
     mapping::{
         map_create_my_user_profile_response, map_get_my_user_profile_response,
-        map_get_user_stats_response, map_list_user_profiles_response, map_user_status_request,
+        map_get_user_profiles_by_principals_response, map_get_user_stats_response,
+        map_list_user_profiles_response, map_user_status_request,
     },
+    service::access_control_service::ProjectAuth,
 };
 use candid::Principal;
 use canister_utils::{ApiError, ApiResult, Uuid};
@@ -29,6 +31,27 @@ struct Claims {
 
 pub fn list_user_profiles() -> ListUserProfilesResponse {
     map_list_user_profiles_response(user_profile_repository::list_user_profiles())
+}
+
+pub fn get_user_profiles_by_principals(
+    caller: &Principal,
+    req: GetUserProfilesByPrincipalsRequest,
+) -> ApiResult<GetUserProfilesByPrincipalsResponse> {
+    let project_id = Uuid::try_from(req.project_id.as_str())?;
+    ProjectAuth::require(caller, project_id, ProjectPermissions::EMPTY)?;
+
+    let lookups = req
+        .principals
+        .into_iter()
+        .map(|principal| {
+            let found = user_profile_repository::get_user_profile_by_principal(&principal)
+                .filter(|(user_id, _)| {
+                    ProjectAuth::for_user(*user_id, project_id, ProjectPermissions::EMPTY).is_ok()
+                });
+            (principal, found)
+        })
+        .collect();
+    Ok(map_get_user_profiles_by_principals_response(lookups))
 }
 
 pub fn update_user_profile(req: UpdateUserProfileRequest) -> ApiResult {


### PR DESCRIPTION
Expose get_proposal, list_project_proposals (with status filter and cursor pagination), and cancel_proposal; track proposer_id on proposals and add a Cancelled status. Add get_user_profiles_by_principals so project members can be resolved from voter principals. Backend tests cover the new endpoints, access checks, and cancel state transitions.