### PR TITLE
feat: surface approval policies and pending-proposal outcomes in frontend

### DIFF
--- a/src/frontend/src/components/approval-policy-editor.tsx
+++ b/src/frontend/src/components/approval-policy-editor.tsx
@@ -1,0 +1,149 @@
+import { LoadingButton } from '@/components/loading-button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  ApprovalOperationType,
+  approvalOperationLabel,
+  type ApprovalPolicy,
+  type ApprovalPolicyType,
+} from '@/lib/api-models';
+import { showErrorToast } from '@/lib/toast';
+import { useEffect, useState } from 'react';
+
+export type ApprovalPolicyEditorProps = {
+  operationType: ApprovalOperationType;
+  value: ApprovalPolicyType;
+  disabled?: boolean;
+  onSave: (next: ApprovalPolicyType) => Promise<ApprovalPolicy>;
+};
+
+type DraftKind = 'AutoApprove' | 'FixedQuorum';
+
+export function ApprovalPolicyEditor({
+  operationType,
+  value,
+  disabled,
+  onSave,
+}: ApprovalPolicyEditorProps) {
+  const [kind, setKind] = useState<DraftKind>(value.kind);
+  const [thresholdText, setThresholdText] = useState<string>(
+    value.kind === 'FixedQuorum' ? String(value.threshold) : '1',
+  );
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    setKind(value.kind);
+    setThresholdText(
+      value.kind === 'FixedQuorum' ? String(value.threshold) : '1',
+    );
+  }, [value]);
+
+  const parsedThreshold = Number.parseInt(thresholdText, 10);
+  const thresholdValid =
+    Number.isFinite(parsedThreshold) && parsedThreshold > 0;
+  const draft: ApprovalPolicyType =
+    kind === 'AutoApprove'
+      ? { kind: 'AutoApprove' }
+      : { kind: 'FixedQuorum', threshold: parsedThreshold };
+
+  const isDirty =
+    draft.kind !== value.kind ||
+    (draft.kind === 'FixedQuorum' &&
+      value.kind === 'FixedQuorum' &&
+      draft.threshold !== value.threshold);
+
+  const canSubmit =
+    !disabled && isDirty && (kind === 'AutoApprove' || thresholdValid);
+
+  async function handleSave() {
+    if (!canSubmit) return;
+    setIsSaving(true);
+    try {
+      await onSave(draft);
+    } catch (err) {
+      showErrorToast('Failed to update approval policy', err);
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  const radioName = `approval-policy-${operationType}`;
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm font-medium">
+        {approvalOperationLabel(operationType)}
+      </p>
+
+      <div className="space-y-3">
+        <div className="flex items-start gap-2">
+          <input
+            id={`${radioName}-auto`}
+            type="radio"
+            className="mt-0.5"
+            name={radioName}
+            disabled={disabled || isSaving}
+            checked={kind === 'AutoApprove'}
+            onChange={() => setKind('AutoApprove')}
+          />
+          <div className="grid gap-1">
+            <Label htmlFor={`${radioName}-auto`}>Auto-approve</Label>
+            <p className="text-muted-foreground text-xs">
+              Proposals execute immediately without a vote.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-start gap-2">
+          <input
+            id={`${radioName}-quorum`}
+            type="radio"
+            className="mt-0.5"
+            name={radioName}
+            disabled={disabled || isSaving}
+            checked={kind === 'FixedQuorum'}
+            onChange={() => setKind('FixedQuorum')}
+          />
+          <div className="grid w-full gap-2">
+            <div className="grid gap-1">
+              <Label htmlFor={`${radioName}-quorum`}>Require approvals</Label>
+              <p className="text-muted-foreground text-xs">
+                Proposals enter pending approval and execute once the threshold
+                of approvers is reached.
+              </p>
+            </div>
+            {kind === 'FixedQuorum' && (
+              <div className="flex items-center gap-2">
+                <Label
+                  htmlFor={`${radioName}-threshold`}
+                  className="text-xs font-normal"
+                >
+                  Threshold
+                </Label>
+                <Input
+                  id={`${radioName}-threshold`}
+                  type="number"
+                  inputMode="numeric"
+                  min={1}
+                  step={1}
+                  className="h-8 w-24"
+                  disabled={disabled || isSaving}
+                  value={thresholdText}
+                  onChange={e => setThresholdText(e.target.value)}
+                />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <LoadingButton
+        isLoading={isSaving}
+        disabled={!canSubmit}
+        onClick={handleSave}
+      >
+        Save Policy
+      </LoadingButton>
+    </div>
+  );
+}

--- a/src/frontend/src/components/layout/project-selector.tsx
+++ b/src/frontend/src/components/layout/project-selector.tsx
@@ -20,7 +20,7 @@ import {
   selectProjectMap,
   useAppStore,
 } from '@/lib/store';
-import { ChevronsUpDown, FolderOpen, Plus, Settings } from 'lucide-react';
+import { Box, ChevronsUpDown, FolderOpen, Plus, Settings } from 'lucide-react';
 import { useMemo, type FC } from 'react';
 import { NavLink, useParams } from 'react-router';
 
@@ -79,6 +79,20 @@ export const ProjectSelector: FC = () => {
           </DropdownMenuTrigger>
 
           <DropdownMenuContent side={isMobile ? 'bottom' : 'right'}>
+            <DropdownMenuGroup>
+              <DropdownMenuItem
+                className="p-2"
+                render={
+                  <NavLink to={`/projects/${activeProject.id}/canisters`} />
+                }
+              >
+                <Box className="size-3.5" />
+                Open Canisters
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
+
+            <DropdownMenuSeparator />
+
             {activeOrgProjects.length > 1 && (
               <>
                 <DropdownMenuGroup>

--- a/src/frontend/src/lib/api-models/approval-policy.ts
+++ b/src/frontend/src/lib/api-models/approval-policy.ts
@@ -1,0 +1,128 @@
+import { mapOkResponse } from '@/lib/api-models/error';
+import type {
+  ApprovalPolicy as ApiApprovalPolicy,
+  ListProjectApprovalPoliciesRequest as ApiListProjectApprovalPoliciesRequest,
+  ListProjectApprovalPoliciesResponse as ApiListProjectApprovalPoliciesResponse,
+  OperationType as ApiOperationType,
+  PolicyType as ApiPolicyType,
+  UpsertApprovalPolicyRequest as ApiUpsertApprovalPolicyRequest,
+  UpsertApprovalPolicyResponse as ApiUpsertApprovalPolicyResponse,
+} from '@ssn/backend-api';
+
+export enum ApprovalOperationType {
+  CreateCanister = 'CreateCanister',
+  AddCanisterController = 'AddCanisterController',
+}
+
+export const APPROVAL_OPERATION_TYPES: ApprovalOperationType[] = [
+  ApprovalOperationType.CreateCanister,
+  ApprovalOperationType.AddCanisterController,
+];
+
+export type ApprovalPolicyType =
+  | { kind: 'AutoApprove' }
+  | { kind: 'FixedQuorum'; threshold: number };
+
+export type ApprovalPolicy = {
+  id: string;
+  operationType: ApprovalOperationType;
+  policyType: ApprovalPolicyType;
+};
+
+export type ListProjectApprovalPoliciesRequest = {
+  projectId: string;
+};
+
+export type ListProjectApprovalPoliciesResponse = {
+  approvalPolicies: ApprovalPolicy[];
+};
+
+export type UpsertApprovalPolicyRequest = {
+  projectId: string;
+  operationType: ApprovalOperationType;
+  policyType: ApprovalPolicyType;
+};
+
+export function mapListProjectApprovalPoliciesRequest(
+  req: ListProjectApprovalPoliciesRequest,
+): ApiListProjectApprovalPoliciesRequest {
+  return { project_id: req.projectId };
+}
+
+export function mapListProjectApprovalPoliciesResponse(
+  res: ApiListProjectApprovalPoliciesResponse,
+): ListProjectApprovalPoliciesResponse {
+  const okRes = mapOkResponse(res);
+  return {
+    approvalPolicies: okRes.approval_policies.map(mapApprovalPolicyResponse),
+  };
+}
+
+export function mapUpsertApprovalPolicyRequest(
+  req: UpsertApprovalPolicyRequest,
+): ApiUpsertApprovalPolicyRequest {
+  return {
+    project_id: req.projectId,
+    operation_type: mapApprovalOperationTypeToApi(req.operationType),
+    policy_type: mapApprovalPolicyTypeToApi(req.policyType),
+  };
+}
+
+export function mapUpsertApprovalPolicyResponse(
+  res: ApiUpsertApprovalPolicyResponse,
+): ApprovalPolicy {
+  return mapApprovalPolicyResponse(mapOkResponse(res));
+}
+
+export function mapApprovalPolicyResponse(
+  res: ApiApprovalPolicy,
+): ApprovalPolicy {
+  return {
+    id: res.id,
+    operationType: mapApprovalOperationType(res.operation_type),
+    policyType: mapApprovalPolicyType(res.policy_type),
+  };
+}
+
+function mapApprovalOperationType(op: ApiOperationType): ApprovalOperationType {
+  if ('CreateCanister' in op) {
+    return ApprovalOperationType.CreateCanister;
+  }
+  return ApprovalOperationType.AddCanisterController;
+}
+
+function mapApprovalOperationTypeToApi(
+  op: ApprovalOperationType,
+): ApiOperationType {
+  if (op === ApprovalOperationType.CreateCanister) {
+    return { CreateCanister: {} };
+  }
+  return { AddCanisterController: {} };
+}
+
+function mapApprovalPolicyType(p: ApiPolicyType): ApprovalPolicyType {
+  if ('AutoApprove' in p) {
+    return { kind: 'AutoApprove' };
+  }
+  return { kind: 'FixedQuorum', threshold: p.FixedQuorum.threshold };
+}
+
+function mapApprovalPolicyTypeToApi(p: ApprovalPolicyType): ApiPolicyType {
+  if (p.kind === 'AutoApprove') {
+    return { AutoApprove: {} };
+  }
+  return { FixedQuorum: { threshold: p.threshold } };
+}
+
+export const DEFAULT_APPROVAL_POLICY_TYPE: ApprovalPolicyType = {
+  kind: 'AutoApprove',
+};
+
+export function approvalOperationLabel(op: ApprovalOperationType): string {
+  switch (op) {
+    case ApprovalOperationType.CreateCanister:
+      return 'Create canister';
+    case ApprovalOperationType.AddCanisterController:
+      return 'Add canister controller';
+  }
+}

--- a/src/frontend/src/lib/api-models/index.ts
+++ b/src/frontend/src/lib/api-models/index.ts
@@ -1,3 +1,4 @@
+export * from './approval-policy';
 export * from './canister';
 export * from './canister-history';
 export * from './error';
@@ -6,6 +7,7 @@ export * from './management-canister';
 export * from './organization';
 export * from './permissions';
 export * from './project';
+export * from './proposal';
 export * from './team';
 export * from './terms-and-conditions';
 export * from './trusted-partner';

--- a/src/frontend/src/lib/api-models/proposal.ts
+++ b/src/frontend/src/lib/api-models/proposal.ts
@@ -1,0 +1,26 @@
+import { isNil } from '@/lib/nil';
+import type { Proposal as ApiProposal } from '@ssn/backend-api';
+
+export type ProposalOutcome =
+  | { kind: 'executed' }
+  | { kind: 'pendingApproval'; proposalId: string };
+
+export function readProposalOutcome(proposal: ApiProposal): ProposalOutcome {
+  const [status] = proposal.status;
+  if (isNil(status)) {
+    throw new Error('Proposal returned without a status');
+  }
+  if ('Failed' in status) {
+    throw new Error(status.Failed.message);
+  }
+  if ('Rejected' in status) {
+    throw new Error('Proposal was rejected');
+  }
+  if ('Cancelled' in status) {
+    throw new Error('Proposal was cancelled');
+  }
+  if ('PendingApproval' in status) {
+    return { kind: 'pendingApproval', proposalId: proposal.id };
+  }
+  return { kind: 'executed' };
+}

--- a/src/frontend/src/lib/api/approval-policy.ts
+++ b/src/frontend/src/lib/api/approval-policy.ts
@@ -1,0 +1,34 @@
+import {
+  mapListProjectApprovalPoliciesRequest,
+  mapListProjectApprovalPoliciesResponse,
+  mapUpsertApprovalPolicyRequest,
+  mapUpsertApprovalPolicyResponse,
+  type ApprovalPolicy,
+  type ListProjectApprovalPoliciesRequest,
+  type ListProjectApprovalPoliciesResponse,
+  type UpsertApprovalPolicyRequest,
+} from '@/lib/api-models';
+import type { ActorSubclass } from '@icp-sdk/core/agent';
+import type { _SERVICE } from '@ssn/backend-api';
+
+export class ApprovalPolicyApi {
+  constructor(private readonly actor: ActorSubclass<_SERVICE>) {}
+
+  public async listProjectApprovalPolicies(
+    req: ListProjectApprovalPoliciesRequest,
+  ): Promise<ListProjectApprovalPoliciesResponse> {
+    const res = await this.actor.list_project_approval_policies(
+      mapListProjectApprovalPoliciesRequest(req),
+    );
+    return mapListProjectApprovalPoliciesResponse(res);
+  }
+
+  public async upsertApprovalPolicy(
+    req: UpsertApprovalPolicyRequest,
+  ): Promise<ApprovalPolicy> {
+    const res = await this.actor.upsert_approval_policy(
+      mapUpsertApprovalPolicyRequest(req),
+    );
+    return mapUpsertApprovalPolicyResponse(res);
+  }
+}

--- a/src/frontend/src/lib/api/canister.ts
+++ b/src/frontend/src/lib/api/canister.ts
@@ -2,29 +2,18 @@ import {
   mapListMyCanistersResponse,
   mapListUserCanistersResponse,
   mapOkResponse,
+  readProposalOutcome,
   type ListMyCanistersRequest,
   type ListMyCanistersResponse,
   type ListUserCanistersRequest,
   type ListUserCanistersResponse,
+  type ProposalOutcome,
 } from '@/lib/api-models';
 import { isNil } from '@/lib/nil';
 import { toCandidOpt } from '@/lib/utils';
 import type { ActorSubclass } from '@icp-sdk/core/agent';
 import { Principal } from '@icp-sdk/core/principal';
-import type { _SERVICE, Proposal } from '@ssn/backend-api';
-
-function assertProposalExecuted(proposal: Proposal): void {
-  const [status] = proposal.status;
-  if (isNil(status)) {
-    throw new Error('Proposal returned without a status');
-  }
-  if ('Failed' in status) {
-    throw new Error(status.Failed.message);
-  }
-  if ('Rejected' in status) {
-    throw new Error('Proposal was rejected');
-  }
-}
+import type { _SERVICE } from '@ssn/backend-api';
 
 export class CanisterApi {
   constructor(private readonly actor: ActorSubclass<_SERVICE>) {}
@@ -45,7 +34,7 @@ export class CanisterApi {
     return mapListUserCanistersResponse(res);
   }
 
-  public async createCanister(projectId: string): Promise<void> {
+  public async createCanister(projectId: string): Promise<ProposalOutcome> {
     const createRes = await this.actor.create_proposal({
       project_id: projectId,
       operation: [
@@ -54,7 +43,7 @@ export class CanisterApi {
         },
       ],
     });
-    assertProposalExecuted(mapOkResponse(createRes));
+    return readProposalOutcome(mapOkResponse(createRes));
   }
 
   public async removeCanister(canisterId: string): Promise<void> {
@@ -78,7 +67,7 @@ export class CanisterApi {
   public async addCanisterController(
     canisterId: string,
     controllerId: string,
-  ): Promise<void> {
+  ): Promise<ProposalOutcome> {
     const res = await this.actor.list_my_projects({});
     const [project] = mapOkResponse(res).projects;
     if (isNil(project)) {
@@ -96,6 +85,6 @@ export class CanisterApi {
         },
       ],
     });
-    assertProposalExecuted(mapOkResponse(createRes));
+    return readProposalOutcome(mapOkResponse(createRes));
   }
 }

--- a/src/frontend/src/lib/api/index.ts
+++ b/src/frontend/src/lib/api/index.ts
@@ -1,3 +1,4 @@
+export * from './approval-policy';
 export * from './canister';
 export * from './canister-history';
 export * from './invite';

--- a/src/frontend/src/lib/store/api.ts
+++ b/src/frontend/src/lib/store/api.ts
@@ -4,6 +4,7 @@ import {
   SHOULD_FETCH_ROOT_KEY,
 } from '@/env';
 import {
+  ApprovalPolicyApi,
   CanisterApi,
   CanisterHistoryApi,
   TrustedPartnerApi,
@@ -69,6 +70,7 @@ const teamApi = new TeamApi(actor);
 const inviteApi = new InviteApi(actor);
 const canisterHistoryApi = new CanisterHistoryApi(canisterHistoryActor);
 const authApi = new AuthApi(OFFCHAIN_SERVICE_URL);
+const approvalPolicyApi = new ApprovalPolicyApi(actor);
 
 export const createApiSlice: AppStateCreator<ApiSlice> = (_set, get) => ({
   agent,
@@ -84,6 +86,7 @@ export const createApiSlice: AppStateCreator<ApiSlice> = (_set, get) => ({
   teamApi,
   inviteApi,
   authApi,
+  approvalPolicyApi,
 
   setAgentIdentity: identity => {
     const { agent } = get();

--- a/src/frontend/src/lib/store/app.ts
+++ b/src/frontend/src/lib/store/app.ts
@@ -1,4 +1,5 @@
 import { createApiSlice } from '@/lib/store/api';
+import { createApprovalPoliciesSlice } from '@/lib/store/approval-policy';
 import { createAuthSlice } from '@/lib/store/auth';
 import { createCanistersSlice } from '@/lib/store/canister';
 import { createInvitesSlice } from '@/lib/store/invite';
@@ -24,4 +25,5 @@ export const useAppStore = create<AppSlice>()((...a) => ({
   ...createOrganizationsSlice(...a),
   ...createTeamsSlice(...a),
   ...createInvitesSlice(...a),
+  ...createApprovalPoliciesSlice(...a),
 }));

--- a/src/frontend/src/lib/store/approval-policy.ts
+++ b/src/frontend/src/lib/store/approval-policy.ts
@@ -1,0 +1,16 @@
+import type { AppStateCreator, ApprovalPoliciesSlice } from '@/lib/store/model';
+
+export const createApprovalPoliciesSlice: AppStateCreator<
+  ApprovalPoliciesSlice
+> = (_set, get) => ({
+  async loadProjectApprovalPolicies(projectId) {
+    const res = await get().approvalPolicyApi.listProjectApprovalPolicies({
+      projectId,
+    });
+    return res.approvalPolicies;
+  },
+
+  async upsertApprovalPolicy(req) {
+    return get().approvalPolicyApi.upsertApprovalPolicy(req);
+  },
+});

--- a/src/frontend/src/lib/store/canister.ts
+++ b/src/frontend/src/lib/store/canister.ts
@@ -63,8 +63,9 @@ export const createCanistersSlice: AppStateCreator<CanistersSlice> = (
   async createCanister(projectId) {
     const { canisterApi, refreshCanisters } = get();
 
-    await canisterApi.createCanister(projectId);
+    const outcome = await canisterApi.createCanister(projectId);
     await refreshCanisters(projectId);
+    return outcome;
   },
 
   async addMissingController(canisterId, projectId) {
@@ -88,8 +89,12 @@ export const createCanistersSlice: AppStateCreator<CanistersSlice> = (
   async addController(canisterId, controllerId, projectId) {
     const { canisterApi, refreshCanisters } = get();
 
-    await canisterApi.addCanisterController(canisterId, controllerId);
+    const outcome = await canisterApi.addCanisterController(
+      canisterId,
+      controllerId,
+    );
     await refreshCanisters(projectId);
+    return outcome;
   },
 
   async removeCanister(canisterRecordId, projectId) {

--- a/src/frontend/src/lib/store/index.ts
+++ b/src/frontend/src/lib/store/index.ts
@@ -1,5 +1,6 @@
 export * from './api';
 export * from './app';
+export * from './approval-policy';
 export * from './auth';
 export * from './invite';
 export * from './model';

--- a/src/frontend/src/lib/store/model.ts
+++ b/src/frontend/src/lib/store/model.ts
@@ -1,5 +1,7 @@
 import type {
+  ApprovalPolicy,
   Canister,
+  ProposalOutcome,
   CreateTrustedPartnerRequest,
   CreateOrgInviteRequest,
   OrgInvite,
@@ -8,6 +10,7 @@ import type {
   ProjectPermissions,
   ProjectTeam,
   TrustedPartner,
+  UpsertApprovalPolicyRequest,
   UserProfile,
   UserStatus,
   GetUserStatsResponse,
@@ -19,6 +22,7 @@ import type {
   Team,
 } from '@/lib/api-models';
 import type {
+  ApprovalPolicyApi,
   CanisterApi,
   CanisterHistoryApi,
   TrustedPartnerApi,
@@ -63,8 +67,16 @@ export type ApiSlice = {
   organizationApi: OrganizationApi;
   teamApi: TeamApi;
   inviteApi: InviteApi;
+  approvalPolicyApi: ApprovalPolicyApi;
 
   setAgentIdentity: (identity: Identity) => void;
+};
+
+export type ApprovalPoliciesSlice = {
+  loadProjectApprovalPolicies: (projectId: string) => Promise<ApprovalPolicy[]>;
+  upsertApprovalPolicy: (
+    req: UpsertApprovalPolicyRequest,
+  ) => Promise<ApprovalPolicy>;
 };
 
 export type UserProfileSlice = {
@@ -100,7 +112,7 @@ export type CanistersSlice = {
   initializeCanisters: (projectId: string) => Promise<void>;
   refreshCanisters: (projectId: string) => Promise<void>;
   clearCanisters: () => void;
-  createCanister: (projectId: string) => Promise<void>;
+  createCanister: (projectId: string) => Promise<ProposalOutcome>;
   addMissingController: (
     canisterId: string,
     projectId: string,
@@ -109,7 +121,7 @@ export type CanistersSlice = {
     canisterId: string,
     controllerId: string,
     projectId: string,
-  ) => Promise<void>;
+  ) => Promise<ProposalOutcome>;
   removeCanister: (
     canisterRecordId: string,
     projectId: string,
@@ -222,6 +234,7 @@ export type AppSlice = AuthSlice &
   ProjectsSlice &
   OrganizationsSlice &
   TeamsSlice &
-  InvitesSlice;
+  InvitesSlice &
+  ApprovalPoliciesSlice;
 
 export type AppStateCreator<T> = StateCreator<AppSlice, [], [], T>;

--- a/src/frontend/src/routes/canisters/add-controller-form.tsx
+++ b/src/frontend/src/routes/canisters/add-controller-form.tsx
@@ -43,9 +43,20 @@ export const AddControllerForm: FC<AddControllerFormProps> = ({
 
   async function onSubmit(formData: FormData): Promise<void> {
     try {
-      await addController(canisterId, formData.principal, projectId);
+      const outcome = await addController(
+        canisterId,
+        formData.principal,
+        projectId,
+      );
       form.reset();
-      showSuccessToast('Controller added successfully!');
+      if (outcome.kind === 'pendingApproval') {
+        showSuccessToast(
+          'Proposal submitted',
+          'Controller will be added once approvers reach the threshold.',
+        );
+      } else {
+        showSuccessToast('Controller added successfully!');
+      }
     } catch (err) {
       showErrorToast('Failed to add controller to canister', err);
     }

--- a/src/frontend/src/routes/canisters/create-canister-button.tsx
+++ b/src/frontend/src/routes/canisters/create-canister-button.tsx
@@ -1,7 +1,7 @@
 import { LoadingButton } from '@/components/loading-button';
 import { useRequireProjectId } from '@/lib/params';
 import { useAppStore } from '@/lib/store';
-import { showErrorToast } from '@/lib/toast';
+import { showErrorToast, showSuccessToast } from '@/lib/toast';
 import { useState, type FC } from 'react';
 
 export type CreateCanisterButtonProps = {
@@ -18,7 +18,13 @@ export const CreateCanisterButton: FC<CreateCanisterButtonProps> = ({
   async function onCreateCanisterClicked(): Promise<void> {
     setIsCreating(true);
     try {
-      await createCanister(projectId);
+      const outcome = await createCanister(projectId);
+      if (outcome.kind === 'pendingApproval') {
+        showSuccessToast(
+          'Proposal submitted',
+          'Canister will be created once approvers reach the threshold.',
+        );
+      }
     } catch (err) {
       showErrorToast('Failed to create canister', err);
     } finally {

--- a/src/frontend/src/routes/organizations/projects/project-settings.tsx
+++ b/src/frontend/src/routes/organizations/projects/project-settings.tsx
@@ -1,3 +1,4 @@
+import { ApprovalPolicyEditor } from '@/components/approval-policy-editor';
 import { LoadingButton } from '@/components/loading-button';
 import { Container } from '@/components/layout/container';
 import {
@@ -17,10 +18,15 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { useAppStore, selectProjectMap } from '@/lib/store';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
-import type {
-  OrgTeam,
-  ProjectPermissions,
-  ProjectTeam,
+import {
+  APPROVAL_OPERATION_TYPES,
+  ApprovalOperationType,
+  DEFAULT_APPROVAL_POLICY_TYPE,
+  type ApprovalPolicy,
+  type ApprovalPolicyType,
+  type OrgTeam,
+  type ProjectPermissions,
+  type ProjectTeam,
 } from '@/lib/api-models';
 import { Separator } from '@/components/ui/separator';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -52,6 +58,8 @@ const ProjectSettings: FC = () => {
     addTeamToProject,
     removeTeamFromProject,
     updateTeamProjectPermissions,
+    loadProjectApprovalPolicies,
+    upsertApprovalPolicy,
   } = useAppStore();
   const projectMap = useAppStore(selectProjectMap);
 
@@ -71,6 +79,9 @@ const ProjectSettings: FC = () => {
   const [isAdding, setIsAdding] = useState(false);
   const [removingTeamId, setRemovingTeamId] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [approvalPolicies, setApprovalPolicies] = useState<ApprovalPolicy[]>(
+    [],
+  );
 
   const refreshOrgTeams = useCallback(async () => {
     if (!orgId) return;
@@ -89,6 +100,15 @@ const ProjectSettings: FC = () => {
       showErrorToast('Failed to load project teams', err);
     }
   }, [projectId, loadProjectTeams]);
+
+  const refreshApprovalPolicies = useCallback(async () => {
+    if (!projectId) return;
+    try {
+      setApprovalPolicies(await loadProjectApprovalPolicies(projectId));
+    } catch (err) {
+      showErrorToast('Failed to load approval policies', err);
+    }
+  }, [projectId, loadProjectApprovalPolicies]);
 
   const projectTeamIds = useMemo(
     () => new Set(projectTeams.map(t => t.id)),
@@ -109,6 +129,23 @@ const ProjectSettings: FC = () => {
     refreshOrgTeams();
     refreshProjectTeams();
   }, [refreshOrgTeams, refreshProjectTeams]);
+
+  const canManageApprovalPolicy =
+    !!project?.yourPermissions.approvalPolicyManage;
+
+  useEffect(() => {
+    if (canManageApprovalPolicy) {
+      refreshApprovalPolicies();
+    }
+  }, [canManageApprovalPolicy, refreshApprovalPolicies]);
+
+  const approvalPolicyMap = useMemo(() => {
+    const map = new Map<ApprovalOperationType, ApprovalPolicy>();
+    for (const policy of approvalPolicies) {
+      map.set(policy.operationType, policy);
+    }
+    return map;
+  }, [approvalPolicies]);
 
   if (isNil(orgId) || isNil(projectId) || isNil(project)) {
     return (
@@ -171,6 +208,23 @@ const ProjectSettings: FC = () => {
     }
   }
 
+  async function onSaveApprovalPolicy(
+    operationType: ApprovalOperationType,
+    policyType: ApprovalPolicyType,
+  ): Promise<ApprovalPolicy> {
+    const updated = await upsertApprovalPolicy({
+      projectId: projectId!,
+      operationType,
+      policyType,
+    });
+    setApprovalPolicies(prev => {
+      const others = prev.filter(p => p.operationType !== operationType);
+      return [...others, updated];
+    });
+    showSuccessToast('Approval policy updated');
+    return updated;
+  }
+
   async function onDelete(): Promise<void> {
     setIsDeleting(true);
     try {
@@ -187,7 +241,7 @@ const ProjectSettings: FC = () => {
   return (
     <Container>
       <div className="space-y-6">
-        <div className="mx-auto max-w-md">
+        <div className="mx-auto max-w-2xl">
           <Button
             variant="ghost"
             size="sm"
@@ -200,7 +254,7 @@ const ProjectSettings: FC = () => {
           </Button>
         </div>
 
-        <Card className="mx-auto max-w-md">
+        <Card className="mx-auto max-w-2xl">
           <CardHeader>
             <CardTitle>Project Settings</CardTitle>
           </CardHeader>
@@ -240,7 +294,7 @@ const ProjectSettings: FC = () => {
           </CardContent>
         </Card>
 
-        <Card className="mx-auto max-w-md">
+        <Card className="mx-auto max-w-2xl">
           <CardHeader>
             <CardTitle>Teams</CardTitle>
           </CardHeader>
@@ -324,8 +378,39 @@ const ProjectSettings: FC = () => {
           </CardContent>
         </Card>
 
+        {canManageApprovalPolicy && (
+          <Card className="mx-auto max-w-2xl">
+            <CardHeader>
+              <CardTitle>Approval Policies</CardTitle>
+            </CardHeader>
+
+            <CardContent className="space-y-6">
+              <p className="text-muted-foreground text-sm">
+                Choose how proposals are approved for each operation. Operations
+                without an explicit policy auto-approve by default.
+              </p>
+
+              {APPROVAL_OPERATION_TYPES.map((op, idx) => {
+                const current =
+                  approvalPolicyMap.get(op)?.policyType ??
+                  DEFAULT_APPROVAL_POLICY_TYPE;
+                return (
+                  <div key={op} className="space-y-4">
+                    {idx > 0 && <Separator />}
+                    <ApprovalPolicyEditor
+                      operationType={op}
+                      value={current}
+                      onSave={next => onSaveApprovalPolicy(op, next)}
+                    />
+                  </div>
+                );
+              })}
+            </CardContent>
+          </Card>
+        )}
+
         {canProjectAdmin && (
-          <Card className="mx-auto max-w-md">
+          <Card className="mx-auto max-w-2xl">
             <CardHeader>
               <CardTitle>Danger Zone</CardTitle>
             </CardHeader>

--- a/src/frontend/src/routes/organizations/teams/team-settings.tsx
+++ b/src/frontend/src/routes/organizations/teams/team-settings.tsx
@@ -201,7 +201,7 @@ const TeamSettings: FC = () => {
       />
 
       <div className="mt-6 space-y-6">
-        <Card className="mx-auto max-w-md">
+        <Card className="mx-auto max-w-2xl">
           <CardHeader>
             <CardTitle>Team Settings</CardTitle>
           </CardHeader>
@@ -242,7 +242,7 @@ const TeamSettings: FC = () => {
         </Card>
 
         {orgTeam && (
-          <Card className="mx-auto max-w-md">
+          <Card className="mx-auto max-w-2xl">
             <CardHeader>
               <CardTitle>Organization Permissions</CardTitle>
             </CardHeader>
@@ -263,7 +263,7 @@ const TeamSettings: FC = () => {
           </Card>
         )}
 
-        <Card className="mx-auto max-w-md">
+        <Card className="mx-auto max-w-2xl">
           <CardHeader>
             <CardTitle>Members</CardTitle>
           </CardHeader>
@@ -347,7 +347,7 @@ const TeamSettings: FC = () => {
         </Card>
 
         {canTeamManage && (
-          <Card className="mx-auto max-w-md">
+          <Card className="mx-auto max-w-2xl">
             <CardHeader>
               <CardTitle>Danger Zone</CardTitle>
             </CardHeader>


### PR DESCRIPTION
Adds project-level approval policy management (auto-approve vs fixed quorum) and propagates proposal outcomes through canister create / add-controller flows so users see a "pending approval" toast when a proposal is queued for vote instead of silently completing.