### PR TITLE
feat: record and surface proposal created/updated timestamps

### DIFF
--- a/src/backend-api/candid/proposal.did
+++ b/src/backend-api/candid/proposal.did
@@ -66,6 +66,8 @@ type Proposal = record {
   proposer_id : text;
   status : opt ProposalStatus;
   operation : opt ProposalOperation;
+  created_at_nanos : opt nat64;
+  updated_at_nanos : opt nat64;
 };
 
 type ProposalStatus = variant {

--- a/src/backend/src/data/model/proposal.rs
+++ b/src/backend/src/data/model/proposal.rs
@@ -10,6 +10,13 @@ pub struct Proposal {
     pub proposer_id: Uuid,
     pub status: ProposalStatus,
     pub operation: ProposalOperation,
+    // `Option` so proposals serialized before timestamps were introduced still
+    // deserialize cleanly post-upgrade. `None` means the data predates the
+    // field; the FE renders that as "—".
+    #[serde(default)]
+    pub created_at_nanos: Option<u64>,
+    #[serde(default)]
+    pub updated_at_nanos: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/backend/src/data/proposal_repository.rs
+++ b/src/backend/src/data/proposal_repository.rs
@@ -6,7 +6,7 @@ use crate::data::{
     ProposalStatus, Vote,
 };
 use candid::Principal;
-use canister_utils::{ApiError, ApiResult, Uuid};
+use canister_utils::{now_nanos, ApiError, ApiResult, Uuid};
 use std::cell::RefCell;
 use std::ops::Bound::{Excluded, Included};
 
@@ -17,8 +17,11 @@ pub enum VoteOutcome {
     StillPending,
 }
 
-pub fn create_proposal(project_id: Uuid, proposal: Proposal) -> Uuid {
+pub fn create_proposal(project_id: Uuid, mut proposal: Proposal) -> Uuid {
     let proposal_id = Uuid::new();
+    let now = now_nanos();
+    proposal.created_at_nanos = Some(now);
+    proposal.updated_at_nanos = Some(now);
 
     mutate_state(|s| {
         s.proposals.insert(proposal_id, proposal);
@@ -87,6 +90,7 @@ pub fn set_proposal_pending_approval(
             approvers,
             votes: Vec::new(),
         };
+        proposal.updated_at_nanos = Some(now_nanos());
         s.proposals.insert(proposal_id, proposal);
 
         Ok(())
@@ -149,6 +153,7 @@ pub fn record_proposal_vote(
                 votes,
             },
         };
+        proposal.updated_at_nanos = Some(now_nanos());
         s.proposals.insert(proposal_id, proposal);
 
         Ok(outcome)
@@ -173,6 +178,7 @@ pub fn cancel_proposal(proposal_id: Uuid) -> ApiResult {
         }
 
         proposal.status = ProposalStatus::Cancelled;
+        proposal.updated_at_nanos = Some(now_nanos());
         s.proposals.insert(proposal_id, proposal);
 
         Ok(())
@@ -200,6 +206,7 @@ fn set_proposal_status(proposal_id: Uuid, status: ProposalStatus) -> ApiResult {
         })?;
 
         proposal.status = status;
+        proposal.updated_at_nanos = Some(now_nanos());
         s.proposals.insert(proposal_id, proposal);
 
         Ok(())
@@ -250,6 +257,8 @@ mod tests {
                 proposer_id: Uuid::new(),
                 status: ProposalStatus::Open,
                 operation: ProposalOperation::CreateCanister,
+                created_at_nanos: None,
+                updated_at_nanos: None,
             },
         );
         set_proposal_pending_approval(proposal_id, threshold, approvers).unwrap();
@@ -367,6 +376,8 @@ mod tests {
                 proposer_id: Uuid::new(),
                 status: ProposalStatus::Open,
                 operation: ProposalOperation::CreateCanister,
+                created_at_nanos: None,
+                updated_at_nanos: None,
             },
         );
 

--- a/src/backend/src/dto/proposal.rs
+++ b/src/backend/src/dto/proposal.rs
@@ -63,6 +63,8 @@ pub struct Proposal {
     pub proposer_id: String,
     pub status: Option<ProposalStatus>,
     pub operation: Option<ProposalOperation>,
+    pub created_at_nanos: Option<u64>,
+    pub updated_at_nanos: Option<u64>,
 }
 
 #[derive(Debug, Clone, CandidType, Deserialize)]

--- a/src/backend/src/mapping/proposal.rs
+++ b/src/backend/src/mapping/proposal.rs
@@ -97,6 +97,8 @@ pub fn map_proposal_response(proposal_id: Uuid, proposal: data::Proposal) -> Pro
         id: proposal_id.to_string(),
         project_id: proposal.project_id.to_string(),
         proposer_id: proposal.proposer_id.to_string(),
+        created_at_nanos: proposal.created_at_nanos,
+        updated_at_nanos: proposal.updated_at_nanos,
         status: match proposal.status {
             data::ProposalStatus::Open => Some(ProposalStatus::Open {}),
             data::ProposalStatus::PendingApproval {

--- a/src/backend/src/service/proposal_service.rs
+++ b/src/backend/src/service/proposal_service.rs
@@ -35,6 +35,9 @@ pub async fn create_proposal(
         proposer_id: auth.user_id(),
         status: ProposalStatus::Open,
         operation,
+        // Stamped by the repository on insert/mutation.
+        created_at_nanos: None,
+        updated_at_nanos: None,
     };
     let proposal_id = proposal_repository::create_proposal(project_id, proposal.clone());
 

--- a/src/canister-utils/src/lib.rs
+++ b/src/canister-utils/src/lib.rs
@@ -7,6 +7,7 @@ mod env;
 mod error;
 mod principal;
 mod rand;
+mod time;
 mod timer;
 mod uuid;
 
@@ -19,4 +20,5 @@ pub use env::*;
 pub use error::*;
 pub use principal::*;
 pub use rand::*;
+pub use time::*;
 pub use uuid::*;

--- a/src/canister-utils/src/time.rs
+++ b/src/canister-utils/src/time.rs
@@ -1,0 +1,7 @@
+// Non-wasm fallback exists so unit tests don't panic on `ic_cdk::api::time()`.
+pub fn now_nanos() -> u64 {
+    #[cfg(target_family = "wasm")]
+    return ic_cdk::api::time();
+    #[cfg(not(target_family = "wasm"))]
+    0
+}

--- a/src/frontend/src/lib/api-models/proposal.ts
+++ b/src/frontend/src/lib/api-models/proposal.ts
@@ -91,6 +91,9 @@ export type Proposal = {
   proposerId: string;
   status: ProposalStatus | null;
   operation: ProposalOperation | null;
+  // Nanoseconds. `null` for proposals created before timestamps were added.
+  createdAtNanos: bigint | null;
+  updatedAtNanos: bigint | null;
 };
 
 export const PROPOSAL_OPEN_FILTER: ProposalStatusKind[] = [
@@ -200,6 +203,8 @@ export function mapProposalResponse(res: ApiProposal): Proposal {
     proposerId: res.proposer_id,
     status: statusOpt ? mapProposalStatus(statusOpt) : null,
     operation: operationOpt ? mapProposalOperation(operationOpt) : null,
+    createdAtNanos: fromCandidOpt(res.created_at_nanos),
+    updatedAtNanos: fromCandidOpt(res.updated_at_nanos),
   };
 }
 

--- a/src/frontend/src/routes/proposals/proposal-detail.tsx
+++ b/src/frontend/src/routes/proposals/proposal-detail.tsx
@@ -11,6 +11,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { H1 } from '@/components/typography/h1';
+import { formatTimestamp } from '@/lib/format';
 import { isNil } from '@/lib/nil';
 import { useRequireProjectId } from '@/lib/params';
 import {
@@ -30,6 +31,20 @@ import { useParams } from 'react-router';
 function shortenPrincipal(p: string): string {
   if (p.length <= 16) return p;
   return `${p.slice(0, 8)}…${p.slice(-6)}`;
+}
+
+// While Open/PendingApproval the proposal is still active, so updated_at is a
+// "last activity" marker. Once it transitions to a terminal status, that same
+// timestamp is when the outcome was reached.
+function updatedAtLabel(status: Proposal['status']): string {
+  if (
+    !status ||
+    status.kind === ProposalStatusKind.Open ||
+    status.kind === ProposalStatusKind.PendingApproval
+  ) {
+    return 'Last activity';
+  }
+  return 'Decided';
 }
 
 function describeOperation(p: Proposal): string {
@@ -224,6 +239,25 @@ const ProposalDetail: FC = () => {
                   <dt className="text-muted-foreground">ID</dt>
                   <dd className="font-mono text-xs">{proposal.id}</dd>
                 </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="text-muted-foreground">Created</dt>
+                  <dd className="text-xs">
+                    {proposal.createdAtNanos !== null
+                      ? formatTimestamp(proposal.createdAtNanos)
+                      : '—'}
+                  </dd>
+                </div>
+                {proposal.updatedAtNanos !== null &&
+                  proposal.updatedAtNanos !== proposal.createdAtNanos && (
+                    <div className="flex justify-between gap-4">
+                      <dt className="text-muted-foreground">
+                        {updatedAtLabel(status)}
+                      </dt>
+                      <dd className="text-xs">
+                        {formatTimestamp(proposal.updatedAtNanos)}
+                      </dd>
+                    </div>
+                  )}
                 {status?.kind === ProposalStatusKind.Failed && (
                   <div className="flex justify-between gap-4">
                     <dt className="text-muted-foreground">Reason</dt>

--- a/src/frontend/src/routes/proposals/proposal-list.tsx
+++ b/src/frontend/src/routes/proposals/proposal-list.tsx
@@ -18,6 +18,7 @@ import {
   type ProposalStatusKind,
 } from '@/lib/api-models';
 import { cn } from '@/lib/utils';
+import { formatTimestamp } from '@/lib/format';
 import { isNil } from '@/lib/nil';
 import { useRequireProjectId } from '@/lib/params';
 import { selectOrgMap, selectProjectMap, useAppStore } from '@/lib/store';
@@ -166,6 +167,7 @@ const ProposalList: FC = () => {
               <TableHead>Status</TableHead>
               <TableHead>Operation</TableHead>
               <TableHead>Proposer</TableHead>
+              <TableHead>Created</TableHead>
               <TableHead>ID</TableHead>
             </TableRow>
           </TableHeader>
@@ -173,7 +175,7 @@ const ProposalList: FC = () => {
             {isLoading && proposals.length === 0 ? (
               <TableRow>
                 <TableCell
-                  colSpan={4}
+                  colSpan={5}
                   className="text-muted-foreground py-8 text-center text-sm"
                 >
                   Loading proposals…
@@ -182,7 +184,7 @@ const ProposalList: FC = () => {
             ) : proposals.length === 0 ? (
               <TableRow>
                 <TableCell
-                  colSpan={4}
+                  colSpan={5}
                   className="text-muted-foreground py-8 text-center text-sm"
                 >
                   No proposals to show.
@@ -201,6 +203,11 @@ const ProposalList: FC = () => {
                   <TableCell>{proposalOperationLabel(p.operation)}</TableCell>
                   <TableCell className="font-mono text-xs">
                     {shorten(p.proposerId)}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground text-xs">
+                    {p.createdAtNanos !== null
+                      ? formatTimestamp(p.createdAtNanos)
+                      : '—'}
                   </TableCell>
                   <TableCell className="font-mono text-xs">
                     {shorten(p.id)}


### PR DESCRIPTION
Stamps `created_at_nanos` once at creation and bumps `updated_at_nanos` on every status mutation (pending-approval transition, votes, cancel, executing/executed/failed). Stored as `Option<u64>` with `#[serde(default)]` so proposals serialized before this change still deserialize after upgrade.