### PR TITLE
feat: add proposals list and detail UI

### DIFF
--- a/src/frontend/src/components/layout/app-sidebar.tsx
+++ b/src/frontend/src/components/layout/app-sidebar.tsx
@@ -12,7 +12,12 @@ import {
 } from '@/components/ui/sidebar';
 import { isNil } from '@/lib/nil';
 import { selectProjectMap, useAppStore } from '@/lib/store';
-import { CreditCardIcon, LayoutDashboardIcon, UsersIcon } from 'lucide-react';
+import {
+  CreditCardIcon,
+  LayoutDashboardIcon,
+  ListChecksIcon,
+  UsersIcon,
+} from 'lucide-react';
 import { useMemo, type FC } from 'react';
 import { NavLink, useParams } from 'react-router';
 
@@ -54,6 +59,20 @@ export const AppSidebar: FC = () => {
                   </SidebarMenuButton>
                 </SidebarMenuItem>
               ))}
+
+              {activeProjectId && (
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    tooltip="Proposals"
+                    render={
+                      <NavLink to={`/projects/${activeProjectId}/proposals`} />
+                    }
+                  >
+                    <ListChecksIcon />
+                    <span>Proposals</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              )}
 
               {activeOrgId && (
                 <SidebarMenuItem>

--- a/src/frontend/src/lib/api-models/proposal.ts
+++ b/src/frontend/src/lib/api-models/proposal.ts
@@ -140,7 +140,7 @@ export function mapListProjectProposalsRequest(
       ? [req.statusFilter.map(mapProposalStatusFilterToApi)]
       : [],
     after: toCandidOpt(req.after),
-    limit: toCandidOpt(req.limit),
+    limit: toCandidOpt(req.limit !== null ? BigInt(req.limit) : null),
   };
 }
 

--- a/src/frontend/src/lib/api-models/proposal.ts
+++ b/src/frontend/src/lib/api-models/proposal.ts
@@ -1,5 +1,23 @@
+import { mapOkResponse } from '@/lib/api-models/error';
 import { isNil } from '@/lib/nil';
-import type { Proposal as ApiProposal } from '@ssn/backend-api';
+import { fromCandidOpt, toCandidOpt } from '@/lib/utils';
+import { Principal } from '@icp-sdk/core/principal';
+import type {
+  CancelProposalRequest as ApiCancelProposalRequest,
+  CancelProposalResponse as ApiCancelProposalResponse,
+  GetProposalRequest as ApiGetProposalRequest,
+  GetProposalResponse as ApiGetProposalResponse,
+  ListProjectProposalsRequest as ApiListProjectProposalsRequest,
+  ListProjectProposalsResponse as ApiListProjectProposalsResponse,
+  Proposal as ApiProposal,
+  ProposalOperation as ApiProposalOperation,
+  ProposalStatus as ApiProposalStatus,
+  ProposalStatusFilter as ApiProposalStatusFilter,
+  ProposalVote as ApiProposalVote,
+  Vote as ApiVote,
+  VoteProposalRequest as ApiVoteProposalRequest,
+  VoteProposalResponse as ApiVoteProposalResponse,
+} from '@ssn/backend-api';
 
 export type ProposalOutcome =
   | { kind: 'executed' }
@@ -23,4 +41,264 @@ export function readProposalOutcome(proposal: ApiProposal): ProposalOutcome {
     return { kind: 'pendingApproval', proposalId: proposal.id };
   }
   return { kind: 'executed' };
+}
+
+export enum ProposalStatusKind {
+  Open = 'Open',
+  PendingApproval = 'PendingApproval',
+  Rejected = 'Rejected',
+  Cancelled = 'Cancelled',
+  Executing = 'Executing',
+  Executed = 'Executed',
+  Failed = 'Failed',
+}
+
+export type ProposalStatus =
+  | { kind: ProposalStatusKind.Open }
+  | {
+      kind: ProposalStatusKind.PendingApproval;
+      threshold: number;
+      approvers: string[];
+      votes: ProposalVoteRecord[];
+    }
+  | { kind: ProposalStatusKind.Rejected }
+  | { kind: ProposalStatusKind.Cancelled }
+  | { kind: ProposalStatusKind.Executing }
+  | { kind: ProposalStatusKind.Executed }
+  | { kind: ProposalStatusKind.Failed; message: string };
+
+export enum Vote {
+  Approve = 'Approve',
+  Reject = 'Reject',
+}
+
+export type ProposalVoteRecord = {
+  voter: string;
+  vote: Vote;
+};
+
+export type ProposalOperation =
+  | { kind: 'CreateCanister' }
+  | {
+      kind: 'AddCanisterController';
+      canisterId: string;
+      controllerId: string;
+    };
+
+export type Proposal = {
+  id: string;
+  projectId: string;
+  proposerId: string;
+  status: ProposalStatus | null;
+  operation: ProposalOperation | null;
+};
+
+export const PROPOSAL_OPEN_FILTER: ProposalStatusKind[] = [
+  ProposalStatusKind.Open,
+  ProposalStatusKind.PendingApproval,
+];
+
+export const PROPOSAL_CLOSED_FILTER: ProposalStatusKind[] = [
+  ProposalStatusKind.Rejected,
+  ProposalStatusKind.Cancelled,
+  ProposalStatusKind.Executing,
+  ProposalStatusKind.Executed,
+  ProposalStatusKind.Failed,
+];
+
+export type ListProjectProposalsRequest = {
+  projectId: string;
+  statusFilter: ProposalStatusKind[] | null;
+  after: string | null;
+  limit: number | null;
+};
+
+export type ListProjectProposalsResponse = {
+  proposals: Proposal[];
+  nextCursor: string | null;
+};
+
+export type GetProposalRequest = {
+  proposalId: string;
+};
+
+export type VoteProposalRequest = {
+  proposalId: string;
+  vote: Vote;
+};
+
+export type CancelProposalRequest = {
+  proposalId: string;
+};
+
+export function mapListProjectProposalsRequest(
+  req: ListProjectProposalsRequest,
+): ApiListProjectProposalsRequest {
+  return {
+    project_id: req.projectId,
+    status_filter: req.statusFilter
+      ? [req.statusFilter.map(mapProposalStatusFilterToApi)]
+      : [],
+    after: toCandidOpt(req.after),
+    limit: toCandidOpt(req.limit),
+  };
+}
+
+export function mapListProjectProposalsResponse(
+  res: ApiListProjectProposalsResponse,
+): ListProjectProposalsResponse {
+  const okRes = mapOkResponse(res);
+  return {
+    proposals: okRes.proposals.map(mapProposalResponse),
+    nextCursor: fromCandidOpt(okRes.next_cursor),
+  };
+}
+
+export function mapGetProposalRequest(
+  req: GetProposalRequest,
+): ApiGetProposalRequest {
+  return { proposal_id: req.proposalId };
+}
+
+export function mapGetProposalResponse(res: ApiGetProposalResponse): Proposal {
+  return mapProposalResponse(mapOkResponse(res));
+}
+
+export function mapVoteProposalRequest(
+  req: VoteProposalRequest,
+): ApiVoteProposalRequest {
+  return {
+    proposal_id: req.proposalId,
+    vote: mapVoteToApi(req.vote),
+  };
+}
+
+export function mapVoteProposalResponse(
+  res: ApiVoteProposalResponse,
+): Proposal {
+  return mapProposalResponse(mapOkResponse(res));
+}
+
+export function mapCancelProposalRequest(
+  req: CancelProposalRequest,
+): ApiCancelProposalRequest {
+  return { proposal_id: req.proposalId };
+}
+
+export function mapCancelProposalResponse(
+  res: ApiCancelProposalResponse,
+): Proposal {
+  return mapProposalResponse(mapOkResponse(res));
+}
+
+export function mapProposalResponse(res: ApiProposal): Proposal {
+  const [statusOpt] = res.status;
+  const [operationOpt] = res.operation;
+  return {
+    id: res.id,
+    projectId: res.project_id,
+    proposerId: res.proposer_id,
+    status: statusOpt ? mapProposalStatus(statusOpt) : null,
+    operation: operationOpt ? mapProposalOperation(operationOpt) : null,
+  };
+}
+
+function mapProposalStatus(status: ApiProposalStatus): ProposalStatus {
+  if ('Open' in status) return { kind: ProposalStatusKind.Open };
+  if ('Rejected' in status) return { kind: ProposalStatusKind.Rejected };
+  if ('Cancelled' in status) return { kind: ProposalStatusKind.Cancelled };
+  if ('Executing' in status) return { kind: ProposalStatusKind.Executing };
+  if ('Executed' in status) return { kind: ProposalStatusKind.Executed };
+  if ('Failed' in status) {
+    return { kind: ProposalStatusKind.Failed, message: status.Failed.message };
+  }
+  return {
+    kind: ProposalStatusKind.PendingApproval,
+    threshold: status.PendingApproval.threshold,
+    approvers: status.PendingApproval.approvers.map(p => p.toText()),
+    votes: status.PendingApproval.votes.map(mapProposalVote),
+  };
+}
+
+function mapProposalVote(v: ApiProposalVote): ProposalVoteRecord {
+  return {
+    voter: v.voter.toText(),
+    vote: 'Approve' in v.vote ? Vote.Approve : Vote.Reject,
+  };
+}
+
+function mapProposalOperation(op: ApiProposalOperation): ProposalOperation {
+  if ('CreateCanister' in op) return { kind: 'CreateCanister' };
+  return {
+    kind: 'AddCanisterController',
+    canisterId: op.AddCanisterController.canister_id.toText(),
+    controllerId: op.AddCanisterController.controller_id.toText(),
+  };
+}
+
+function mapVoteToApi(vote: Vote): ApiVote {
+  return vote === Vote.Approve ? { Approve: {} } : { Reject: {} };
+}
+
+function mapProposalStatusFilterToApi(
+  kind: ProposalStatusKind,
+): ApiProposalStatusFilter {
+  switch (kind) {
+    case ProposalStatusKind.Open:
+      return { Open: {} };
+    case ProposalStatusKind.PendingApproval:
+      return { PendingApproval: {} };
+    case ProposalStatusKind.Rejected:
+      return { Rejected: {} };
+    case ProposalStatusKind.Cancelled:
+      return { Cancelled: {} };
+    case ProposalStatusKind.Executing:
+      return { Executing: {} };
+    case ProposalStatusKind.Executed:
+      return { Executed: {} };
+    case ProposalStatusKind.Failed:
+      return { Failed: {} };
+  }
+}
+
+export function proposalOperationLabel(op: ProposalOperation | null): string {
+  if (!op) return 'Unknown operation';
+  switch (op.kind) {
+    case 'CreateCanister':
+      return 'Create canister';
+    case 'AddCanisterController':
+      return 'Add canister controller';
+  }
+}
+
+export function proposalStatusLabel(status: ProposalStatus | null): string {
+  if (!status) return 'Unknown';
+  switch (status.kind) {
+    case ProposalStatusKind.Open:
+      return 'Open';
+    case ProposalStatusKind.PendingApproval:
+      return 'Pending approval';
+    case ProposalStatusKind.Rejected:
+      return 'Rejected';
+    case ProposalStatusKind.Cancelled:
+      return 'Cancelled';
+    case ProposalStatusKind.Executing:
+      return 'Executing';
+    case ProposalStatusKind.Executed:
+      return 'Executed';
+    case ProposalStatusKind.Failed:
+      return 'Failed';
+  }
+}
+
+export function isProposalActionable(status: ProposalStatus | null): boolean {
+  if (!status) return false;
+  return (
+    status.kind === ProposalStatusKind.Open ||
+    status.kind === ProposalStatusKind.PendingApproval
+  );
+}
+
+export function principalToText(p: string | Principal): string {
+  return typeof p === 'string' ? p : p.toText();
 }

--- a/src/frontend/src/lib/api-models/user-profile.ts
+++ b/src/frontend/src/lib/api-models/user-profile.ts
@@ -165,7 +165,7 @@ export function mapGetUserProfilesByPrincipalsRequest(
 export function mapGetUserProfilesByPrincipalsResponse(
   res: ApiGetUserProfilesByPrincipalsResponse,
 ): GetUserProfilesByPrincipalsResponse {
-  return mapOkResponse(res).map(entry => ({
+  return mapOkResponse(res).profiles.map(entry => ({
     principal: entry.subject_principal.toText(),
     profile: mapUserProfileBriefOpt(entry.profile),
   }));

--- a/src/frontend/src/lib/api-models/user-profile.ts
+++ b/src/frontend/src/lib/api-models/user-profile.ts
@@ -1,8 +1,10 @@
 import { mapOkResponse } from '@/lib/api-models/error';
 import { isNotNil } from '@/lib/nil';
 import { fromCandidOpt, toCandidOpt } from '@/lib/utils';
+import { Principal } from '@icp-sdk/core/principal';
 import type {
   UserProfile as ApiUserProfile,
+  UserProfileBrief as ApiUserProfileBrief,
   UserStatus as ApiUserStatus,
   ListUserProfilesResponse as ApiListUserProfilesResponse,
   GetMyUserProfileResponse as ApiGetMyUserProfileResponse,
@@ -10,6 +12,8 @@ import type {
   UpdateMyUserProfileRequest as ApiUpdateMyUserProfileRequest,
   UpdateUserProfileRequest as ApiUpdateUserProfileRequest,
   GetUserStatsResponse as ApiGetUserStatsResponse,
+  GetUserProfilesByPrincipalsRequest as ApiGetUserProfilesByPrincipalsRequest,
+  GetUserProfilesByPrincipalsResponse as ApiGetUserProfilesByPrincipalsResponse,
 } from '@ssn/backend-api';
 
 export type ListUserProfilesResponse = UserProfile[];
@@ -129,4 +133,53 @@ export function mapUserStatsResponse(
     active: Number(okRes.active),
     inactive: Number(okRes.inactive),
   };
+}
+
+export type UserProfileBrief = {
+  id: string;
+  email: string | null;
+  emailVerified: boolean;
+};
+
+export type GetUserProfilesByPrincipalsRequest = {
+  projectId: string;
+  principals: string[];
+};
+
+export type UserProfileByPrincipal = {
+  principal: string;
+  profile: UserProfileBrief | null;
+};
+
+export type GetUserProfilesByPrincipalsResponse = UserProfileByPrincipal[];
+
+export function mapGetUserProfilesByPrincipalsRequest(
+  req: GetUserProfilesByPrincipalsRequest,
+): ApiGetUserProfilesByPrincipalsRequest {
+  return {
+    project_id: req.projectId,
+    principals: req.principals.map(p => Principal.fromText(p)),
+  };
+}
+
+export function mapGetUserProfilesByPrincipalsResponse(
+  res: ApiGetUserProfilesByPrincipalsResponse,
+): GetUserProfilesByPrincipalsResponse {
+  return mapOkResponse(res).map(entry => ({
+    principal: entry.subject_principal.toText(),
+    profile: mapUserProfileBriefOpt(entry.profile),
+  }));
+}
+
+function mapUserProfileBriefOpt(
+  opt: [] | [ApiUserProfileBrief],
+): UserProfileBrief | null {
+  const brief = fromCandidOpt(opt);
+  return brief
+    ? {
+        id: brief.id,
+        email: fromCandidOpt(brief.email),
+        emailVerified: brief.email_verified,
+      }
+    : null;
 }

--- a/src/frontend/src/lib/api/index.ts
+++ b/src/frontend/src/lib/api/index.ts
@@ -1,6 +1,7 @@
 export * from './approval-policy';
 export * from './canister';
 export * from './canister-history';
+export * from './proposal';
 export * from './invite';
 export * from './management-canister';
 export * from './organization';

--- a/src/frontend/src/lib/api/proposal.ts
+++ b/src/frontend/src/lib/api/proposal.ts
@@ -1,0 +1,46 @@
+import {
+  mapCancelProposalRequest,
+  mapCancelProposalResponse,
+  mapGetProposalRequest,
+  mapGetProposalResponse,
+  mapListProjectProposalsRequest,
+  mapListProjectProposalsResponse,
+  mapVoteProposalRequest,
+  mapVoteProposalResponse,
+  type CancelProposalRequest,
+  type GetProposalRequest,
+  type ListProjectProposalsRequest,
+  type ListProjectProposalsResponse,
+  type Proposal,
+  type VoteProposalRequest,
+} from '@/lib/api-models';
+import type { ActorSubclass } from '@icp-sdk/core/agent';
+import type { _SERVICE } from '@ssn/backend-api';
+
+export class ProposalApi {
+  constructor(private readonly actor: ActorSubclass<_SERVICE>) {}
+
+  public async listProjectProposals(
+    req: ListProjectProposalsRequest,
+  ): Promise<ListProjectProposalsResponse> {
+    const res = await this.actor.list_project_proposals(
+      mapListProjectProposalsRequest(req),
+    );
+    return mapListProjectProposalsResponse(res);
+  }
+
+  public async getProposal(req: GetProposalRequest): Promise<Proposal> {
+    const res = await this.actor.get_proposal(mapGetProposalRequest(req));
+    return mapGetProposalResponse(res);
+  }
+
+  public async voteProposal(req: VoteProposalRequest): Promise<Proposal> {
+    const res = await this.actor.vote_proposal(mapVoteProposalRequest(req));
+    return mapVoteProposalResponse(res);
+  }
+
+  public async cancelProposal(req: CancelProposalRequest): Promise<Proposal> {
+    const res = await this.actor.cancel_proposal(mapCancelProposalRequest(req));
+    return mapCancelProposalResponse(res);
+  }
+}

--- a/src/frontend/src/lib/api/user-profile.ts
+++ b/src/frontend/src/lib/api/user-profile.ts
@@ -1,12 +1,16 @@
 import {
   mapCreateMyUserProfileResponse,
   mapGetMyUserProfileResponse,
+  mapGetUserProfilesByPrincipalsRequest,
+  mapGetUserProfilesByPrincipalsResponse,
   mapListUserProfilesResponse,
   mapUpdateMyUserProfileRequest,
   mapUpdateUserProfileRequest,
   mapUserStatsResponse,
   type CreateMyUserProfileResponse,
   type GetMyUserProfileResponse,
+  type GetUserProfilesByPrincipalsRequest,
+  type GetUserProfilesByPrincipalsResponse,
   type ListUserProfilesResponse,
   type UpdateMyUserProfileRequest,
   type UpdateUserProfileRequest,
@@ -73,5 +77,14 @@ export class UserProfileApi {
   public async verifyMyEmail(token: string): Promise<void> {
     const res = await this.actor.verify_my_email({ token });
     mapOkResponse(res);
+  }
+
+  public async getUserProfilesByPrincipals(
+    req: GetUserProfilesByPrincipalsRequest,
+  ): Promise<GetUserProfilesByPrincipalsResponse> {
+    const res = await this.actor.get_user_profiles_by_principals(
+      mapGetUserProfilesByPrincipalsRequest(req),
+    );
+    return mapGetUserProfilesByPrincipalsResponse(res);
   }
 }

--- a/src/frontend/src/lib/store/api.ts
+++ b/src/frontend/src/lib/store/api.ts
@@ -7,6 +7,7 @@ import {
   ApprovalPolicyApi,
   CanisterApi,
   CanisterHistoryApi,
+  ProposalApi,
   TrustedPartnerApi,
   UserProfileApi,
   ManagementCanisterApi,
@@ -71,6 +72,7 @@ const inviteApi = new InviteApi(actor);
 const canisterHistoryApi = new CanisterHistoryApi(canisterHistoryActor);
 const authApi = new AuthApi(OFFCHAIN_SERVICE_URL);
 const approvalPolicyApi = new ApprovalPolicyApi(actor);
+const proposalApi = new ProposalApi(actor);
 
 export const createApiSlice: AppStateCreator<ApiSlice> = (_set, get) => ({
   agent,
@@ -87,6 +89,7 @@ export const createApiSlice: AppStateCreator<ApiSlice> = (_set, get) => ({
   inviteApi,
   authApi,
   approvalPolicyApi,
+  proposalApi,
 
   setAgentIdentity: identity => {
     const { agent } = get();

--- a/src/frontend/src/lib/store/app.ts
+++ b/src/frontend/src/lib/store/app.ts
@@ -2,6 +2,7 @@ import { createApiSlice } from '@/lib/store/api';
 import { createApprovalPoliciesSlice } from '@/lib/store/approval-policy';
 import { createAuthSlice } from '@/lib/store/auth';
 import { createCanistersSlice } from '@/lib/store/canister';
+import { createProposalsSlice } from '@/lib/store/proposal';
 import { createInvitesSlice } from '@/lib/store/invite';
 import type { AppSlice } from '@/lib/store/model';
 import { createOrganizationsSlice } from '@/lib/store/organization';
@@ -26,4 +27,5 @@ export const useAppStore = create<AppSlice>()((...a) => ({
   ...createTeamsSlice(...a),
   ...createInvitesSlice(...a),
   ...createApprovalPoliciesSlice(...a),
+  ...createProposalsSlice(...a),
 }));

--- a/src/frontend/src/lib/store/index.ts
+++ b/src/frontend/src/lib/store/index.ts
@@ -2,6 +2,7 @@ export * from './api';
 export * from './app';
 export * from './approval-policy';
 export * from './auth';
+export * from './proposal';
 export * from './invite';
 export * from './model';
 export * from './organization';

--- a/src/frontend/src/lib/store/model.ts
+++ b/src/frontend/src/lib/store/model.ts
@@ -1,7 +1,12 @@
 import type {
   ApprovalPolicy,
   Canister,
+  GetUserProfilesByPrincipalsResponse,
+  ListProjectProposalsRequest,
+  ListProjectProposalsResponse,
+  Proposal,
   ProposalOutcome,
+  Vote,
   CreateTrustedPartnerRequest,
   CreateOrgInviteRequest,
   OrgInvite,
@@ -25,6 +30,7 @@ import type {
   ApprovalPolicyApi,
   CanisterApi,
   CanisterHistoryApi,
+  ProposalApi,
   TrustedPartnerApi,
   UserProfileApi,
   ManagementCanisterApi,
@@ -68,6 +74,7 @@ export type ApiSlice = {
   teamApi: TeamApi;
   inviteApi: InviteApi;
   approvalPolicyApi: ApprovalPolicyApi;
+  proposalApi: ProposalApi;
 
   setAgentIdentity: (identity: Identity) => void;
 };
@@ -77,6 +84,19 @@ export type ApprovalPoliciesSlice = {
   upsertApprovalPolicy: (
     req: UpsertApprovalPolicyRequest,
   ) => Promise<ApprovalPolicy>;
+};
+
+export type ProposalsSlice = {
+  listProjectProposals: (
+    req: ListProjectProposalsRequest,
+  ) => Promise<ListProjectProposalsResponse>;
+  getProposal: (proposalId: string) => Promise<Proposal>;
+  voteProposal: (proposalId: string, vote: Vote) => Promise<Proposal>;
+  cancelProposal: (proposalId: string) => Promise<Proposal>;
+  getUserProfilesByPrincipals: (
+    projectId: string,
+    principals: string[],
+  ) => Promise<GetUserProfilesByPrincipalsResponse>;
 };
 
 export type UserProfileSlice = {
@@ -235,6 +255,7 @@ export type AppSlice = AuthSlice &
   OrganizationsSlice &
   TeamsSlice &
   InvitesSlice &
-  ApprovalPoliciesSlice;
+  ApprovalPoliciesSlice &
+  ProposalsSlice;
 
 export type AppStateCreator<T> = StateCreator<AppSlice, [], [], T>;

--- a/src/frontend/src/lib/store/proposal.ts
+++ b/src/frontend/src/lib/store/proposal.ts
@@ -1,0 +1,29 @@
+import type { AppStateCreator, ProposalsSlice } from '@/lib/store/model';
+
+export const createProposalsSlice: AppStateCreator<ProposalsSlice> = (
+  _set,
+  get,
+) => ({
+  async listProjectProposals(req) {
+    return get().proposalApi.listProjectProposals(req);
+  },
+
+  async getProposal(proposalId) {
+    return get().proposalApi.getProposal({ proposalId });
+  },
+
+  async voteProposal(proposalId, vote) {
+    return get().proposalApi.voteProposal({ proposalId, vote });
+  },
+
+  async cancelProposal(proposalId) {
+    return get().proposalApi.cancelProposal({ proposalId });
+  },
+
+  async getUserProfilesByPrincipals(projectId, principals) {
+    return get().userProfileApi.getUserProfilesByPrincipals({
+      projectId,
+      principals,
+    });
+  },
+});

--- a/src/frontend/src/router.tsx
+++ b/src/frontend/src/router.tsx
@@ -11,6 +11,8 @@ const TermsAndConditions = lazy(
 );
 const Canisters = lazy(() => import('@/routes/canisters/canisters'));
 const CanisterDetail = lazy(() => import('@/routes/canisters/canister-detail'));
+const ProposalList = lazy(() => import('@/routes/proposals/proposal-list'));
+const ProposalDetail = lazy(() => import('@/routes/proposals/proposal-detail'));
 const RedirectToProjectCanisters = lazy(
   () =>
     import('@/routes/redirect-to-project-canisters/redirect-to-project-canisters'),
@@ -87,6 +89,8 @@ export const Router: FC = () => (
           <Route path="projects/:projectId" element={<ProjectLayout />}>
             <Route path="canisters" element={<Canisters />} />
             <Route path="canisters/:canisterId" element={<CanisterDetail />} />
+            <Route path="proposals" element={<ProposalList />} />
+            <Route path="proposals/:proposalId" element={<ProposalDetail />} />
           </Route>
         </Route>
 

--- a/src/frontend/src/routes/canisters/add-controller-form.tsx
+++ b/src/frontend/src/routes/canisters/add-controller-form.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/form';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
 import { useRequireProjectId } from '@/lib/params';
+import { useNavigate } from 'react-router';
 
 export type AddControllerFormProps = {
   canisterId: string;
@@ -35,6 +36,7 @@ export const AddControllerForm: FC<AddControllerFormProps> = ({
 }) => {
   const { addController } = useAppStore();
   const projectId = useRequireProjectId();
+  const navigate = useNavigate();
 
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
@@ -52,8 +54,9 @@ export const AddControllerForm: FC<AddControllerFormProps> = ({
       if (outcome.kind === 'pendingApproval') {
         showSuccessToast(
           'Proposal submitted',
-          'Controller will be added once approvers reach the threshold.',
+          'Awaiting approvals before the controller is added.',
         );
+        navigate(`/projects/${projectId}/proposals/${outcome.proposalId}`);
       } else {
         showSuccessToast('Controller added successfully!');
       }

--- a/src/frontend/src/routes/canisters/create-canister-button.tsx
+++ b/src/frontend/src/routes/canisters/create-canister-button.tsx
@@ -3,6 +3,7 @@ import { useRequireProjectId } from '@/lib/params';
 import { useAppStore } from '@/lib/store';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
 import { useState, type FC } from 'react';
+import { useNavigate } from 'react-router';
 
 export type CreateCanisterButtonProps = {
   className?: string;
@@ -13,6 +14,7 @@ export const CreateCanisterButton: FC<CreateCanisterButtonProps> = ({
 }) => {
   const { createCanister } = useAppStore();
   const projectId = useRequireProjectId();
+  const navigate = useNavigate();
   const [isCreating, setIsCreating] = useState(false);
 
   async function onCreateCanisterClicked(): Promise<void> {
@@ -22,8 +24,9 @@ export const CreateCanisterButton: FC<CreateCanisterButtonProps> = ({
       if (outcome.kind === 'pendingApproval') {
         showSuccessToast(
           'Proposal submitted',
-          'Canister will be created once approvers reach the threshold.',
+          'Awaiting approvals before the canister is created.',
         );
+        navigate(`/projects/${projectId}/proposals/${outcome.proposalId}`);
       }
     } catch (err) {
       showErrorToast('Failed to create canister', err);

--- a/src/frontend/src/routes/proposals/proposal-detail.tsx
+++ b/src/frontend/src/routes/proposals/proposal-detail.tsx
@@ -1,0 +1,332 @@
+import { Breadcrumbs } from '@/components/breadcrumbs';
+import { LoadingButton } from '@/components/loading-button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { H1 } from '@/components/typography/h1';
+import { isNil } from '@/lib/nil';
+import { useRequireProjectId } from '@/lib/params';
+import {
+  isProposalActionable,
+  proposalOperationLabel,
+  ProposalStatusKind,
+  Vote,
+  type Proposal,
+  type UserProfileBrief,
+} from '@/lib/api-models';
+import { selectOrgMap, selectProjectMap, useAppStore } from '@/lib/store';
+import { showErrorToast, showSuccessToast } from '@/lib/toast';
+import { ProposalStatusBadge } from '@/routes/proposals/proposal-status-badge';
+import { useEffect, useMemo, useState, type FC } from 'react';
+import { useParams } from 'react-router';
+
+function shortenPrincipal(p: string): string {
+  if (p.length <= 16) return p;
+  return `${p.slice(0, 8)}…${p.slice(-6)}`;
+}
+
+function describeOperation(p: Proposal): string {
+  if (!p.operation) return 'Unknown operation';
+  switch (p.operation.kind) {
+    case 'CreateCanister':
+      return 'Create a new canister in this project.';
+    case 'AddCanisterController':
+      return `Add ${shortenPrincipal(p.operation.controllerId)} as a controller of ${shortenPrincipal(p.operation.canisterId)}.`;
+  }
+}
+
+function renderProfileLabel(
+  principal: string,
+  profile: UserProfileBrief | null,
+): string {
+  if (profile?.email) return profile.email;
+  return shortenPrincipal(principal);
+}
+
+const ProposalDetail: FC = () => {
+  const projectId = useRequireProjectId();
+  const { proposalId } = useParams();
+
+  const projectMap = useAppStore(selectProjectMap);
+  const orgMap = useAppStore(selectOrgMap);
+  const profile = useAppStore(s => s.profile);
+  const identity = useAppStore(s => s.identity);
+  const getProposal = useAppStore(s => s.getProposal);
+  const voteProposal = useAppStore(s => s.voteProposal);
+  const cancelProposal = useAppStore(s => s.cancelProposal);
+  const getUserProfilesByPrincipals = useAppStore(
+    s => s.getUserProfilesByPrincipals,
+  );
+
+  const project = useMemo(
+    () => projectMap.get(projectId) ?? null,
+    [projectId, projectMap],
+  );
+  const organization = useMemo(
+    () => (project ? (orgMap.get(project.orgId) ?? null) : null),
+    [project, orgMap],
+  );
+
+  const [proposal, setProposal] = useState<Proposal | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [profileMap, setProfileMap] = useState<
+    Map<string, UserProfileBrief | null>
+  >(new Map());
+  const [pendingVote, setPendingVote] = useState<Vote | null>(null);
+  const [isCancelling, setIsCancelling] = useState(false);
+
+  const myPrincipal = useMemo(
+    () => identity?.getPrincipal().toText() ?? null,
+    [identity],
+  );
+
+  useEffect(() => {
+    if (isNil(proposalId)) return;
+    setIsLoading(true);
+    getProposal(proposalId)
+      .then(setProposal)
+      .catch(err => showErrorToast('Failed to load proposal', err))
+      .finally(() => setIsLoading(false));
+  }, [proposalId, getProposal]);
+
+  useEffect(() => {
+    if (
+      !proposal ||
+      proposal.status?.kind !== ProposalStatusKind.PendingApproval
+    ) {
+      return;
+    }
+    const principals = new Set<string>();
+    proposal.status.approvers.forEach(p => principals.add(p));
+    proposal.status.votes.forEach(v => principals.add(v.voter));
+    if (principals.size === 0) return;
+
+    getUserProfilesByPrincipals(projectId, [...principals])
+      .then(entries => {
+        setProfileMap(prev => {
+          const next = new Map(prev);
+          for (const e of entries) next.set(e.principal, e.profile);
+          return next;
+        });
+      })
+      .catch(err => showErrorToast('Failed to resolve voter profiles', err));
+  }, [proposal, projectId, getUserProfilesByPrincipals]);
+
+  if (isNil(proposalId)) {
+    return <p className="text-muted-foreground">Missing proposal id.</p>;
+  }
+
+  const status = proposal?.status ?? null;
+  const isPendingApproval = status?.kind === ProposalStatusKind.PendingApproval;
+  const canVote =
+    isPendingApproval &&
+    !!project?.yourPermissions.proposalApprove &&
+    !!myPrincipal &&
+    status.approvers.includes(myPrincipal) &&
+    !status.votes.some(v => v.voter === myPrincipal);
+
+  const isProposer = !!profile && proposal?.proposerId === profile.id;
+  const canCancel = isProposer && isProposalActionable(status);
+
+  async function onVote(vote: Vote): Promise<void> {
+    if (!proposalId) return;
+    setPendingVote(vote);
+    try {
+      const updated = await voteProposal(proposalId, vote);
+      setProposal(updated);
+      showSuccessToast(
+        vote === Vote.Approve ? 'Approved' : 'Rejected',
+        'Your vote was recorded.',
+      );
+    } catch (err) {
+      showErrorToast('Failed to record vote', err);
+    } finally {
+      setPendingVote(null);
+    }
+  }
+
+  async function onCancel(): Promise<void> {
+    if (!proposalId) return;
+    setIsCancelling(true);
+    try {
+      const updated = await cancelProposal(proposalId);
+      setProposal(updated);
+      showSuccessToast('Proposal cancelled');
+    } catch (err) {
+      showErrorToast('Failed to cancel proposal', err);
+    } finally {
+      setIsCancelling(false);
+    }
+  }
+
+  return (
+    <>
+      <Breadcrumbs
+        items={[
+          ...(organization
+            ? [
+                {
+                  label: organization.name,
+                  to: `/organizations/${organization.id}/settings`,
+                },
+              ]
+            : []),
+          { label: project?.name ?? 'Project' },
+          { label: 'Proposals', to: `/projects/${projectId}/proposals` },
+          { label: shortenPrincipal(proposalId) },
+        ]}
+      />
+      <div className="mt-3 flex items-center gap-3">
+        <H1>Proposal</H1>
+        {proposal && <ProposalStatusBadge status={proposal.status} />}
+      </div>
+
+      {isLoading && !proposal ? (
+        <p className="text-muted-foreground mt-6 text-sm">Loading…</p>
+      ) : !proposal ? (
+        <p className="text-muted-foreground mt-6 text-sm">
+          Proposal not found.
+        </p>
+      ) : (
+        <div className="mt-6 grid gap-6 md:grid-cols-2">
+          <Card>
+            <CardHeader>
+              <CardTitle>Operation</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              <div>
+                <p className="font-medium">
+                  {proposalOperationLabel(proposal.operation)}
+                </p>
+                <p className="text-muted-foreground">
+                  {describeOperation(proposal)}
+                </p>
+              </div>
+              <dl className="grid gap-2">
+                <div className="flex justify-between gap-4">
+                  <dt className="text-muted-foreground">Proposer</dt>
+                  <dd className="font-mono text-xs">{proposal.proposerId}</dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="text-muted-foreground">ID</dt>
+                  <dd className="font-mono text-xs">{proposal.id}</dd>
+                </div>
+                {status?.kind === ProposalStatusKind.Failed && (
+                  <div className="flex justify-between gap-4">
+                    <dt className="text-muted-foreground">Reason</dt>
+                    <dd className="text-destructive max-w-[60%] text-right text-xs">
+                      {status.message}
+                    </dd>
+                  </div>
+                )}
+              </dl>
+
+              {(canVote || canCancel) && (
+                <div className="flex flex-wrap gap-2 pt-2">
+                  {canVote && (
+                    <>
+                      <LoadingButton
+                        size="sm"
+                        isLoading={pendingVote === Vote.Approve}
+                        disabled={pendingVote !== null}
+                        onClick={() => onVote(Vote.Approve)}
+                      >
+                        Approve
+                      </LoadingButton>
+                      <LoadingButton
+                        size="sm"
+                        variant="outline"
+                        isLoading={pendingVote === Vote.Reject}
+                        disabled={pendingVote !== null}
+                        onClick={() => onVote(Vote.Reject)}
+                      >
+                        Reject
+                      </LoadingButton>
+                    </>
+                  )}
+                  {canCancel && (
+                    <LoadingButton
+                      size="sm"
+                      variant="destructive"
+                      isLoading={isCancelling}
+                      onClick={onCancel}
+                    >
+                      Cancel proposal
+                    </LoadingButton>
+                  )}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {isPendingApproval && (
+            <Card>
+              <CardHeader>
+                <CardTitle>
+                  Approvals{' '}
+                  <span className="text-muted-foreground text-sm font-normal">
+                    {status.votes.filter(v => v.vote === Vote.Approve).length}
+                    {' / '}
+                    {status.threshold}
+                  </span>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Approver</TableHead>
+                      <TableHead className="text-right">Vote</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {status.approvers.map(principal => {
+                      const vote =
+                        status.votes.find(v => v.voter === principal)?.vote ??
+                        null;
+                      return (
+                        <TableRow key={principal}>
+                          <TableCell>
+                            <span className="text-sm">
+                              {renderProfileLabel(
+                                principal,
+                                profileMap.get(principal) ?? null,
+                              )}
+                            </span>
+                            {principal === myPrincipal && (
+                              <span className="text-muted-foreground ml-1 text-xs">
+                                (you)
+                              </span>
+                            )}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            {vote === Vote.Approve ? (
+                              <Badge variant="success">Approved</Badge>
+                            ) : vote === Vote.Reject ? (
+                              <Badge variant="destructive">Rejected</Badge>
+                            ) : (
+                              <Badge variant="outline">Pending</Badge>
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      )}
+    </>
+  );
+};
+
+export default ProposalDetail;

--- a/src/frontend/src/routes/proposals/proposal-detail.tsx
+++ b/src/frontend/src/routes/proposals/proposal-detail.tsx
@@ -104,8 +104,12 @@ const ProposalDetail: FC = () => {
       return;
     }
     const principals = new Set<string>();
-    proposal.status.approvers.forEach(p => principals.add(p));
-    proposal.status.votes.forEach(v => principals.add(v.voter));
+    proposal.status.approvers.forEach(p => {
+      if (!profileMap.has(p)) principals.add(p);
+    });
+    proposal.status.votes.forEach(v => {
+      if (!profileMap.has(v.voter)) principals.add(v.voter);
+    });
     if (principals.size === 0) return;
 
     getUserProfilesByPrincipals(projectId, [...principals])
@@ -117,7 +121,7 @@ const ProposalDetail: FC = () => {
         });
       })
       .catch(err => showErrorToast('Failed to resolve voter profiles', err));
-  }, [proposal, projectId, getUserProfilesByPrincipals]);
+  }, [proposal, projectId, getUserProfilesByPrincipals, profileMap]);
 
   if (isNil(proposalId)) {
     return <p className="text-muted-foreground">Missing proposal id.</p>;
@@ -133,7 +137,9 @@ const ProposalDetail: FC = () => {
     !status.votes.some(v => v.voter === myPrincipal);
 
   const isProposer = !!profile && proposal?.proposerId === profile.id;
-  const canCancel = isProposer && isProposalActionable(status);
+  const isProjectAdmin = !!project?.yourPermissions.projectAdmin;
+  const canCancel =
+    (isProposer || isProjectAdmin) && isProposalActionable(status);
 
   async function onVote(vote: Vote): Promise<void> {
     if (!proposalId) return;
@@ -235,7 +241,7 @@ const ProposalDetail: FC = () => {
                       <LoadingButton
                         size="sm"
                         isLoading={pendingVote === Vote.Approve}
-                        disabled={pendingVote !== null}
+                        disabled={pendingVote !== null || isCancelling}
                         onClick={() => onVote(Vote.Approve)}
                       >
                         Approve
@@ -244,7 +250,7 @@ const ProposalDetail: FC = () => {
                         size="sm"
                         variant="outline"
                         isLoading={pendingVote === Vote.Reject}
-                        disabled={pendingVote !== null}
+                        disabled={pendingVote !== null || isCancelling}
                         onClick={() => onVote(Vote.Reject)}
                       >
                         Reject
@@ -256,6 +262,7 @@ const ProposalDetail: FC = () => {
                       size="sm"
                       variant="destructive"
                       isLoading={isCancelling}
+                      disabled={isCancelling || pendingVote !== null}
                       onClick={onCancel}
                     >
                       Cancel proposal
@@ -275,6 +282,12 @@ const ProposalDetail: FC = () => {
                     {status.votes.filter(v => v.vote === Vote.Approve).length}
                     {' / '}
                     {status.threshold}
+                  </span>
+                  <span className="text-muted-foreground ml-3 text-sm font-normal">
+                    Rejections{' '}
+                    {status.votes.filter(v => v.vote === Vote.Reject).length}
+                    {' / '}
+                    {Math.max(status.approvers.length - status.threshold, 0)}
                   </span>
                 </CardTitle>
               </CardHeader>

--- a/src/frontend/src/routes/proposals/proposal-list.tsx
+++ b/src/frontend/src/routes/proposals/proposal-list.tsx
@@ -74,6 +74,8 @@ const ProposalList: FC = () => {
 
   const loadFirstPage = useCallback(async () => {
     setIsLoading(true);
+    setProposals([]);
+    setNextCursor(null);
     try {
       const res = await listProjectProposals({
         projectId,

--- a/src/frontend/src/routes/proposals/proposal-list.tsx
+++ b/src/frontend/src/routes/proposals/proposal-list.tsx
@@ -1,0 +1,229 @@
+import { Breadcrumbs } from '@/components/breadcrumbs';
+import { LoadingButton } from '@/components/loading-button';
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { H1 } from '@/components/typography/h1';
+import {
+  PROPOSAL_CLOSED_FILTER,
+  PROPOSAL_OPEN_FILTER,
+  proposalOperationLabel,
+  type Proposal,
+  type ProposalStatusKind,
+} from '@/lib/api-models';
+import { cn } from '@/lib/utils';
+import { isNil } from '@/lib/nil';
+import { useRequireProjectId } from '@/lib/params';
+import { selectOrgMap, selectProjectMap, useAppStore } from '@/lib/store';
+import { showErrorToast } from '@/lib/toast';
+import { ProposalStatusBadge } from '@/routes/proposals/proposal-status-badge';
+import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
+import { useNavigate } from 'react-router';
+
+const PAGE_SIZE = 25;
+
+type FilterTab = {
+  id: 'all' | 'open' | 'closed';
+  label: string;
+  filter: ProposalStatusKind[] | null;
+};
+
+const FILTER_TABS: FilterTab[] = [
+  { id: 'all', label: 'All', filter: null },
+  { id: 'open', label: 'Open', filter: PROPOSAL_OPEN_FILTER },
+  { id: 'closed', label: 'Closed', filter: PROPOSAL_CLOSED_FILTER },
+];
+
+function shorten(id: string): string {
+  if (id.length <= 10) return id;
+  return `${id.slice(0, 6)}…${id.slice(-4)}`;
+}
+
+const ProposalList: FC = () => {
+  const projectId = useRequireProjectId();
+  const navigate = useNavigate();
+  const projectMap = useAppStore(selectProjectMap);
+  const orgMap = useAppStore(selectOrgMap);
+  const listProjectProposals = useAppStore(s => s.listProjectProposals);
+
+  const project = useMemo(
+    () => projectMap.get(projectId) ?? null,
+    [projectId, projectMap],
+  );
+  const organization = useMemo(
+    () => (project ? (orgMap.get(project.orgId) ?? null) : null),
+    [project, orgMap],
+  );
+
+  const [activeTab, setActiveTab] = useState<FilterTab['id']>('open');
+  const [proposals, setProposals] = useState<Proposal[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+
+  const activeFilter = useMemo(
+    () => FILTER_TABS.find(t => t.id === activeTab)?.filter ?? null,
+    [activeTab],
+  );
+
+  const loadFirstPage = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const res = await listProjectProposals({
+        projectId,
+        statusFilter: activeFilter,
+        after: null,
+        limit: PAGE_SIZE,
+      });
+      setProposals(res.proposals);
+      setNextCursor(res.nextCursor);
+    } catch (err) {
+      showErrorToast('Failed to load proposals', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [projectId, activeFilter, listProjectProposals]);
+
+  useEffect(() => {
+    loadFirstPage();
+  }, [loadFirstPage]);
+
+  async function onLoadMore(): Promise<void> {
+    if (isNil(nextCursor)) return;
+    setIsLoadingMore(true);
+    try {
+      const res = await listProjectProposals({
+        projectId,
+        statusFilter: activeFilter,
+        after: nextCursor,
+        limit: PAGE_SIZE,
+      });
+      setProposals(prev => [...prev, ...res.proposals]);
+      setNextCursor(res.nextCursor);
+    } catch (err) {
+      showErrorToast('Failed to load more proposals', err);
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }
+
+  function openDetail(proposalId: string): void {
+    navigate(`/projects/${projectId}/proposals/${proposalId}`);
+  }
+
+  return (
+    <>
+      <Breadcrumbs
+        items={[
+          ...(organization
+            ? [
+                {
+                  label: organization.name,
+                  to: `/organizations/${organization.id}/settings`,
+                },
+              ]
+            : []),
+          { label: project?.name ?? 'Project' },
+          { label: 'Proposals' },
+        ]}
+      />
+      <H1 className="mt-3">Proposals</H1>
+
+      <div
+        className="border-border mt-6 inline-flex rounded-md border p-1"
+        role="tablist"
+      >
+        {FILTER_TABS.map(tab => {
+          const active = tab.id === activeTab;
+          return (
+            <Button
+              key={tab.id}
+              variant={active ? 'secondary' : 'ghost'}
+              size="sm"
+              className={cn('h-7 px-3', !active && 'text-muted-foreground')}
+              role="tab"
+              aria-selected={active}
+              onClick={() => setActiveTab(tab.id)}
+            >
+              {tab.label}
+            </Button>
+          );
+        })}
+      </div>
+
+      <div className="mt-6 rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Status</TableHead>
+              <TableHead>Operation</TableHead>
+              <TableHead>Proposer</TableHead>
+              <TableHead>ID</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isLoading && proposals.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={4}
+                  className="text-muted-foreground py-8 text-center text-sm"
+                >
+                  Loading proposals…
+                </TableCell>
+              </TableRow>
+            ) : proposals.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={4}
+                  className="text-muted-foreground py-8 text-center text-sm"
+                >
+                  No proposals to show.
+                </TableCell>
+              </TableRow>
+            ) : (
+              proposals.map(p => (
+                <TableRow
+                  key={p.id}
+                  className="hover:bg-muted/40 cursor-pointer"
+                  onClick={() => openDetail(p.id)}
+                >
+                  <TableCell>
+                    <ProposalStatusBadge status={p.status} />
+                  </TableCell>
+                  <TableCell>{proposalOperationLabel(p.operation)}</TableCell>
+                  <TableCell className="font-mono text-xs">
+                    {shorten(p.proposerId)}
+                  </TableCell>
+                  <TableCell className="font-mono text-xs">
+                    {shorten(p.id)}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {nextCursor && (
+        <div className="mt-4 flex justify-center">
+          <LoadingButton
+            variant="outline"
+            size="sm"
+            isLoading={isLoadingMore}
+            onClick={onLoadMore}
+          >
+            Load more
+          </LoadingButton>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default ProposalList;

--- a/src/frontend/src/routes/proposals/proposal-status-badge.tsx
+++ b/src/frontend/src/routes/proposals/proposal-status-badge.tsx
@@ -1,0 +1,40 @@
+import { Badge } from '@/components/ui/badge';
+import {
+  ProposalStatusKind,
+  proposalStatusLabel,
+  type ProposalStatus,
+} from '@/lib/api-models';
+import type { FC } from 'react';
+
+type BadgeVariant =
+  | 'default'
+  | 'secondary'
+  | 'destructive'
+  | 'outline'
+  | 'success'
+  | 'ghost';
+
+function badgeVariant(kind: ProposalStatusKind | null): BadgeVariant {
+  switch (kind) {
+    case ProposalStatusKind.Executed:
+      return 'success';
+    case ProposalStatusKind.Failed:
+    case ProposalStatusKind.Rejected:
+    case ProposalStatusKind.Cancelled:
+      return 'destructive';
+    case ProposalStatusKind.Open:
+    case ProposalStatusKind.PendingApproval:
+    case ProposalStatusKind.Executing:
+      return 'outline';
+    case null:
+      return 'secondary';
+  }
+}
+
+export const ProposalStatusBadge: FC<{ status: ProposalStatus | null }> = ({
+  status,
+}) => (
+  <Badge variant={badgeVariant(status?.kind ?? null)}>
+    {proposalStatusLabel(status)}
+  </Badge>
+);


### PR DESCRIPTION
List page with All/Open/Closed tabs and cursor pagination; detail page shows operation, proposer, and (when PendingApproval) approvers with threshold and per-voter state, resolved via get_user_profiles_by_principals. Approve/Reject and Cancel are permission- and state-gated. createCanister and addController flows redirect to the detail page on PendingApproval.