### PR TITLE
feat: soft-delete canisters instead of hard removal

### DIFF
--- a/src/backend-api/candid/canister.did
+++ b/src/backend-api/candid/canister.did
@@ -46,6 +46,7 @@ type CanisterWithOwner = record {
   principal_id : text;
   user_id : text;
   email : opt text;
+  deleted_at : opt nat64;
 };
 
 type PaginationMetaResponse = record {
@@ -60,6 +61,7 @@ type Canister = record {
   principal_id : text;
   name : opt text;
   state : CanisterState;
+  deleted_at : opt nat64;
 };
 
 type CanisterState = variant {

--- a/src/backend-tests/src/tests/canister.spec.ts
+++ b/src/backend-tests/src/tests/canister.spec.ts
@@ -51,6 +51,7 @@ describe('Canisters', () => {
     expect(canister).toEqual({
       id: expect.any(String),
       name: [],
+      deleted_at: [],
       state: {
         Accessible: {
           cycles: 0n,
@@ -718,7 +719,7 @@ describe('Canisters', () => {
       expect(after[0]!.state).toEqual({ Deleted: null });
     });
 
-    it('remove_my_canister deletes the record for a canister removed on-chain', async () => {
+    it('remove_my_canister hides the record from list_my_canisters when also deleted on-chain', async () => {
       const { projectId, record } = await createAndDeleteCanister();
 
       const removeRes = await driver.actor.remove_my_canister({
@@ -732,7 +733,7 @@ describe('Canisters', () => {
       expect(after).toEqual([]);
     });
 
-    it('remove_my_canister rejects canisters that still exist on-chain', async () => {
+    it('remove_my_canister soft-deletes canisters that still exist on-chain', async () => {
       const [aliceIdentity] = await driver.users.createUser();
       driver.actor.setIdentity(aliceIdentity);
       const project = await driver.getDefaultProject();
@@ -745,12 +746,12 @@ describe('Canisters', () => {
       const removeRes = await driver.actor.remove_my_canister({
         canister_id: record!.id,
       });
-      expect(removeRes).toHaveProperty('Err');
+      extractOkResponse(removeRes);
 
       const after = extractOkResponse(
         await driver.actor.list_my_canisters({ project_id: project.id }),
       );
-      expect(after).toHaveLength(1);
+      expect(after).toEqual([]);
     });
 
     it('remove_my_canister rejects callers who do not own the canister', async () => {
@@ -763,6 +764,98 @@ describe('Canisters', () => {
         canister_id: record.id,
       });
       expect(removeRes).toHaveProperty('Err');
+    });
+  });
+
+  describe('soft-deleted canisters', () => {
+    it('remove_my_canister sets deleted_at and hides from list_my_canisters', async () => {
+      const [aliceIdentity] = await driver.users.createUser();
+      driver.actor.setIdentity(aliceIdentity);
+      const project = await driver.getDefaultProject();
+      await driver.proposals.createCanister(aliceIdentity, project.id);
+
+      const [record] = extractOkResponse(
+        await driver.actor.list_my_canisters({ project_id: project.id }),
+      );
+      expect(record!.deleted_at).toEqual([]);
+
+      extractOkResponse(
+        await driver.actor.remove_my_canister({ canister_id: record!.id }),
+      );
+
+      const after = extractOkResponse(
+        await driver.actor.list_my_canisters({ project_id: project.id }),
+      );
+      expect(after).toEqual([]);
+    });
+
+    it('list_user_canisters surfaces soft-deleted canisters with deleted_at populated', async () => {
+      const [aliceIdentity, aliceProfile] = await driver.users.createUser();
+      driver.actor.setIdentity(aliceIdentity);
+      const project = await driver.getDefaultProject();
+      await driver.proposals.createCanister(aliceIdentity, project.id);
+
+      const [record] = extractOkResponse(
+        await driver.actor.list_my_canisters({ project_id: project.id }),
+      );
+      extractOkResponse(
+        await driver.actor.remove_my_canister({ canister_id: record!.id }),
+      );
+
+      driver.actor.setIdentity(controllerIdentity);
+      const { canisters } = extractOkResponse(
+        await driver.actor.list_user_canisters({ user_id: aliceProfile.id }),
+      );
+
+      expect(canisters).toHaveLength(1);
+      expect(canisters[0]!.id).toBe(record!.id);
+      expect(canisters[0]!.deleted_at).toHaveLength(1);
+      expect(canisters[0]!.deleted_at[0]).toEqual(expect.any(BigInt));
+    });
+
+    it('list_all_canisters surfaces soft-deleted canisters with deleted_at populated', async () => {
+      const [aliceIdentity] = await driver.users.createUser();
+      driver.actor.setIdentity(aliceIdentity);
+      const project = await driver.getDefaultProject();
+      await driver.proposals.createCanister(aliceIdentity, project.id);
+
+      const [record] = extractOkResponse(
+        await driver.actor.list_my_canisters({ project_id: project.id }),
+      );
+      extractOkResponse(
+        await driver.actor.remove_my_canister({ canister_id: record!.id }),
+      );
+
+      driver.actor.setIdentity(controllerIdentity);
+      const { canisters, meta } = extractOkResponse(
+        await driver.actor.list_all_canisters({ limit: [10n], page: [1n] }),
+      );
+
+      expect(meta.total_items).toBe(1n);
+      expect(canisters).toHaveLength(1);
+      expect(canisters[0]!.id).toBe(record!.id);
+      expect(canisters[0]!.deleted_at).toHaveLength(1);
+      expect(canisters[0]!.deleted_at[0]).toEqual(expect.any(BigInt));
+    });
+
+    it('remove_my_canister errors when called twice on the same canister', async () => {
+      const [aliceIdentity] = await driver.users.createUser();
+      driver.actor.setIdentity(aliceIdentity);
+      const project = await driver.getDefaultProject();
+      await driver.proposals.createCanister(aliceIdentity, project.id);
+
+      const [record] = extractOkResponse(
+        await driver.actor.list_my_canisters({ project_id: project.id }),
+      );
+
+      extractOkResponse(
+        await driver.actor.remove_my_canister({ canister_id: record!.id }),
+      );
+
+      const second = await driver.actor.remove_my_canister({
+        canister_id: record!.id,
+      });
+      expect(second).toHaveProperty('Err');
     });
   });
 });

--- a/src/backend-tests/src/tests/list-all-canisters.spec.ts
+++ b/src/backend-tests/src/tests/list-all-canisters.spec.ts
@@ -159,6 +159,7 @@ describe('list_all_canisters', () => {
           user_id: aliceProfile.id,
           email: [aliceEmail],
           principal_id: canister.principal_id,
+          deleted_at: [],
         });
       }
 
@@ -168,6 +169,7 @@ describe('list_all_canisters', () => {
           user_id: bobProfile.id,
           email: [bobEmail],
           principal_id: canister.principal_id,
+          deleted_at: [],
         });
       }
     });

--- a/src/backend/src/controller/canister.rs
+++ b/src/backend/src/controller/canister.rs
@@ -6,15 +6,15 @@ use crate::{
     },
     service::canister_service,
 };
-use canister_utils::{assert_authenticated, assert_controller, ApiResultDto, Uuid};
+use canister_utils::{assert_authenticated, assert_controller, ApiResult, ApiResultDto, Uuid};
 use ic_cdk::{api::msg_caller, *};
 
-async fn remove_my_canister_inner(
+fn remove_my_canister_inner(
     caller: candid::Principal,
     request: RemoveMyCanisterRequest,
-) -> canister_utils::ApiResult<()> {
+) -> ApiResult<()> {
     let canister_id = Uuid::try_from(request.canister_id.as_str())?;
-    canister_service::remove_my_canister(caller, canister_id).await
+    canister_service::remove_my_canister(caller, canister_id)
 }
 
 #[update]
@@ -44,13 +44,13 @@ async fn list_user_canisters(
 }
 
 #[update]
-async fn remove_my_canister(request: RemoveMyCanisterRequest) -> ApiResultDto<()> {
+fn remove_my_canister(request: RemoveMyCanisterRequest) -> ApiResultDto<()> {
     let caller = msg_caller();
     if let Err(err) = assert_authenticated(&caller) {
         return ApiResultDto::Err(err);
     }
 
-    remove_my_canister_inner(caller, request).await.into()
+    remove_my_canister_inner(caller, request).into()
 }
 
 #[update]

--- a/src/backend/src/data/canister_repository.rs
+++ b/src/backend/src/data/canister_repository.rs
@@ -1,7 +1,8 @@
 use crate::data::{
     memory::{
-        init_canister_project_index, init_canisters, init_project_canister_index, CanisterMemory,
-        CanisterProjectIndexMemory, ProjectCanisterIndexMemory,
+        init_active_project_canister_index, init_canister_project_index, init_canisters,
+        init_deleted_project_canister_index, ActiveProjectCanisterIndexMemory, CanisterMemory,
+        CanisterProjectIndexMemory, DeletedProjectCanisterIndexMemory,
     },
     Canister,
 };
@@ -10,16 +11,38 @@ use std::cell::RefCell;
 
 pub fn project_has_canisters(project_id: Uuid) -> bool {
     with_state(|s| {
-        s.project_canister_index
-            .range((project_id, Uuid::MIN)..=(project_id, Uuid::MAX))
+        let range = (project_id, Uuid::MIN)..=(project_id, Uuid::MAX);
+        s.active_project_canister_index
+            .range(range.clone())
             .any(|_| true)
+            || s.deleted_project_canister_index.range(range).any(|_| true)
     })
 }
 
-pub fn list_canisters_by_project(project_id: Uuid) -> Vec<(Uuid, Canister)> {
+pub fn list_active_canisters_by_project(project_id: Uuid) -> Vec<(Uuid, Canister)> {
     with_state(|s| {
-        s.project_canister_index
+        s.active_project_canister_index
             .range((project_id, Uuid::MIN)..=(project_id, Uuid::MAX))
+            .filter_map(|(_, canister_id)| {
+                s.canisters
+                    .get(&canister_id)
+                    .map(|canister| (canister_id, canister))
+            })
+            .collect()
+    })
+}
+
+pub fn list_canisters_by_project_including_deleted(project_id: Uuid) -> Vec<(Uuid, Canister)> {
+    with_state(|s| {
+        let active = s
+            .active_project_canister_index
+            .range((project_id, Uuid::MIN)..=(project_id, Uuid::MAX));
+        let deleted = s
+            .deleted_project_canister_index
+            .range((project_id, Uuid::MIN)..=(project_id, Uuid::MAX));
+
+        active
+            .chain(deleted)
             .filter_map(|(_, canister_id)| {
                 s.canisters
                     .get(&canister_id)
@@ -50,7 +73,8 @@ pub fn create_canister(project_id: Uuid, canister: Canister) -> Uuid {
 
     mutate_state(|s| {
         s.canisters.insert(canister_id, canister);
-        s.project_canister_index.insert((project_id, canister_id));
+        s.active_project_canister_index
+            .insert((project_id, canister_id));
         s.canister_project_index.insert(canister_id, project_id);
     });
 
@@ -65,24 +89,30 @@ pub fn get_canister_project_id(canister_id: Uuid) -> Option<Uuid> {
     with_state(|s| s.canister_project_index.get(&canister_id))
 }
 
-pub fn get_canister_in_project(project_id: Uuid, canister_id: Uuid) -> Option<Canister> {
-    with_state(|s| {
-        if s.project_canister_index
+pub fn soft_delete_canister(
+    project_id: Uuid,
+    canister_id: Uuid,
+    deleted_at: u64,
+) -> Option<Canister> {
+    mutate_state(|s| {
+        if !s
+            .active_project_canister_index
             .contains(&(project_id, canister_id))
         {
-            s.canisters.get(&canister_id)
-        } else {
-            None
+            return None;
         }
-    })
-}
 
-pub fn remove_canister(project_id: Uuid, canister_id: Uuid) {
-    mutate_state(|s| {
-        s.canisters.remove(&canister_id);
-        s.project_canister_index.remove(&(project_id, canister_id));
-        s.canister_project_index.remove(&canister_id);
-    });
+        let mut canister = s.canisters.get(&canister_id)?;
+        canister.deleted_at = Some(deleted_at);
+        s.canisters.insert(canister_id, canister.clone());
+
+        s.active_project_canister_index
+            .remove(&(project_id, canister_id));
+        s.deleted_project_canister_index
+            .insert((project_id, canister_id));
+
+        Some(canister)
+    })
 }
 
 pub fn update_canister_name(canister_id: Uuid, name: Option<String>) -> Option<Canister> {
@@ -96,7 +126,8 @@ pub fn update_canister_name(canister_id: Uuid, name: Option<String>) -> Option<C
 
 struct CanisterState {
     canisters: CanisterMemory,
-    project_canister_index: ProjectCanisterIndexMemory,
+    active_project_canister_index: ActiveProjectCanisterIndexMemory,
+    deleted_project_canister_index: DeletedProjectCanisterIndexMemory,
     canister_project_index: CanisterProjectIndexMemory,
 }
 
@@ -104,7 +135,8 @@ impl Default for CanisterState {
     fn default() -> Self {
         Self {
             canisters: init_canisters(),
-            project_canister_index: init_project_canister_index(),
+            active_project_canister_index: init_active_project_canister_index(),
+            deleted_project_canister_index: init_deleted_project_canister_index(),
             canister_project_index: init_canister_project_index(),
         }
     }

--- a/src/backend/src/data/memory/canister_memory.rs
+++ b/src/backend/src/data/memory/canister_memory.rs
@@ -1,7 +1,7 @@
 use crate::data::{
     memory::{
-        get_memory, Memory, CANISTERS_MEMORY_ID, CANISTER_PROJECT_INDEX_MEMORY_ID,
-        PROJECT_CANISTER_INDEX_MEMORY_ID,
+        get_memory, Memory, ACTIVE_PROJECT_CANISTER_INDEX_MEMORY_ID, CANISTERS_MEMORY_ID,
+        CANISTER_PROJECT_INDEX_MEMORY_ID, DELETED_PROJECT_CANISTER_INDEX_MEMORY_ID,
     },
     Canister,
 };
@@ -9,15 +9,20 @@ use canister_utils::Uuid;
 use ic_stable_structures::{BTreeMap, BTreeSet};
 
 pub type CanisterMemory = BTreeMap<Uuid, Canister, Memory>;
-pub type ProjectCanisterIndexMemory = BTreeSet<(Uuid, Uuid), Memory>;
+pub type ActiveProjectCanisterIndexMemory = BTreeSet<(Uuid, Uuid), Memory>;
+pub type DeletedProjectCanisterIndexMemory = BTreeSet<(Uuid, Uuid), Memory>;
 pub type CanisterProjectIndexMemory = BTreeMap<Uuid, Uuid, Memory>;
 
 pub fn init_canisters() -> CanisterMemory {
     CanisterMemory::init(get_canisters_memory())
 }
 
-pub fn init_project_canister_index() -> ProjectCanisterIndexMemory {
-    ProjectCanisterIndexMemory::init(get_project_canister_index_memory())
+pub fn init_active_project_canister_index() -> ActiveProjectCanisterIndexMemory {
+    ActiveProjectCanisterIndexMemory::init(get_active_project_canister_index_memory())
+}
+
+pub fn init_deleted_project_canister_index() -> DeletedProjectCanisterIndexMemory {
+    DeletedProjectCanisterIndexMemory::init(get_deleted_project_canister_index_memory())
 }
 
 pub fn init_canister_project_index() -> CanisterProjectIndexMemory {
@@ -28,8 +33,12 @@ fn get_canisters_memory() -> Memory {
     get_memory(CANISTERS_MEMORY_ID)
 }
 
-fn get_project_canister_index_memory() -> Memory {
-    get_memory(PROJECT_CANISTER_INDEX_MEMORY_ID)
+fn get_active_project_canister_index_memory() -> Memory {
+    get_memory(ACTIVE_PROJECT_CANISTER_INDEX_MEMORY_ID)
+}
+
+fn get_deleted_project_canister_index_memory() -> Memory {
+    get_memory(DELETED_PROJECT_CANISTER_INDEX_MEMORY_ID)
 }
 
 fn get_canister_project_index_memory() -> Memory {

--- a/src/backend/src/data/memory/memory_manager.rs
+++ b/src/backend/src/data/memory/memory_manager.rs
@@ -18,7 +18,7 @@ pub(super) const USER_PROFILE_PRINCIPAL_INDEX_MEMORY_ID: MemoryId = MemoryId::ne
 pub(super) const USER_PROFILE_ID_PRINCIPAL_INDEX_MEMORY_ID: MemoryId = MemoryId::new(2);
 
 pub(super) const CANISTERS_MEMORY_ID: MemoryId = MemoryId::new(3);
-pub(super) const PROJECT_CANISTER_INDEX_MEMORY_ID: MemoryId = MemoryId::new(4);
+pub(super) const ACTIVE_PROJECT_CANISTER_INDEX_MEMORY_ID: MemoryId = MemoryId::new(4);
 
 pub(super) const TRUSTED_PARTNERS_MEMORY_ID: MemoryId = MemoryId::new(5);
 pub(super) const TRUSTED_PARTNER_PRINCIPAL_INDEX_MEMORY_ID: MemoryId = MemoryId::new(6);
@@ -63,3 +63,5 @@ pub(super) const INVITE_STATUS_INDEX_MEMORY_ID: MemoryId = MemoryId::new(30);
 pub(super) const ORGANIZATION_TEAM_PERMISSIONS_INDEX_MEMORY_ID: MemoryId = MemoryId::new(31);
 pub(super) const PROJECT_TEAM_PERMISSIONS_INDEX_MEMORY_ID: MemoryId = MemoryId::new(32);
 pub(super) const TEAM_PROJECT_PERMISSIONS_INDEX_MEMORY_ID: MemoryId = MemoryId::new(33);
+
+pub(super) const DELETED_PROJECT_CANISTER_INDEX_MEMORY_ID: MemoryId = MemoryId::new(34);

--- a/src/backend/src/data/model/canister.rs
+++ b/src/backend/src/data/model/canister.rs
@@ -9,6 +9,8 @@ pub struct Canister {
     pub principal: Principal,
     #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
+    pub deleted_at: Option<u64>,
 }
 
 impl Storable for Canister {

--- a/src/backend/src/dto/canister.rs
+++ b/src/backend/src/dto/canister.rs
@@ -36,6 +36,7 @@ pub struct CanisterWithOwner {
     pub principal_id: String,
     pub user_id: String,
     pub email: Option<String>,
+    pub deleted_at: Option<u64>,
 }
 
 #[derive(Debug, Clone, CandidType, Deserialize)]
@@ -52,6 +53,7 @@ pub struct Canister {
     pub principal_id: String,
     pub name: Option<String>,
     pub state: CanisterState,
+    pub deleted_at: Option<u64>,
 }
 
 #[derive(Debug, Clone, CandidType, Deserialize)]

--- a/src/backend/src/mapping/canister.rs
+++ b/src/backend/src/mapping/canister.rs
@@ -18,6 +18,7 @@ pub fn map_canister_response(
         principal_id: canister.principal.to_string(),
         name: canister.name.clone(),
         state,
+        deleted_at: canister.deleted_at,
     }
 }
 

--- a/src/backend/src/service/canister_service.rs
+++ b/src/backend/src/service/canister_service.rs
@@ -19,7 +19,7 @@ use candid::Principal;
 use canister_utils::{is_destination_invalid, ApiError, ApiResult, Uuid, MAX_CALLS_PER_BATCH};
 use futures::future::join_all;
 use ic_cdk::{
-    api::canister_self,
+    api::{canister_self, time},
     call::Error as CallError,
     management_canister::{
         self, CanisterSettings, CanisterStatusArgs, CreateCanisterArgs, UpdateSettingsArgs,
@@ -32,7 +32,9 @@ pub async fn list_my_canisters(
 ) -> ApiResult<ListMyCanistersResponse> {
     let project_id = request.project_id.as_str().try_into()?;
     let auth = ProjectAuth::require(&caller, project_id, ProjectPermissions::EMPTY)?;
-    list_canisters_by_project_internal(auth.project_id()).await
+    let project_canisters =
+        canister_repository::list_active_canisters_by_project(auth.project_id());
+    Ok(fetch_canisters_with_state(project_canisters).await)
 }
 
 pub async fn list_user_canisters(
@@ -51,14 +53,17 @@ pub async fn list_user_canisters(
 
     let mut canisters = vec![];
     for project_id in project_ids {
-        canisters.extend(list_canisters_by_project_internal(project_id).await?);
+        let project_canisters =
+            canister_repository::list_canisters_by_project_including_deleted(project_id);
+        canisters.extend(fetch_canisters_with_state(project_canisters).await);
     }
 
     Ok(ListUserCanistersResponse { canisters })
 }
 
-async fn list_canisters_by_project_internal(project_id: Uuid) -> ApiResult<Vec<dto::Canister>> {
-    let project_canisters = canister_repository::list_canisters_by_project(project_id);
+async fn fetch_canisters_with_state(
+    project_canisters: Vec<(Uuid, Canister)>,
+) -> Vec<dto::Canister> {
     let mut canisters = vec![];
 
     for chunk in project_canisters.chunks(MAX_CALLS_PER_BATCH) {
@@ -70,7 +75,7 @@ async fn list_canisters_by_project_internal(project_id: Uuid) -> ApiResult<Vec<d
         canisters.extend(join_all(canister_futures).await);
     }
 
-    Ok(canisters)
+    canisters
 }
 
 async fn fetch_canister_state(canister_id: Principal) -> CanisterState {
@@ -135,31 +140,21 @@ pub fn update_my_canister_name(
     Ok(())
 }
 
-pub async fn remove_my_canister(caller: Principal, canister_id: Uuid) -> ApiResult<()> {
+pub fn remove_my_canister(caller: Principal, canister_id: Uuid) -> ApiResult<()> {
     let project_id = canister_repository::get_canister_project_id(canister_id)
         .ok_or_else(|| ApiError::client_error(format!("Canister {canister_id} not found.")))?;
 
     let auth = ProjectAuth::require(&caller, project_id, ProjectPermissions::CANISTER_MANAGE)?;
 
-    let canister = canister_repository::get_canister_in_project(auth.project_id(), canister_id)
-        .ok_or_else(|| {
+    canister_repository::soft_delete_canister(auth.project_id(), canister_id, time()).ok_or_else(
+        || {
             ApiError::client_error(format!(
-                "Canister {canister_id} not found in user's project."
+                "Canister {canister_id} is not active in user's project (already removed?)."
             ))
-        })?;
+        },
+    )?;
 
-    match fetch_canister_state(canister.principal).await {
-        CanisterState::Deleted => {
-            canister_repository::remove_canister(auth.project_id(), canister_id);
-            Ok(())
-        }
-        CanisterState::Accessible(_) | CanisterState::Inaccessible => {
-            Err(ApiError::client_error(format!(
-                "Canister {} still exists on the network and cannot be removed from the dashboard.",
-                canister.principal
-            )))
-        }
-    }
+    Ok(())
 }
 
 pub fn list_all_canisters(
@@ -190,6 +185,7 @@ pub fn list_all_canisters(
                     principal_id: canister.principal.to_text(),
                     user_id: org_owner_id.to_string(),
                     email: org_owner.email,
+                    deleted_at: canister.deleted_at,
                 })
         })
         .collect::<Vec<_>>();
@@ -221,6 +217,7 @@ pub async fn create_my_canister(project_id: Uuid) -> Result<(), String> {
     let canister = Canister {
         principal: result.canister_id,
         name: None,
+        deleted_at: None,
     };
     canister_repository::create_canister(project_id, canister.clone());
 

--- a/src/frontend/src/lib/api-models/canister.ts
+++ b/src/frontend/src/lib/api-models/canister.ts
@@ -35,6 +35,7 @@ export type Canister = {
   principal: string;
   name: string | null;
   state: CanisterState;
+  deletedAt: bigint | null;
 };
 
 export type CanisterInfo = {
@@ -101,6 +102,7 @@ export function mapCanisterResponse(res: ApiCanister): Canister {
     principal: res.principal_id,
     name: fromCandidOpt(res.name),
     state: mapCanisterState(res.state),
+    deletedAt: fromCandidOpt(res.deleted_at),
   };
 }
 

--- a/src/frontend/src/routes/admin/user-canister-card.tsx
+++ b/src/frontend/src/routes/admin/user-canister-card.tsx
@@ -3,7 +3,7 @@ import {
   CanisterStatus,
   type Canister,
 } from '@/lib/api-models';
-import { formatBytes, formatCycles } from '@/lib/format';
+import { formatBytes, formatCycles, formatTimestamp } from '@/lib/format';
 import { Badge } from '@/components/ui/badge';
 import { LoadingButton } from '@/components/loading-button';
 import { useAppStore } from '@/lib/store';
@@ -141,6 +141,11 @@ export const UserCanisterCard: FC<UserCanisterCardProps> = ({
           <CardAction className="flex items-center gap-2">
             <Badge variant="destructive">Deleted</Badge>
           </CardAction>
+        )}
+        {canister.deletedAt !== null && (
+          <CardDescription className="text-destructive">
+            Removed by user on {formatTimestamp(canister.deletedAt)}
+          </CardDescription>
         )}
       </CardHeader>
 


### PR DESCRIPTION
remove_my_canister now flips a deleted_at flag and moves the record to a separate index, rather than dropping it. The previous hard-delete let users sever parent→child controller relationships by removing the parent record; the audit trail is now preserved indefinitely. Admin views (list_user_canisters, list_all_canisters) surface deleted_at; user-facing list_my_canisters filters soft-deleted records out.