### PR TITLE
feat: surface terms and conditions history and preview in admin panel

### DIFF
--- a/src/backend-api/candid/terms_and_conditions.did
+++ b/src/backend-api/candid/terms_and_conditions.did
@@ -5,12 +5,25 @@ type GetLatestTermsAndConditionsResponse = variant {
   Err : ApiError;
 };
 
+type ListTermsAndConditionsResponse = variant {
+  Ok : vec TermsAndConditionsListItem;
+  Err : ApiError;
+};
+
 type TermsAndConditions = record {
   id : text;
   content : text;
   comment : text;
   created_at : nat64;
   has_accepted : bool;
+};
+
+type TermsAndConditionsListItem = record {
+  id : text;
+  content : text;
+  comment : text;
+  created_at : nat64;
+  created_by : text;
 };
 
 type CreateTermsAndConditionsRequest = record {
@@ -40,6 +53,7 @@ type TermsAndConditionsDecisionType = variant {
 
 service : {
   get_latest_terms_and_conditions : () -> (GetLatestTermsAndConditionsResponse) query;
+  list_terms_and_conditions : () -> (ListTermsAndConditionsResponse) query;
   upsert_terms_and_conditions_decision : (UpsertTermsAndConditionsDecisionRequest) -> (UpsertTermsAndConditionsDecisionResponse);
   create_terms_and_conditions : (CreateTermsAndConditionsRequest) -> (CreateTermsAndConditionsResponse);
 };

--- a/src/backend/src/controller/terms_and_conditions.rs
+++ b/src/backend/src/controller/terms_and_conditions.rs
@@ -1,8 +1,8 @@
 use crate::{
     dto::{
         CreateTermsAndConditionsRequest, CreateTermsAndConditionsResponse,
-        GetLatestTermsAndConditionsResponse, UpsertTermsAndConditionsDecisionRequest,
-        UpsertTermsAndConditionsDecisionResponse,
+        GetLatestTermsAndConditionsResponse, ListTermsAndConditionsResponse,
+        UpsertTermsAndConditionsDecisionRequest, UpsertTermsAndConditionsDecisionResponse,
     },
     service::terms_and_conditions_service,
 };
@@ -17,6 +17,16 @@ fn get_latest_terms_and_conditions() -> ApiResultDto<GetLatestTermsAndConditions
     }
 
     terms_and_conditions_service::get_latest_terms_and_conditions(caller).into()
+}
+
+#[query]
+fn list_terms_and_conditions() -> ApiResultDto<ListTermsAndConditionsResponse> {
+    let caller = msg_caller();
+    if let Err(err) = assert_controller(&caller) {
+        return ApiResultDto::Err(err);
+    }
+
+    ApiResultDto::Ok(terms_and_conditions_service::list_terms_and_conditions())
 }
 
 #[update]

--- a/src/backend/src/data/terms_and_conditions_repository.rs
+++ b/src/backend/src/data/terms_and_conditions_repository.rs
@@ -10,9 +10,9 @@ use crate::data::{
 use canister_utils::{ApiError, ApiResult, Uuid};
 use std::cell::RefCell;
 
-// Returns versions ordered ascending by created_at. The stable BTreeSet iter
-// is forward-only (no DoubleEndedIterator), so callers that want newest-first
-// reverse on their end.
+// Returns versions ordered ascending by created_at. ic_stable_structures'
+// BTreeSet iter is forward-only (no DoubleEndedIterator), so callers that
+// want newest-first reverse on their end.
 pub fn list_terms_and_conditions() -> Vec<(Uuid, TermsAndConditions)> {
     with_state(|s| {
         s.terms_and_conditions_created_at_index
@@ -140,4 +140,32 @@ fn with_state<R>(f: impl FnOnce(&TermsAndConditionsState) -> R) -> R {
 
 fn mutate_state<R>(f: impl FnOnce(&mut TermsAndConditionsState) -> R) -> R {
     STATE.with(|s| f(&mut s.borrow_mut()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn seed(created_at: u64) -> Uuid {
+        create_terms_and_conditions(TermsAndConditions {
+            content: format!("content-{created_at}"),
+            comment: format!("comment-{created_at}"),
+            created_at,
+            created_by: Uuid::new(),
+        })
+    }
+
+    #[test]
+    fn list_returns_versions_in_ascending_created_at_order() {
+        let middle = seed(200);
+        let oldest = seed(100);
+        let newest = seed(300);
+
+        let ids: Vec<Uuid> = list_terms_and_conditions()
+            .into_iter()
+            .map(|(id, _)| id)
+            .collect();
+
+        assert_eq!(ids, vec![oldest, middle, newest]);
+    }
 }

--- a/src/backend/src/data/terms_and_conditions_repository.rs
+++ b/src/backend/src/data/terms_and_conditions_repository.rs
@@ -10,6 +10,18 @@ use crate::data::{
 use canister_utils::{ApiError, ApiResult, Uuid};
 use std::cell::RefCell;
 
+// Returns versions ordered ascending by created_at. The stable BTreeSet iter
+// is forward-only (no DoubleEndedIterator), so callers that want newest-first
+// reverse on their end.
+pub fn list_terms_and_conditions() -> Vec<(Uuid, TermsAndConditions)> {
+    with_state(|s| {
+        s.terms_and_conditions_created_at_index
+            .iter()
+            .filter_map(|(_, id)| s.terms_and_conditions.get(&id).map(|t| (id, t)))
+            .collect()
+    })
+}
+
 pub fn get_latest_terms_and_conditions(user_id: Uuid) -> Option<(Uuid, TermsAndConditions, bool)> {
     let latest_id = get_latest_terms_and_condition_id()?;
 

--- a/src/backend/src/dto/terms_and_conditions.rs
+++ b/src/backend/src/dto/terms_and_conditions.rs
@@ -3,6 +3,8 @@ use serde::Deserialize;
 
 pub type GetLatestTermsAndConditionsResponse = Option<TermsAndConditions>;
 
+pub type ListTermsAndConditionsResponse = Vec<TermsAndConditionsListItem>;
+
 #[derive(Debug, Clone, CandidType, Deserialize)]
 pub struct TermsAndConditions {
     pub id: String,
@@ -10,6 +12,15 @@ pub struct TermsAndConditions {
     pub comment: String,
     pub created_at: u64,
     pub has_accepted: bool,
+}
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct TermsAndConditionsListItem {
+    pub id: String,
+    pub content: String,
+    pub comment: String,
+    pub created_at: u64,
+    pub created_by: String,
 }
 
 #[derive(Debug, Clone, CandidType, Deserialize)]

--- a/src/backend/src/mapping/terms_and_conditions.rs
+++ b/src/backend/src/mapping/terms_and_conditions.rs
@@ -1,8 +1,9 @@
 use crate::{
     data::{self},
     dto::{
-        CreateTermsAndConditionsRequest, GetLatestTermsAndConditionsResponse, TermsAndConditions,
-        TermsAndConditionsDecisionType, UpsertTermsAndConditionsDecisionRequest,
+        CreateTermsAndConditionsRequest, GetLatestTermsAndConditionsResponse,
+        ListTermsAndConditionsResponse, TermsAndConditions, TermsAndConditionsDecisionType,
+        TermsAndConditionsListItem, UpsertTermsAndConditionsDecisionRequest,
     },
 };
 use canister_utils::{ApiResult, Uuid};
@@ -17,6 +18,21 @@ pub fn map_get_latest_terms_and_conditions_response(
         comment: res.comment,
         has_accepted,
     })
+}
+
+pub fn map_list_terms_and_conditions_response(
+    items: Vec<(Uuid, data::TermsAndConditions)>,
+) -> ListTermsAndConditionsResponse {
+    items
+        .into_iter()
+        .map(|(id, t)| TermsAndConditionsListItem {
+            id: id.to_string(),
+            content: t.content,
+            comment: t.comment,
+            created_at: t.created_at,
+            created_by: t.created_by.to_string(),
+        })
+        .collect()
 }
 
 pub fn map_create_terms_and_conditions_decision_request(

--- a/src/backend/src/service/terms_and_conditions_service.rs
+++ b/src/backend/src/service/terms_and_conditions_service.rs
@@ -2,11 +2,11 @@ use crate::{
     data::{terms_and_conditions_repository, user_profile_repository},
     dto::{
         CreateTermsAndConditionsRequest, GetLatestTermsAndConditionsResponse,
-        UpsertTermsAndConditionsDecisionRequest,
+        ListTermsAndConditionsResponse, UpsertTermsAndConditionsDecisionRequest,
     },
     mapping::{
         map_create_terms_and_conditions_decision_request, map_create_terms_and_conditions_request,
-        map_get_latest_terms_and_conditions_response,
+        map_get_latest_terms_and_conditions_response, map_list_terms_and_conditions_response,
     },
 };
 use candid::Principal;
@@ -43,6 +43,11 @@ pub fn upsert_terms_and_conditions_decision(
     let _id = terms_and_conditions_repository::upsert_terms_and_conditions_decision(req)?;
 
     Ok(())
+}
+
+pub fn list_terms_and_conditions() -> ListTermsAndConditionsResponse {
+    let items = terms_and_conditions_repository::list_terms_and_conditions();
+    map_list_terms_and_conditions_response(items)
 }
 
 pub fn create_terms_and_conditions(

--- a/src/frontend/src/components/layout/header-menu.tsx
+++ b/src/frontend/src/components/layout/header-menu.tsx
@@ -96,7 +96,7 @@ export const HeaderMenu: FC = () => {
             </DropdownMenuItem>
           )}
 
-          {isActive && isNotNil(termsAndConditions) && (
+          {isActive && !isAdmin && isNotNil(termsAndConditions) && (
             <DropdownMenuItem
               className="justify-between"
               render={<NavLink to="/terms-and-conditions" />}

--- a/src/frontend/src/lib/api-models/terms-and-conditions.ts
+++ b/src/frontend/src/lib/api-models/terms-and-conditions.ts
@@ -7,7 +7,6 @@ import type {
   UpsertTermsAndConditionsDecisionRequest as ApiUpsertTermsAndConditionsDecisionRequest,
   CreateTermsAndConditionsRequest as ApiCreateTermsAndConditionsRequest,
 } from '@ssn/backend-api';
-import { micromark } from 'micromark';
 
 export type GetLatestTermsAndConditionsResponse = TermsAndConditions | null;
 
@@ -36,7 +35,7 @@ export function mapTermsAndConditionsResponse(
 ): TermsAndConditions {
   return {
     id: res.id,
-    content: micromark(res.content),
+    content: res.content,
     comment: res.comment,
     createdAt: new Date(Number(res.created_at / 1_000_000n)),
     hasAccepted: res.has_accepted,
@@ -56,7 +55,7 @@ export function mapTermsAndConditionsListItemResponse(
 ): TermsAndConditionsListItem {
   return {
     id: res.id,
-    content: micromark(res.content),
+    content: res.content,
     comment: res.comment,
     createdAt: new Date(Number(res.created_at / 1_000_000n)),
     createdBy: res.created_by,

--- a/src/frontend/src/lib/api-models/terms-and-conditions.ts
+++ b/src/frontend/src/lib/api-models/terms-and-conditions.ts
@@ -1,7 +1,9 @@
 import { mapOkResponse } from '@/lib/api-models/error';
 import type {
   TermsAndConditions as ApiTermsAndConditions,
+  TermsAndConditionsListItem as ApiTermsAndConditionsListItem,
   GetLatestTermsAndConditionsResponse as ApiGetLatestTermsAndConditionsResponse,
+  ListTermsAndConditionsResponse as ApiListTermsAndConditionsResponse,
   UpsertTermsAndConditionsDecisionRequest as ApiUpsertTermsAndConditionsDecisionRequest,
   CreateTermsAndConditionsRequest as ApiCreateTermsAndConditionsRequest,
 } from '@ssn/backend-api';
@@ -39,6 +41,33 @@ export function mapTermsAndConditionsResponse(
     createdAt: new Date(Number(res.created_at / 1_000_000n)),
     hasAccepted: res.has_accepted,
   };
+}
+
+export type TermsAndConditionsListItem = {
+  id: string;
+  content: string;
+  comment: string;
+  createdAt: Date;
+  createdBy: string;
+};
+
+export function mapTermsAndConditionsListItemResponse(
+  res: ApiTermsAndConditionsListItem,
+): TermsAndConditionsListItem {
+  return {
+    id: res.id,
+    content: micromark(res.content),
+    comment: res.comment,
+    createdAt: new Date(Number(res.created_at / 1_000_000n)),
+    createdBy: res.created_by,
+  };
+}
+
+export function mapListTermsAndConditionsResponse(
+  res: ApiListTermsAndConditionsResponse,
+): TermsAndConditionsListItem[] {
+  const items = mapOkResponse(res);
+  return items.map(mapTermsAndConditionsListItemResponse).reverse();
 }
 
 export type CreateTermsAndConditionsRequest = {

--- a/src/frontend/src/lib/api/terms-and-conditions.ts
+++ b/src/frontend/src/lib/api/terms-and-conditions.ts
@@ -1,10 +1,12 @@
 import {
   mapCreateTermsAndConditionsRequest,
   mapGetLatestTermsAndConditionForUserResponse,
+  mapListTermsAndConditionsResponse,
   mapOkResponse,
   mapUpsertTermsAndConditionsDecisionRequest,
   type CreateTermsAndConditionsRequest,
   type GetLatestTermsAndConditionsResponse,
+  type TermsAndConditionsListItem,
   type UpsertTermsAndConditionsDecisionRequest,
 } from '@/lib/api-models';
 import type { ActorSubclass } from '@icp-sdk/core/agent';
@@ -17,6 +19,12 @@ export class TermsAndConditionsApi {
     const res = await this.actor.get_latest_terms_and_conditions();
 
     return mapGetLatestTermsAndConditionForUserResponse(res);
+  }
+
+  public async listTermsAndConditions(): Promise<TermsAndConditionsListItem[]> {
+    const res = await this.actor.list_terms_and_conditions();
+
+    return mapListTermsAndConditionsResponse(res);
   }
 
   public async upsertTermsAndConditionsDecision(

--- a/src/frontend/src/lib/auth.ts
+++ b/src/frontend/src/lib/auth.ts
@@ -10,6 +10,7 @@ export const useRequireAuth = (): void => {
     termsAndConditions,
   } = useAppStore();
   const isActive = useAppStore(selectIsActive);
+  const isAdmin = useAppStore(selectIsAdmin);
   const returnTo = useReturnTo();
 
   useEffect(() => {
@@ -22,7 +23,11 @@ export const useRequireAuth = (): void => {
       return;
     }
 
-    if (isNotNil(termsAndConditions) && !termsAndConditions.hasAccepted) {
+    if (
+      !isAdmin &&
+      isNotNil(termsAndConditions) &&
+      !termsAndConditions.hasAccepted
+    ) {
       returnTo('/terms-and-conditions');
       return;
     }
@@ -31,6 +36,7 @@ export const useRequireAuth = (): void => {
     isTermsAndConditionsInitialized,
     termsAndConditions,
     isActive,
+    isAdmin,
     returnTo,
   ]);
 };

--- a/src/frontend/src/lib/store/model.ts
+++ b/src/frontend/src/lib/store/model.ts
@@ -20,6 +20,7 @@ import type {
   UserStatus,
   GetUserStatsResponse,
   TermsAndConditions,
+  TermsAndConditionsListItem,
   UpsertTermsAndConditionsDecisionRequest,
   CreateTermsAndConditionsRequest,
   Organization,
@@ -165,9 +166,11 @@ export type TrustedPartnersSlice = {
 export type TermsAndConditionsSlice = {
   isTermsAndConditionsInitialized: boolean;
   termsAndConditions: TermsAndConditions | null;
+  termsAndConditionsHistory: TermsAndConditionsListItem[] | null;
 
   initializeTermsAndConditions: () => Promise<void>;
   clearTermsAndConditions: () => void;
+  refreshTermsAndConditionsHistory: () => Promise<void>;
   upsertTermsAndConditionsDecision: (
     req: UpsertTermsAndConditionsDecisionRequest,
   ) => Promise<void>;

--- a/src/frontend/src/lib/store/terms-and-conditions.ts
+++ b/src/frontend/src/lib/store/terms-and-conditions.ts
@@ -8,11 +8,12 @@ export const createTermsAndConditionsSlice: AppStateCreator<
 > = (set, get) => ({
   isTermsAndConditionsInitialized: false,
   termsAndConditions: null,
+  termsAndConditionsHistory: null,
 
   async initializeTermsAndConditions() {
     const { termsAndConditionsApi, isAuthenticated, profile } = get();
 
-    if (!isAuthenticated || profile?.isAdmin) {
+    if (!isAuthenticated) {
       set({ isTermsAndConditionsInitialized: true });
       return;
     }
@@ -21,13 +22,31 @@ export const createTermsAndConditionsSlice: AppStateCreator<
       const termsAndConditions =
         await termsAndConditionsApi.getLatestTermsAndConditions();
       set({ termsAndConditions });
+
+      if (profile?.isAdmin) {
+        const termsAndConditionsHistory =
+          await termsAndConditionsApi.listTermsAndConditions();
+        set({ termsAndConditionsHistory });
+      }
     } finally {
       set({ isTermsAndConditionsInitialized: true });
     }
   },
 
   clearTermsAndConditions() {
-    set({ termsAndConditions: null });
+    set({ termsAndConditions: null, termsAndConditionsHistory: null });
+  },
+
+  async refreshTermsAndConditionsHistory() {
+    const { termsAndConditionsApi, isAuthenticated, profile } = get();
+
+    if (!isAuthenticated || !profile?.isAdmin) {
+      return;
+    }
+
+    const termsAndConditionsHistory =
+      await termsAndConditionsApi.listTermsAndConditions();
+    set({ termsAndConditionsHistory });
   },
 
   async upsertTermsAndConditionsDecision(req) {
@@ -82,5 +101,11 @@ export const createTermsAndConditionsSlice: AppStateCreator<
     }
 
     await termsAndConditionsApi.createTermsAndConditions(req);
+
+    const [termsAndConditions, termsAndConditionsHistory] = await Promise.all([
+      termsAndConditionsApi.getLatestTermsAndConditions(),
+      termsAndConditionsApi.listTermsAndConditions(),
+    ]);
+    set({ termsAndConditions, termsAndConditionsHistory });
   },
 });

--- a/src/frontend/src/routes/admin/admin.tsx
+++ b/src/frontend/src/routes/admin/admin.tsx
@@ -12,6 +12,8 @@ import {
 import { useAppStore } from '@/lib/store';
 import { type FC } from 'react';
 import { TermsAndConditionsForm } from '@/routes/admin/terms-and-conditions-form';
+import { TermsAndConditionsCurrent } from '@/routes/admin/terms-and-conditions-current';
+import { TermsAndConditionsTable } from '@/routes/admin/terms-and-conditions-table';
 import { Container } from '@/components/layout/container';
 
 const Admin: FC = () => {
@@ -53,7 +55,9 @@ const Admin: FC = () => {
       <TrustedPartnerForm className="mt-12" />
 
       <H2 className="mt-10">Terms and Conditions</H2>
-      <TermsAndConditionsForm className="mt-3" />
+      <TermsAndConditionsCurrent className="mt-3" />
+      <TermsAndConditionsTable className="mt-6" />
+      <TermsAndConditionsForm className="mt-6" />
     </Container>
   );
 };

--- a/src/frontend/src/routes/admin/terms-and-conditions-content.tsx
+++ b/src/frontend/src/routes/admin/terms-and-conditions-content.tsx
@@ -3,23 +3,18 @@ import { useMemo, type FC } from 'react';
 import { micromark } from 'micromark';
 
 export type TermsAndConditionsContentProps = {
-  // The HTML to render. Pass already-rendered HTML (as the API mappers
-  // produce) or set `raw` to true to treat the value as markdown source
-  // and run it through micromark first - used for the live preview pane.
   value: string;
-  raw?: boolean;
   className?: string;
 };
 
 export const TermsAndConditionsContent: FC<TermsAndConditionsContentProps> = ({
   value,
-  raw,
   className,
 }) => {
-  const sanitized = useMemo(() => {
-    const html = raw ? micromark(value) : value;
-    return DOMPurify.sanitize(html);
-  }, [value, raw]);
+  const sanitized = useMemo(
+    () => DOMPurify.sanitize(micromark(value)),
+    [value],
+  );
 
   return (
     <div

--- a/src/frontend/src/routes/admin/terms-and-conditions-content.tsx
+++ b/src/frontend/src/routes/admin/terms-and-conditions-content.tsx
@@ -1,0 +1,30 @@
+import DOMPurify from 'dompurify';
+import { useMemo, type FC } from 'react';
+import { micromark } from 'micromark';
+
+export type TermsAndConditionsContentProps = {
+  // The HTML to render. Pass already-rendered HTML (as the API mappers
+  // produce) or set `raw` to true to treat the value as markdown source
+  // and run it through micromark first - used for the live preview pane.
+  value: string;
+  raw?: boolean;
+  className?: string;
+};
+
+export const TermsAndConditionsContent: FC<TermsAndConditionsContentProps> = ({
+  value,
+  raw,
+  className,
+}) => {
+  const sanitized = useMemo(() => {
+    const html = raw ? micromark(value) : value;
+    return DOMPurify.sanitize(html);
+  }, [value, raw]);
+
+  return (
+    <div
+      className={`prose dark:prose-invert min-w-full ${className ?? ''}`}
+      dangerouslySetInnerHTML={{ __html: sanitized }}
+    />
+  );
+};

--- a/src/frontend/src/routes/admin/terms-and-conditions-current.tsx
+++ b/src/frontend/src/routes/admin/terms-and-conditions-current.tsx
@@ -1,0 +1,57 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { buttonVariants } from '@/components/ui/button';
+import { useAppStore } from '@/lib/store';
+import type { FC } from 'react';
+import { Link } from 'react-router';
+import { TermsAndConditionsContent } from '@/routes/admin/terms-and-conditions-content';
+
+export type TermsAndConditionsCurrentProps = {
+  className?: string;
+};
+
+export const TermsAndConditionsCurrent: FC<TermsAndConditionsCurrentProps> = ({
+  className,
+}) => {
+  const { termsAndConditions } = useAppStore();
+
+  return (
+    <Card className={className}>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle>Current Terms and Conditions</CardTitle>
+        {termsAndConditions && (
+          <Link
+            to="/terms-and-conditions"
+            className={buttonVariants({ variant: 'outline', size: 'sm' })}
+          >
+            Open page
+          </Link>
+        )}
+      </CardHeader>
+
+      <CardContent>
+        {termsAndConditions ? (
+          <>
+            <p>
+              <span className="mr-2 font-bold">Effective from:</span>
+              {termsAndConditions.createdAt.toLocaleDateString()}
+            </p>
+
+            <p className="mt-3">
+              <span className="mr-2 font-bold">Comment:</span>
+              {termsAndConditions.comment}
+            </p>
+
+            <TermsAndConditionsContent
+              value={termsAndConditions.content}
+              className="mt-6"
+            />
+          </>
+        ) : (
+          <p className="text-muted-foreground">
+            No terms and conditions have been published yet.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/frontend/src/routes/admin/terms-and-conditions-form.tsx
+++ b/src/frontend/src/routes/admin/terms-and-conditions-form.tsx
@@ -102,7 +102,6 @@ export const TermsAndConditionsForm: FC<TermsAndConditionsFormProps> = ({
                     {isPreviewing ? (
                       <TermsAndConditionsContent
                         value={previewContent}
-                        raw
                         className="border-input min-h-32 rounded-md border p-3"
                       />
                     ) : (

--- a/src/frontend/src/routes/admin/terms-and-conditions-form.tsx
+++ b/src/frontend/src/routes/admin/terms-and-conditions-form.tsx
@@ -7,15 +7,17 @@ import {
   FormMessage,
 } from '@/components/form';
 import { LoadingButton } from '@/components/loading-button';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { useAppStore } from '@/lib/store';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
 import { zodResolver } from '@hookform/resolvers/zod';
-import type { FC } from 'react';
+import { useState, type FC } from 'react';
 import { useForm } from 'react-hook-form';
 import z from 'zod';
+import { TermsAndConditionsContent } from '@/routes/admin/terms-and-conditions-content';
 
 export type TermsAndConditionsFormProps = {
   className?: string;
@@ -33,6 +35,8 @@ export const TermsAndConditionsForm: FC<TermsAndConditionsFormProps> = ({
 }) => {
   const { createTermsAndConditions } = useAppStore();
 
+  const [isPreviewing, setIsPreviewing] = useState(false);
+
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -41,10 +45,13 @@ export const TermsAndConditionsForm: FC<TermsAndConditionsFormProps> = ({
     },
   });
 
+  const previewContent = form.watch('content');
+
   async function onSubmit(formData: FormData): Promise<void> {
     try {
       await createTermsAndConditions(formData);
       form.reset();
+      setIsPreviewing(false);
       showSuccessToast('Terms and conditions created successfully!');
     } catch (err) {
       showErrorToast('Failed to create terms and conditions', err);
@@ -79,12 +86,32 @@ export const TermsAndConditionsForm: FC<TermsAndConditionsFormProps> = ({
               name="content"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Content</FormLabel>
+                  <div className="flex flex-row items-center justify-between">
+                    <FormLabel>Content</FormLabel>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setIsPreviewing(p => !p)}
+                      disabled={!previewContent}
+                    >
+                      {isPreviewing ? 'Edit' : 'Preview'}
+                    </Button>
+                  </div>
                   <FormControl>
-                    <Textarea
-                      placeholder="Enter terms and conditions content"
-                      {...field}
-                    />
+                    {isPreviewing ? (
+                      <TermsAndConditionsContent
+                        value={previewContent}
+                        raw
+                        className="border-input min-h-32 rounded-md border p-3"
+                      />
+                    ) : (
+                      <Textarea
+                        placeholder="Enter terms and conditions content (markdown)"
+                        className="min-h-64"
+                        {...field}
+                      />
+                    )}
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/src/frontend/src/routes/admin/terms-and-conditions-table.tsx
+++ b/src/frontend/src/routes/admin/terms-and-conditions-table.tsx
@@ -1,0 +1,79 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import { useAppStore } from '@/lib/store';
+import { Fragment, useState, type FC } from 'react';
+import { TermsAndConditionsContent } from '@/routes/admin/terms-and-conditions-content';
+
+export type TermsAndConditionsTableProps = {
+  className?: string;
+};
+
+export const TermsAndConditionsTable: FC<TermsAndConditionsTableProps> = ({
+  className,
+}) => {
+  const { termsAndConditionsHistory } = useAppStore();
+
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  if (!termsAndConditionsHistory || termsAndConditionsHistory.length === 0) {
+    return (
+      <p className={`text-muted-foreground ${className ?? ''}`}>
+        No terms and conditions have been published yet.
+      </p>
+    );
+  }
+
+  return (
+    <Table className={className}>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Effective from</TableHead>
+          <TableHead>Comment</TableHead>
+          <TableHead>Created by</TableHead>
+          <TableHead className="w-1" />
+        </TableRow>
+      </TableHeader>
+
+      <TableBody>
+        {termsAndConditionsHistory.map(item => {
+          const isExpanded = expandedId === item.id;
+          return (
+            <Fragment key={item.id}>
+              <TableRow>
+                <TableCell>{item.createdAt.toLocaleDateString()}</TableCell>
+                <TableCell>{item.comment}</TableCell>
+                <TableCell className="font-mono text-xs">
+                  {item.createdBy}
+                </TableCell>
+                <TableCell>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setExpandedId(isExpanded ? null : item.id)}
+                  >
+                    {isExpanded ? 'Hide' : 'View'}
+                  </Button>
+                </TableCell>
+              </TableRow>
+              {isExpanded && (
+                <TableRow>
+                  <TableCell colSpan={4}>
+                    <TermsAndConditionsContent value={item.content} />
+                  </TableCell>
+                </TableRow>
+              )}
+            </Fragment>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+};

--- a/src/frontend/src/routes/terms-and-conditions/terms-and-conditions.tsx
+++ b/src/frontend/src/routes/terms-and-conditions/terms-and-conditions.tsx
@@ -4,10 +4,10 @@ import { TermsAndConditionsDecisionType } from '@/lib/api-models';
 import { isNil } from '@/lib/nil';
 import { useAppStore } from '@/lib/store';
 import { showErrorToast } from '@/lib/toast';
-import { useMemo, useState, type FC } from 'react';
+import { useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
-import DOMPurify from 'dompurify';
 import { Container } from '@/components/layout/container';
+import { TermsAndConditionsContent } from '@/routes/admin/terms-and-conditions-content';
 
 const TermsAndConditions: FC = () => {
   const navigate = useNavigate();
@@ -18,11 +18,6 @@ const TermsAndConditions: FC = () => {
 
   const [isAccepting, setIsAccepting] = useState(false);
   const [isDeclining, setIsDeclining] = useState(false);
-
-  const sanitizedContent = useMemo(
-    () => DOMPurify.sanitize(termsAndConditions?.content ?? ''),
-    [termsAndConditions?.content],
-  );
 
   async function onDeclineTermsAndConditions(): Promise<void> {
     if (isNil(termsAndConditions)) {
@@ -82,9 +77,9 @@ const TermsAndConditions: FC = () => {
         </p>
       </div>
 
-      <div
-        className="prose dark:prose-invert mt-10 min-w-full"
-        dangerouslySetInnerHTML={{ __html: sanitizedContent }}
+      <TermsAndConditionsContent
+        value={termsAndConditions?.content ?? ''}
+        className="mt-10"
       />
 
       <div className="mb-10 flex flex-row justify-end space-x-2">


### PR DESCRIPTION
Adds a controller-gated list_terms_and_conditions endpoint and rebuilds the admin section to show the current published version, all historical versions, and a live markdown preview before publishing. Creating a new version refreshes both the current and history views in place.