### PR TITLE
feat: allow linking existing canisters to a project

### DIFF
--- a/src/backend-api/candid/proposal.did
+++ b/src/backend-api/candid/proposal.did
@@ -29,6 +29,10 @@ type ProposalStatus = variant {
 
 type ProposalOperation = variant {
   CreateCanister : record {};
+  LinkCanister : record {
+    canister_id : principal;
+    name : opt text;
+  };
   AddCanisterController : record {
     canister_id : principal;
     controller_id : principal;

--- a/src/backend-tests/src/support/proposal-driver.ts
+++ b/src/backend-tests/src/support/proposal-driver.ts
@@ -38,7 +38,7 @@ export class ProposalDriver {
     });
   }
 
-  private async createProposal(
+  public async createProposal(
     identity: Identity,
     projectId: string,
     operation: ProposalOperation,

--- a/src/backend-tests/src/tests/canister.spec.ts
+++ b/src/backend-tests/src/tests/canister.spec.ts
@@ -765,4 +765,191 @@ describe('Canisters', () => {
       expect(removeRes).toHaveProperty('Err');
     });
   });
+
+  describe('link_canister', () => {
+    it('should return an error for an anonymous user', async () => {
+      driver.actor.setIdentity(anonymousIdentity);
+
+      const res = await driver.actor.create_proposal({
+        project_id: projectId,
+        operation: [{ LinkCanister: { canister_id: canisterId, name: [] } }],
+      });
+      expect(res).toEqual(unauthenticatedError);
+    });
+
+    it('should return an error for a user without a profile', async () => {
+      const aliceIdentity = generateRandomIdentity();
+      driver.actor.setIdentity(aliceIdentity);
+
+      const res = await driver.actor.create_proposal({
+        project_id: projectId,
+        operation: [{ LinkCanister: { canister_id: canisterId, name: [] } }],
+      });
+      expect(res).toEqual(noProfileError(aliceIdentity.getPrincipal()));
+    });
+
+    it('should return an error for a project the user does not have access to', async () => {
+      const [aliceIdentity] = await driver.users.createUser();
+
+      const bobIdentity = generateRandomIdentity();
+      driver.actor.setIdentity(bobIdentity);
+      await driver.actor.create_my_user_profile();
+      const bobProject = await driver.getDefaultProject();
+
+      driver.actor.setIdentity(aliceIdentity);
+      const res = await driver.actor.create_proposal({
+        project_id: bobProject.id,
+        operation: [{ LinkCanister: { canister_id: canisterId, name: [] } }],
+      });
+      expect(res).toEqual(projectNotFoundOrNoAccessError(bobProject.id));
+    });
+
+    it('should return an error for a project that does not exist', async () => {
+      const [aliceIdentity] = await driver.users.createUser();
+      driver.actor.setIdentity(aliceIdentity);
+
+      const res = await driver.actor.create_proposal({
+        project_id: projectId,
+        operation: [{ LinkCanister: { canister_id: canisterId, name: [] } }],
+      });
+      expect(res).toEqual(projectNotFoundOrNoAccessError(projectId));
+    });
+
+    it('should fail when the canister does not exist on-chain', async () => {
+      const [aliceIdentity] = await driver.users.createUser();
+      driver.actor.setIdentity(aliceIdentity);
+      const project = await driver.getDefaultProject();
+
+      const proposal = await driver.proposals.createProposal(
+        aliceIdentity,
+        project.id,
+        { LinkCanister: { canister_id: canisterId, name: [] } },
+      );
+
+      const [status] = proposal.status;
+      if (!status || !('Failed' in status)) {
+        throw new Error('Expected a failed proposal');
+      }
+      expect(status.Failed.message).toContain(
+        `Failed to get canister_status for ${canisterId}`,
+      );
+    });
+
+    it('should fail when the backend canister is not a controller', async () => {
+      const [aliceIdentity] = await driver.users.createUser();
+      driver.actor.setIdentity(aliceIdentity);
+      const project = await driver.getDefaultProject();
+
+      // Backend is not in the controllers list, so canister_status will reject.
+      const externalCanisterId = await driver.pic.createCanister({
+        controllers: [aliceIdentity.getPrincipal()],
+      });
+
+      const proposal = await driver.proposals.createProposal(
+        aliceIdentity,
+        project.id,
+        {
+          LinkCanister: { canister_id: externalCanisterId, name: [] },
+        },
+      );
+
+      const [status] = proposal.status;
+      if (!status || !('Failed' in status)) {
+        throw new Error('Expected a failed proposal');
+      }
+      expect(status.Failed.message).toContain('Failed to get canister_status');
+      expect(status.Failed.message).toContain(
+        'The backend canister must be a controller',
+      );
+    });
+
+    it('should fail when the caller is not a controller of the canister', async () => {
+      const [aliceIdentity] = await driver.users.createUser();
+      driver.actor.setIdentity(aliceIdentity);
+      const project = await driver.getDefaultProject();
+
+      // Backend is a controller but Alice is not.
+      const externalCanisterId = await driver.pic.createCanister({
+        controllers: [driver.canisterId],
+      });
+
+      const proposal = await driver.proposals.createProposal(
+        aliceIdentity,
+        project.id,
+        {
+          LinkCanister: { canister_id: externalCanisterId, name: [] },
+        },
+      );
+
+      const [status] = proposal.status;
+      if (!status || !('Failed' in status)) {
+        throw new Error('Expected a failed proposal');
+      }
+      expect(status.Failed.message).toContain(
+        `Caller ${aliceIdentity.getPrincipal()} is not a controller of ${externalCanisterId}`,
+      );
+    });
+
+    it('should fail when the canister is already linked', async () => {
+      const [aliceIdentity] = await driver.users.createUser();
+      driver.actor.setIdentity(aliceIdentity);
+      const project = await driver.getDefaultProject();
+
+      const externalCanisterId = await driver.pic.createCanister({
+        controllers: [driver.canisterId, aliceIdentity.getPrincipal()],
+      });
+
+      await driver.proposals.createProposal(aliceIdentity, project.id, {
+        LinkCanister: { canister_id: externalCanisterId, name: [] },
+      });
+
+      const proposal = await driver.proposals.createProposal(
+        aliceIdentity,
+        project.id,
+        {
+          LinkCanister: { canister_id: externalCanisterId, name: [] },
+        },
+      );
+
+      const [status] = proposal.status;
+      if (!status || !('Failed' in status)) {
+        throw new Error('Expected a failed proposal');
+      }
+      expect(status.Failed.message).toContain(
+        `Canister ${externalCanisterId} is already linked to a project`,
+      );
+    });
+
+    it('should link an existing canister with backend and caller as controllers', async () => {
+      const [aliceIdentity] = await driver.users.createUser();
+      driver.actor.setIdentity(aliceIdentity);
+      const project = await driver.getDefaultProject();
+
+      const externalCanisterId = await driver.pic.createCanister({
+        controllers: [driver.canisterId, aliceIdentity.getPrincipal()],
+      });
+
+      const proposal = await driver.proposals.createProposal(
+        aliceIdentity,
+        project.id,
+        {
+          LinkCanister: {
+            canister_id: externalCanisterId,
+            name: ['My Linked Canister'],
+          },
+        },
+      );
+
+      const [status] = proposal.status;
+      expect(status && 'Executed' in status).toBe(true);
+
+      const canisterRes = await driver.actor.list_my_canisters({
+        project_id: project.id,
+      });
+      const [canister] = extractOkResponse(canisterRes);
+      expect(canister).toBeDefined();
+      expect(canister!.principal_id).toBe(externalCanisterId.toText());
+      expect(canister!.name).toEqual(['My Linked Canister']);
+    });
+  });
 });

--- a/src/backend/src/constants.rs
+++ b/src/backend/src/constants.rs
@@ -21,3 +21,9 @@ pub const INVITE_TTL_NS: u64 = 7 * 24 * 60 * 60 * 1_000_000_000;
 // Maximum number of pending (non-expired) invites a single org may have.
 // Bounds per-org storage and prevents invite spam.
 pub const MAX_PENDING_INVITES_PER_ORG: usize = 10;
+
+// Principal of the Swiss subnet. Linked canisters are expected to reside here,
+// but the link flow does not yet enforce this — see TODO in
+// canister_service::link_my_canister.
+#[allow(dead_code)]
+pub const SWISS_SUBNET_ID: &str = "3zsyy-cnoqf-tvlun-ymf55-tkpca-ox7uw-kfxoh-7khwq-2gz43-wafem-lqe";

--- a/src/backend/src/data/canister_repository.rs
+++ b/src/backend/src/data/canister_repository.rs
@@ -5,6 +5,7 @@ use crate::data::{
     },
     Canister,
 };
+use candid::Principal;
 use canister_utils::Uuid;
 use std::cell::RefCell;
 
@@ -63,6 +64,16 @@ pub fn get_canister_count() -> u64 {
 
 pub fn get_canister_project_id(canister_id: Uuid) -> Option<Uuid> {
     with_state(|s| s.canister_project_index.get(&canister_id))
+}
+
+pub fn find_canister_id_by_principal(principal: Principal) -> Option<Uuid> {
+    with_state(|s| {
+        s.canisters
+            .iter()
+            .map(|val| val.into_pair())
+            .find(|(_, canister)| canister.principal == principal)
+            .map(|(canister_id, _)| canister_id)
+    })
 }
 
 pub fn get_canister_in_project(project_id: Uuid, canister_id: Uuid) -> Option<Canister> {

--- a/src/backend/src/data/model/approval_policy.rs
+++ b/src/backend/src/data/model/approval_policy.rs
@@ -25,6 +25,7 @@ pub enum PolicyType {
 #[repr(u8)]
 pub enum OperationType {
     CreateCanister = 0,
+    LinkCanister = 1,
     Noop = 254,
     AddCanisterController = 255,
 }
@@ -83,6 +84,7 @@ impl Storable for OperationType {
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
         match bytes.first() {
             Some(0) => OperationType::CreateCanister,
+            Some(1) => OperationType::LinkCanister,
             Some(255) => OperationType::AddCanisterController,
             _ => OperationType::Noop,
         }

--- a/src/backend/src/data/model/proposal.rs
+++ b/src/backend/src/data/model/proposal.rs
@@ -23,6 +23,10 @@ pub enum ProposalStatus {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ProposalOperation {
     CreateCanister,
+    LinkCanister {
+        canister_id: Principal,
+        name: Option<String>,
+    },
     AddCanisterController {
         canister_id: Principal,
         controller_id: Principal,

--- a/src/backend/src/dto/proposal.rs
+++ b/src/backend/src/dto/proposal.rs
@@ -29,6 +29,10 @@ pub enum ProposalStatus {
 #[derive(Debug, Clone, CandidType, Deserialize)]
 pub enum ProposalOperation {
     CreateCanister {},
+    LinkCanister {
+        canister_id: Principal,
+        name: Option<String>,
+    },
     AddCanisterController {
         canister_id: Principal,
         controller_id: Principal,

--- a/src/backend/src/mapping/proposal.rs
+++ b/src/backend/src/mapping/proposal.rs
@@ -1,6 +1,7 @@
 use crate::{
     data,
     dto::{CreateProposalRequest, CreateProposalResponse, ProposalOperation, ProposalStatus},
+    validation::CanisterName,
 };
 use canister_utils::{ApiError, ApiResult, Uuid};
 
@@ -17,6 +18,16 @@ pub fn map_create_proposal_request(
             operation: match req.operation {
                 Some(ProposalOperation::CreateCanister {}) => {
                     data::ProposalOperation::CreateCanister
+                }
+                Some(ProposalOperation::LinkCanister { canister_id, name }) => {
+                    let validated_name = match name {
+                        None => None,
+                        Some(raw) => Some(CanisterName::try_from(raw)?.into_inner()),
+                    };
+                    data::ProposalOperation::LinkCanister {
+                        canister_id,
+                        name: validated_name,
+                    }
                 }
                 Some(ProposalOperation::AddCanisterController {
                     canister_id,
@@ -51,6 +62,9 @@ pub fn map_create_proposal_response(
         },
         operation: match proposal.operation {
             data::ProposalOperation::CreateCanister => Some(ProposalOperation::CreateCanister {}),
+            data::ProposalOperation::LinkCanister { canister_id, name } => {
+                Some(ProposalOperation::LinkCanister { canister_id, name })
+            }
             data::ProposalOperation::AddCanisterController {
                 canister_id,
                 controller_id,

--- a/src/backend/src/service/canister_service.rs
+++ b/src/backend/src/service/canister_service.rs
@@ -227,6 +227,53 @@ pub async fn create_my_canister(project_id: Uuid) -> Result<(), String> {
     Ok(())
 }
 
+pub async fn link_my_canister(
+    caller: Principal,
+    project_id: Uuid,
+    canister_principal: Principal,
+    name: Option<String>,
+) -> Result<(), String> {
+    if canister_repository::find_canister_id_by_principal(canister_principal).is_some() {
+        return Err(format!(
+            "Canister {canister_principal} is already linked to a project"
+        ));
+    }
+
+    let canister_status =
+        management_canister::canister_status(&CanisterStatusArgs { canister_id: canister_principal })
+            .await
+            .map_err(|err| {
+                format!("Failed to get canister_status for {canister_principal}: {err}. The backend canister must be a controller of the canister you are linking.")
+            })?;
+
+    let controllers = &canister_status.settings.controllers;
+    if !controllers.contains(&canister_self()) {
+        return Err(format!(
+            "Backend canister is not a controller of {canister_principal}"
+        ));
+    }
+    if !controllers.contains(&caller) {
+        return Err(format!(
+            "Caller {caller} is not a controller of {canister_principal}"
+        ));
+    }
+
+    // TODO: verify the canister resides on the Swiss subnet by calling the NNS
+    // Registry's `get_subnet_for_canister` and comparing against SWISS_SUBNET_ID.
+    // Skipped for now — pic-js test envs don't ship the NNS Registry, and
+    // wiring a stub registry + runtime-configurable principal is its own change.
+    // The frontend warns the user that subnet membership is currently their
+    // responsibility.
+
+    let canister = Canister {
+        principal: canister_principal,
+        name,
+    };
+    canister_repository::create_canister(project_id, canister);
+
+    Ok(())
+}
+
 pub async fn add_canister_controller(
     canister_id: Principal,
     controller_id: Principal,

--- a/src/backend/src/service/proposal_service.rs
+++ b/src/backend/src/service/proposal_service.rs
@@ -20,7 +20,7 @@ pub async fn create_proposal(
 
     let proposal_id = proposal_repository::create_proposal(project_id, proposal.clone());
 
-    process_proposal(project_id, proposal_id, proposal.clone()).await?;
+    process_proposal(caller, project_id, proposal_id, proposal.clone()).await?;
 
     let proposal = proposal_repository::get_proposal(&proposal_id).ok_or_else(|| {
         ApiError::internal_error(format!(
@@ -31,7 +31,12 @@ pub async fn create_proposal(
     Ok(map_create_proposal_response(proposal_id, proposal))
 }
 
-async fn process_proposal(project_id: Uuid, proposal_id: Uuid, proposal: Proposal) -> ApiResult {
+async fn process_proposal(
+    caller: &Principal,
+    project_id: Uuid,
+    proposal_id: Uuid,
+    proposal: Proposal,
+) -> ApiResult {
     match proposal.operation {
         ProposalOperation::CreateCanister => {
             let approval_policy =
@@ -46,6 +51,30 @@ async fn process_proposal(project_id: Uuid, proposal_id: Uuid, proposal: Proposa
                     proposal_repository::set_proposal_executing(proposal_id)?;
                     match canister_service::create_my_canister(project_id).await {
                         Ok(_) => {
+                            proposal_repository::set_proposal_executed(proposal_id)?;
+                        }
+                        Err(err) => {
+                            proposal_repository::set_proposal_failed(proposal_id, err)?;
+                        }
+                    }
+                }
+            }
+        }
+        ProposalOperation::LinkCanister { canister_id, name } => {
+            let approval_policy =
+                approval_policy_repository::get_project_approval_policy_by_operation_type(
+                    project_id,
+                    OperationType::LinkCanister,
+                )
+                .unwrap_or_default();
+
+            match approval_policy.policy_type {
+                PolicyType::AutoApprove => {
+                    proposal_repository::set_proposal_executing(proposal_id)?;
+                    match canister_service::link_my_canister(*caller, project_id, canister_id, name)
+                        .await
+                    {
+                        Ok(()) => {
                             proposal_repository::set_proposal_executed(proposal_id)?;
                         }
                         Err(err) => {

--- a/src/frontend/src/lib/api/canister.ts
+++ b/src/frontend/src/lib/api/canister.ts
@@ -57,6 +57,25 @@ export class CanisterApi {
     assertProposalExecuted(mapOkResponse(createRes));
   }
 
+  public async linkCanister(
+    projectId: string,
+    canisterPrincipal: string,
+    name: string | null,
+  ): Promise<void> {
+    const createRes = await this.actor.create_proposal({
+      project_id: projectId,
+      operation: [
+        {
+          LinkCanister: {
+            canister_id: Principal.from(canisterPrincipal),
+            name: toCandidOpt(name),
+          },
+        },
+      ],
+    });
+    assertProposalExecuted(mapOkResponse(createRes));
+  }
+
   public async removeCanister(canisterId: string): Promise<void> {
     const res = await this.actor.remove_my_canister({
       canister_id: canisterId,

--- a/src/frontend/src/lib/store/canister.ts
+++ b/src/frontend/src/lib/store/canister.ts
@@ -67,6 +67,13 @@ export const createCanistersSlice: AppStateCreator<CanistersSlice> = (
     await refreshCanisters(projectId);
   },
 
+  async linkCanister(projectId, canisterPrincipal, name) {
+    const { canisterApi, refreshCanisters } = get();
+
+    await canisterApi.linkCanister(projectId, canisterPrincipal, name);
+    await refreshCanisters(projectId);
+  },
+
   async addMissingController(canisterId, projectId) {
     const { managementCanisterApi, refreshCanisters } = get();
 

--- a/src/frontend/src/lib/store/model.ts
+++ b/src/frontend/src/lib/store/model.ts
@@ -101,6 +101,11 @@ export type CanistersSlice = {
   refreshCanisters: (projectId: string) => Promise<void>;
   clearCanisters: () => void;
   createCanister: (projectId: string) => Promise<void>;
+  linkCanister: (
+    projectId: string,
+    canisterPrincipal: string,
+    name: string | null,
+  ) => Promise<void>;
   addMissingController: (
     canisterId: string,
     projectId: string,

--- a/src/frontend/src/routes/canisters/canisters.tsx
+++ b/src/frontend/src/routes/canisters/canisters.tsx
@@ -3,7 +3,9 @@ import { Breadcrumbs } from '@/components/breadcrumbs';
 import { selectOrgMap, selectProjectMap, useAppStore } from '@/lib/store';
 import { CanisterGrid } from '@/routes/canisters/canister-grid';
 import { CreateCanisterButton } from '@/routes/canisters/create-canister-button';
-import { useEffect, useMemo, type FC } from 'react';
+import { LinkCanisterButton } from '@/routes/canisters/link-canister-button';
+import { LinkCanisterForm } from '@/routes/canisters/link-canister-form';
+import { useEffect, useMemo, useState, type FC } from 'react';
 import { CanisterSkeleton } from '@/routes/canisters/canister-skeleton';
 import { isNil } from '@/lib/nil';
 import { useRequireProjectId } from '@/lib/params';
@@ -13,6 +15,7 @@ const Canisters: FC = () => {
   const projectMap = useAppStore(selectProjectMap);
   const orgMap = useAppStore(selectOrgMap);
   const projectId = useRequireProjectId();
+  const [isLinkFormOpen, setIsLinkFormOpen] = useState(false);
 
   useEffect(() => {
     initializeCanisters(projectId);
@@ -60,7 +63,21 @@ const Canisters: FC = () => {
         <>
           <CanisterGrid className="mt-8" canisters={projectCanisters} />
           {project?.yourPermissions.canisterManage && (
-            <CreateCanisterButton className="mt-4" />
+            <div className="mt-4 flex flex-col gap-3">
+              <div className="flex flex-wrap gap-2">
+                {!isLinkFormOpen && <CreateCanisterButton />}
+                <LinkCanisterButton
+                  isOpen={isLinkFormOpen}
+                  onToggle={() => setIsLinkFormOpen(o => !o)}
+                />
+              </div>
+              {isLinkFormOpen && (
+                <LinkCanisterForm
+                  className="mt-2 max-w-2xl"
+                  onLinked={() => setIsLinkFormOpen(false)}
+                />
+              )}
+            </div>
           )}
         </>
       )}

--- a/src/frontend/src/routes/canisters/link-canister-button.tsx
+++ b/src/frontend/src/routes/canisters/link-canister-button.tsx
@@ -1,0 +1,24 @@
+import { Button } from '@/components/ui/button';
+import { type FC } from 'react';
+
+export type LinkCanisterButtonProps = {
+  isOpen: boolean;
+  onToggle: () => void;
+  className?: string;
+};
+
+export const LinkCanisterButton: FC<LinkCanisterButtonProps> = ({
+  isOpen,
+  onToggle,
+  className,
+}) => {
+  return (
+    <Button
+      variant="outline"
+      {...(className !== undefined ? { className } : {})}
+      onClick={onToggle}
+    >
+      {isOpen ? 'Cancel' : 'Link Existing Canister'}
+    </Button>
+  );
+};

--- a/src/frontend/src/routes/canisters/link-canister-form.tsx
+++ b/src/frontend/src/routes/canisters/link-canister-form.tsx
@@ -1,0 +1,136 @@
+import { LoadingButton } from '@/components/loading-button';
+import { Input } from '@/components/ui/input';
+import { useAppStore } from '@/lib/store';
+import { cn } from '@/lib/utils';
+import { type FC } from 'react';
+import z from 'zod';
+import { PrincipalTextSchema } from '@dfinity/zod-schemas';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/form';
+import { showErrorToast, showSuccessToast } from '@/lib/toast';
+import { useRequireProjectId } from '@/lib/params';
+import { BACKEND_CANISTER_ID } from '@/env';
+
+export type LinkCanisterFormProps = {
+  className?: string;
+  onLinked?: () => void;
+};
+
+const formSchema = z.object({
+  principal: PrincipalTextSchema,
+  name: z.string().trim().max(64).optional(),
+});
+
+type FormData = z.infer<typeof formSchema>;
+
+export const LinkCanisterForm: FC<LinkCanisterFormProps> = ({
+  className,
+  onLinked,
+}) => {
+  const { linkCanister, identity } = useAppStore();
+  const projectId = useRequireProjectId();
+  const callerPrincipal = identity?.getPrincipal().toText() ?? '';
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { principal: '', name: '' },
+  });
+
+  async function onSubmit(formData: FormData): Promise<void> {
+    const trimmedName = formData.name?.trim();
+    try {
+      await linkCanister(
+        projectId,
+        formData.principal,
+        trimmedName ? trimmedName : null,
+      );
+      form.reset();
+      showSuccessToast('Canister linked successfully!');
+      onLinked?.();
+    } catch (err) {
+      showErrorToast('Failed to link canister', err);
+    }
+  }
+
+  return (
+    <div className={cn('flex flex-col gap-4', className)}>
+      <div className="bg-muted/30 rounded-md border p-4 text-sm">
+        <p className="font-medium">Before linking, set up the canister:</p>
+        <ol className="text-muted-foreground mt-2 ml-5 list-decimal space-y-1">
+          <li>
+            Add the SSN backend canister as a controller:
+            <code className="bg-background ml-1 rounded px-1 py-0.5 text-xs break-all">
+              {BACKEND_CANISTER_ID}
+            </code>
+          </li>
+          <li>
+            Your principal must also be a controller:
+            <code className="bg-background ml-1 rounded px-1 py-0.5 text-xs break-all">
+              {callerPrincipal || '(not signed in)'}
+            </code>
+          </li>
+        </ol>
+        <p className="text-muted-foreground mt-2">
+          Use{' '}
+          <code className="bg-background rounded px-1 py-0.5 text-xs">
+            dfx canister update-settings &lt;canister&gt; --add-controller
+            &lt;principal&gt;
+          </code>{' '}
+          to add controllers.
+        </p>
+      </div>
+
+      <Form {...form}>
+        <form
+          className="flex w-full flex-col gap-3"
+          onSubmit={form.handleSubmit(onSubmit)}
+        >
+          <FormField
+            control={form.control}
+            name="principal"
+            render={({ field }) => (
+              <FormItem className="w-full">
+                <FormLabel>Canister Principal</FormLabel>
+                <FormControl>
+                  <Input placeholder="rrkah-fqaaa-aaaaa-aaaaq-cai" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem className="w-full">
+                <FormLabel>Display Name (optional)</FormLabel>
+                <FormControl>
+                  <Input placeholder="My Backend" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <LoadingButton
+            type="submit"
+            variant="default"
+            isLoading={form.formState.isSubmitting}
+            className="self-start"
+          >
+            Link Canister
+          </LoadingButton>
+        </form>
+      </Form>
+    </div>
+  );
+};


### PR DESCRIPTION
Adds a LinkCanister proposal operation that registers an existing canister against a project. Before persisting, the backend verifies the principal isn't already linked, then calls canister_status and asserts both the backend and the caller are in the controllers list. The frontend form surfaces the backend principal and the user's own principal so they can wire up controllers via dfx before submitting.