### PR TITLE
feat: add staff permissions admin UI with list_staff endpoint

### DIFF
--- a/src/backend-api/candid/staff_permissions.did
+++ b/src/backend-api/candid/staff_permissions.did
@@ -31,8 +31,24 @@ type GetMyStaffPermissionsResponse = variant {
   Err : ApiError;
 };
 
+type ListStaffRequest = record {};
+
+type ListStaffResponse = variant {
+  Ok : vec StaffMember;
+  Err : ApiError;
+};
+
+type StaffMember = record {
+  user_id : text;
+  email : opt text;
+  email_verified : bool;
+  status : UserStatus;
+  permissions : StaffPermissions;
+};
+
 service : {
   get_my_staff_permissions : (GetMyStaffPermissionsRequest) -> (GetMyStaffPermissionsResponse) query;
   grant_staff_permissions : (GrantStaffPermissionsRequest) -> (GrantStaffPermissionsResponse);
   revoke_staff_permissions : (RevokeStaffPermissionsRequest) -> (RevokeStaffPermissionsResponse);
+  list_staff : (ListStaffRequest) -> (ListStaffResponse) query;
 };

--- a/src/backend/src/controller/staff_permissions.rs
+++ b/src/backend/src/controller/staff_permissions.rs
@@ -1,8 +1,8 @@
 use crate::{
     dto::{
         GetMyStaffPermissionsRequest, GetMyStaffPermissionsResponse, GrantStaffPermissionsRequest,
-        GrantStaffPermissionsResponse, RevokeStaffPermissionsRequest,
-        RevokeStaffPermissionsResponse,
+        GrantStaffPermissionsResponse, ListStaffRequest, ListStaffResponse,
+        RevokeStaffPermissionsRequest, RevokeStaffPermissionsResponse,
     },
     service::staff_permissions_service,
 };
@@ -55,4 +55,17 @@ fn revoke_staff_permissions(
     staff_permissions_service::revoke_staff_permissions(req)
         .map(|()| RevokeStaffPermissionsResponse {})
         .into()
+}
+
+// Admin-side projection of every staff user. Controller-gated: the staff
+// roster is sensitive (it lists who has cross-org read or billing-write
+// authority) and is never exposed to non-controllers.
+#[query]
+fn list_staff(_req: ListStaffRequest) -> ApiResultDto<ListStaffResponse> {
+    let caller = msg_caller();
+    if let Err(err) = assert_controller(&caller) {
+        return ApiResultDto::Err(err);
+    }
+
+    ApiResultDto::Ok(staff_permissions_service::list_staff())
 }

--- a/src/backend/src/dto/staff_permissions.rs
+++ b/src/backend/src/dto/staff_permissions.rs
@@ -1,3 +1,4 @@
+use crate::dto::UserStatus;
 use candid::CandidType;
 use serde::Deserialize;
 
@@ -35,5 +36,22 @@ pub struct GetMyStaffPermissionsRequest {}
 
 // Self-introspection. None means the caller is not staff. Never returns
 // information about other users' staff status; admin-side listings live
-// behind a separate, controller-gated surface (not shipped in this PR).
+// behind a separate, controller-gated surface (`list_staff`).
 pub type GetMyStaffPermissionsResponse = Option<StaffPermissions>;
+
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub struct ListStaffRequest {}
+
+pub type ListStaffResponse = Vec<StaffMember>;
+
+// Admin-side projection of a staff user. Distinct from `UserProfile` so
+// that staff state can never leak through user-listing endpoints whose
+// auth surface may relax in the future. Always controller-gated.
+#[derive(Debug, Clone, CandidType)]
+pub struct StaffMember {
+    pub user_id: String,
+    pub email: Option<String>,
+    pub email_verified: bool,
+    pub status: UserStatus,
+    pub permissions: StaffPermissions,
+}

--- a/src/backend/src/mapping/staff_permissions.rs
+++ b/src/backend/src/mapping/staff_permissions.rs
@@ -1,4 +1,26 @@
-use crate::{data, dto};
+use crate::{
+    data,
+    dto::{self, ListStaffResponse, StaffMember},
+};
+use canister_utils::Uuid;
+
+use super::map_user_status_response;
+
+pub fn map_list_staff_response(profiles: Vec<(Uuid, data::UserProfile)>) -> ListStaffResponse {
+    profiles
+        .into_iter()
+        .filter_map(|(id, profile)| {
+            let perms = profile.staff_permissions?;
+            Some(StaffMember {
+                user_id: id.to_string(),
+                email: profile.email,
+                email_verified: profile.email_verified,
+                status: map_user_status_response(profile.status),
+                permissions: map_staff_permissions(perms),
+            })
+        })
+        .collect()
+}
 
 pub fn map_staff_permissions(perms: data::StaffPermissions) -> dto::StaffPermissions {
     dto::StaffPermissions {

--- a/src/backend/src/service/staff_permissions_service.rs
+++ b/src/backend/src/service/staff_permissions_service.rs
@@ -60,11 +60,14 @@ pub fn get_my_staff_permissions(caller: &Principal) -> GetMyStaffPermissionsResp
         .map(map_staff_permissions)
 }
 
-// Returns every user with non-empty staff_permissions. Caller authorisation
-// lives in the controller layer (controller key required); this service
-// trusts it has been performed. Kept on its own surface, separate from the
-// general user listing, so the staff projection cannot leak through any
-// future relaxation of user-listing auth.
+// Returns every user that currently has a staff_permissions record. The
+// service hands all profiles to map_list_staff_response, which drops the
+// ones whose staff_permissions is None, so only actual staff come back.
+//
+// Caller authorisation lives in the controller layer (controller key
+// required); this service trusts it has been performed. Kept on its own
+// surface, separate from the general user listing, so the staff projection
+// cannot leak through any future relaxation of user-listing auth.
 pub fn list_staff() -> ListStaffResponse {
     let profiles = user_profile_repository::list_user_profiles()
         .into_iter()

--- a/src/backend/src/service/staff_permissions_service.rs
+++ b/src/backend/src/service/staff_permissions_service.rs
@@ -1,9 +1,10 @@
 use crate::{
     data::{self, user_profile_repository},
     dto::{
-        GetMyStaffPermissionsResponse, GrantStaffPermissionsRequest, RevokeStaffPermissionsRequest,
+        GetMyStaffPermissionsResponse, GrantStaffPermissionsRequest, ListStaffResponse,
+        RevokeStaffPermissionsRequest,
     },
-    mapping::{map_staff_permissions, map_staff_permissions_from_dto},
+    mapping::{map_list_staff_response, map_staff_permissions, map_staff_permissions_from_dto},
 };
 use candid::Principal;
 use canister_utils::{ApiError, ApiResult, Uuid};
@@ -57,4 +58,17 @@ pub fn get_my_staff_permissions(caller: &Principal) -> GetMyStaffPermissionsResp
     user_profile_repository::get_user_profile_by_principal(caller)
         .and_then(|(_, profile)| profile.staff_permissions)
         .map(map_staff_permissions)
+}
+
+// Returns every user with non-empty staff_permissions. Caller authorisation
+// lives in the controller layer (controller key required); this service
+// trusts it has been performed. Kept on its own surface, separate from the
+// general user listing, so the staff projection cannot leak through any
+// future relaxation of user-listing auth.
+pub fn list_staff() -> ListStaffResponse {
+    let profiles = user_profile_repository::list_user_profiles()
+        .into_iter()
+        .map(|(id, profile, _principals)| (id, profile))
+        .collect();
+    map_list_staff_response(profiles)
 }

--- a/src/frontend/src/lib/api-models/index.ts
+++ b/src/frontend/src/lib/api-models/index.ts
@@ -8,6 +8,7 @@ export * from './organization';
 export * from './permissions';
 export * from './project';
 export * from './proposal';
+export * from './staff-permissions';
 export * from './team';
 export * from './terms-and-conditions';
 export * from './trusted-partner';

--- a/src/frontend/src/lib/api-models/staff-permissions.ts
+++ b/src/frontend/src/lib/api-models/staff-permissions.ts
@@ -1,0 +1,102 @@
+import { mapOkResponse } from '@/lib/api-models/error';
+import {
+  mapUserStatusResponse,
+  UserStatus,
+} from '@/lib/api-models/user-profile';
+import { fromCandidOpt } from '@/lib/utils';
+import type {
+  GrantStaffPermissionsRequest as ApiGrantStaffPermissionsRequest,
+  GrantStaffPermissionsResponse as ApiGrantStaffPermissionsResponse,
+  ListStaffResponse as ApiListStaffResponse,
+  RevokeStaffPermissionsRequest as ApiRevokeStaffPermissionsRequest,
+  RevokeStaffPermissionsResponse as ApiRevokeStaffPermissionsResponse,
+  StaffMember as ApiStaffMember,
+  StaffPermissions as ApiStaffPermissions,
+} from '@ssn/backend-api';
+
+export type StaffPermissions = {
+  readAllOrgs: boolean;
+  writeBilling: boolean;
+};
+
+export type StaffMember = {
+  userId: string;
+  email: string | null;
+  emailVerified: boolean;
+  status: UserStatus;
+  permissions: StaffPermissions;
+};
+
+export type ListStaffResponse = StaffMember[];
+
+export type GrantStaffPermissionsRequest = {
+  userId: string;
+  permissions: StaffPermissions;
+};
+
+export type RevokeStaffPermissionsRequest = {
+  userId: string;
+};
+
+export function mapStaffPermissionsResponse(
+  res: ApiStaffPermissions,
+): StaffPermissions {
+  return {
+    readAllOrgs: res.read_all_orgs,
+    writeBilling: res.write_billing,
+  };
+}
+
+export function mapStaffPermissionsRequest(
+  req: StaffPermissions,
+): ApiStaffPermissions {
+  return {
+    read_all_orgs: req.readAllOrgs,
+    write_billing: req.writeBilling,
+  };
+}
+
+export function mapStaffMemberResponse(res: ApiStaffMember): StaffMember {
+  return {
+    userId: res.user_id,
+    email: fromCandidOpt(res.email),
+    emailVerified: res.email_verified,
+    status: mapUserStatusResponse(res.status),
+    permissions: mapStaffPermissionsResponse(res.permissions),
+  };
+}
+
+export function mapListStaffResponse(
+  res: ApiListStaffResponse,
+): ListStaffResponse {
+  return mapOkResponse(res).map(mapStaffMemberResponse);
+}
+
+export function mapGrantStaffPermissionsRequest(
+  req: GrantStaffPermissionsRequest,
+): ApiGrantStaffPermissionsRequest {
+  return {
+    user_id: req.userId,
+    permissions: mapStaffPermissionsRequest(req.permissions),
+  };
+}
+
+export function mapGrantStaffPermissionsResponse(
+  res: ApiGrantStaffPermissionsResponse,
+): void {
+  mapOkResponse(res);
+}
+
+export function mapRevokeStaffPermissionsRequest(
+  req: RevokeStaffPermissionsRequest,
+): ApiRevokeStaffPermissionsRequest {
+  return {
+    user_id: req.userId,
+  };
+}
+
+export function mapRevokeStaffPermissionsResponse(
+  res: ApiRevokeStaffPermissionsResponse,
+): void {
+  mapOkResponse(res);
+}

--- a/src/frontend/src/lib/api/index.ts
+++ b/src/frontend/src/lib/api/index.ts
@@ -6,6 +6,7 @@ export * from './invite';
 export * from './management-canister';
 export * from './organization';
 export * from './project';
+export * from './staff-permissions';
 export * from './team';
 export * from './terms-and-conditions';
 export * from './trusted-partner';

--- a/src/frontend/src/lib/api/staff-permissions.ts
+++ b/src/frontend/src/lib/api/staff-permissions.ts
@@ -1,0 +1,39 @@
+import {
+  mapGrantStaffPermissionsRequest,
+  mapGrantStaffPermissionsResponse,
+  mapListStaffResponse,
+  mapRevokeStaffPermissionsRequest,
+  mapRevokeStaffPermissionsResponse,
+  type GrantStaffPermissionsRequest,
+  type ListStaffResponse,
+  type RevokeStaffPermissionsRequest,
+} from '@/lib/api-models';
+import type { ActorSubclass } from '@icp-sdk/core/agent';
+import type { _SERVICE } from '@ssn/backend-api';
+
+export class StaffPermissionsApi {
+  constructor(private readonly actor: ActorSubclass<_SERVICE>) {}
+
+  public async listStaff(): Promise<ListStaffResponse> {
+    const res = await this.actor.list_staff({});
+    return mapListStaffResponse(res);
+  }
+
+  public async grantStaffPermissions(
+    req: GrantStaffPermissionsRequest,
+  ): Promise<void> {
+    const res = await this.actor.grant_staff_permissions(
+      mapGrantStaffPermissionsRequest(req),
+    );
+    mapGrantStaffPermissionsResponse(res);
+  }
+
+  public async revokeStaffPermissions(
+    req: RevokeStaffPermissionsRequest,
+  ): Promise<void> {
+    const res = await this.actor.revoke_staff_permissions(
+      mapRevokeStaffPermissionsRequest(req),
+    );
+    mapRevokeStaffPermissionsResponse(res);
+  }
+}

--- a/src/frontend/src/lib/store/api.ts
+++ b/src/frontend/src/lib/store/api.ts
@@ -8,6 +8,7 @@ import {
   CanisterApi,
   CanisterHistoryApi,
   ProposalApi,
+  StaffPermissionsApi,
   TrustedPartnerApi,
   UserProfileApi,
   ManagementCanisterApi,
@@ -64,6 +65,7 @@ const managementCanisterApi = new ManagementCanisterApi(
   managementCanisterActor,
 );
 const trustedPartnerApi = new TrustedPartnerApi(actor);
+const staffPermissionsApi = new StaffPermissionsApi(actor);
 const termsAndConditionsApi = new TermsAndConditionsApi(actor);
 const projectApi = new ProjectApi(actor);
 const organizationApi = new OrganizationApi(actor);
@@ -82,6 +84,7 @@ export const createApiSlice: AppStateCreator<ApiSlice> = (_set, get) => ({
   canisterHistoryApi,
   managementCanisterApi,
   trustedPartnerApi,
+  staffPermissionsApi,
   termsAndConditionsApi,
   projectApi,
   organizationApi,

--- a/src/frontend/src/lib/store/app.ts
+++ b/src/frontend/src/lib/store/app.ts
@@ -7,6 +7,7 @@ import { createInvitesSlice } from '@/lib/store/invite';
 import type { AppSlice } from '@/lib/store/model';
 import { createOrganizationsSlice } from '@/lib/store/organization';
 import { createProjectsSlice } from '@/lib/store/project';
+import { createStaffSlice } from '@/lib/store/staff-permissions';
 import { createTeamsSlice } from '@/lib/store/team';
 import { createTermsAndConditionsSlice } from '@/lib/store/terms-and-conditions';
 import { createTrustedPartnerSlice } from '@/lib/store/trusted-partner';
@@ -21,6 +22,7 @@ export const useAppStore = create<AppSlice>()((...a) => ({
   ...createUsersSlice(...a),
   ...createCanistersSlice(...a),
   ...createTrustedPartnerSlice(...a),
+  ...createStaffSlice(...a),
   ...createTermsAndConditionsSlice(...a),
   ...createProjectsSlice(...a),
   ...createOrganizationsSlice(...a),

--- a/src/frontend/src/lib/store/auth.ts
+++ b/src/frontend/src/lib/store/auth.ts
@@ -22,6 +22,7 @@ export const createAuthSlice: AppStateCreator<AuthSlice> = (set, get) => ({
       initializeUserProfile,
       initializeUsers,
       initializeTrustedPartners,
+      initializeStaff,
       initializeTermsAndConditions,
       initializeProjects,
       initializeOrganizations,
@@ -33,6 +34,7 @@ export const createAuthSlice: AppStateCreator<AuthSlice> = (set, get) => ({
     await Promise.all([
       initializeUsers(),
       initializeTrustedPartners(),
+      initializeStaff(),
       initializeTermsAndConditions(),
       initializeProjects(),
       initializeOrganizations(),
@@ -115,6 +117,7 @@ export const createAuthSlice: AppStateCreator<AuthSlice> = (set, get) => ({
       clearUsers,
       clearCanisters,
       clearTrustedPartners,
+      clearStaff,
       clearTermsAndConditions,
       clearProjects,
       clearOrganizations,
@@ -140,6 +143,7 @@ export const createAuthSlice: AppStateCreator<AuthSlice> = (set, get) => ({
       clearUsers();
       clearCanisters();
       clearTrustedPartners();
+      clearStaff();
       clearTermsAndConditions();
       clearProjects();
       clearOrganizations();

--- a/src/frontend/src/lib/store/model.ts
+++ b/src/frontend/src/lib/store/model.ts
@@ -6,6 +6,8 @@ import type {
   ListProjectProposalsResponse,
   Proposal,
   ProposalOutcome,
+  StaffMember,
+  StaffPermissions,
   Vote,
   CreateTrustedPartnerRequest,
   CreateOrgInviteRequest,
@@ -32,6 +34,7 @@ import type {
   CanisterApi,
   CanisterHistoryApi,
   ProposalApi,
+  StaffPermissionsApi,
   TrustedPartnerApi,
   UserProfileApi,
   ManagementCanisterApi,
@@ -69,6 +72,7 @@ export type ApiSlice = {
   authApi: AuthApi;
   managementCanisterApi: ManagementCanisterApi;
   trustedPartnerApi: TrustedPartnerApi;
+  staffPermissionsApi: StaffPermissionsApi;
   termsAndConditionsApi: TermsAndConditionsApi;
   projectApi: ProjectApi;
   organizationApi: OrganizationApi;
@@ -163,6 +167,19 @@ export type TrustedPartnersSlice = {
   createTrustedPartner: (req: CreateTrustedPartnerRequest) => Promise<void>;
 };
 
+export type StaffSlice = {
+  isStaffInitialized: boolean;
+  staff: StaffMember[] | null;
+
+  initializeStaff: () => Promise<void>;
+  clearStaff: () => void;
+  grantStaffPermissions: (
+    userId: string,
+    permissions: StaffPermissions,
+  ) => Promise<void>;
+  revokeStaffPermissions: (userId: string) => Promise<void>;
+};
+
 export type TermsAndConditionsSlice = {
   isTermsAndConditionsInitialized: boolean;
   termsAndConditions: TermsAndConditions | null;
@@ -253,6 +270,7 @@ export type AppSlice = AuthSlice &
   UsersSlice &
   CanistersSlice &
   TrustedPartnersSlice &
+  StaffSlice &
   TermsAndConditionsSlice &
   ProjectsSlice &
   OrganizationsSlice &

--- a/src/frontend/src/lib/store/staff-permissions.ts
+++ b/src/frontend/src/lib/store/staff-permissions.ts
@@ -1,0 +1,58 @@
+import type { AppStateCreator, StaffSlice } from '@/lib/store/model';
+
+export const createStaffSlice: AppStateCreator<StaffSlice> = (set, get) => ({
+  isStaffInitialized: false,
+  staff: null,
+
+  async initializeStaff() {
+    const { staffPermissionsApi, isAuthenticated, profile } = get();
+
+    if (!isAuthenticated || !profile?.isAdmin) {
+      set({ isStaffInitialized: true });
+      return;
+    }
+
+    try {
+      const staff = await staffPermissionsApi.listStaff();
+      set({ staff });
+    } finally {
+      set({ isStaffInitialized: true });
+    }
+  },
+
+  clearStaff() {
+    set({ staff: null });
+  },
+
+  async grantStaffPermissions(userId, permissions) {
+    const { staffPermissionsApi, isAuthenticated, profile } = get();
+
+    if (!isAuthenticated || !profile?.isAdmin) {
+      throw new Error('Not authorized to grant staff permissions');
+    }
+
+    await staffPermissionsApi.grantStaffPermissions({ userId, permissions });
+
+    // Always refetch: the grant response carries no email/status, and the
+    // local cache may be missing or stale (e.g. first visit to the page).
+    const refreshed = await staffPermissionsApi.listStaff();
+    set({ staff: refreshed });
+  },
+
+  async revokeStaffPermissions(userId) {
+    const { staffPermissionsApi, isAuthenticated, profile } = get();
+
+    if (!isAuthenticated || !profile?.isAdmin) {
+      throw new Error('Not authorized to revoke staff permissions');
+    }
+
+    await staffPermissionsApi.revokeStaffPermissions({ userId });
+
+    const { staff } = get();
+    if (staff === null) {
+      return;
+    }
+
+    set({ staff: staff.filter(member => member.userId !== userId) });
+  },
+});

--- a/src/frontend/src/routes/admin/staff-form.tsx
+++ b/src/frontend/src/routes/admin/staff-form.tsx
@@ -1,0 +1,317 @@
+import { LoadingButton } from '@/components/loading-button';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/form';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { useAppStore } from '@/lib/store';
+import { showErrorToast, showSuccessToast } from '@/lib/toast';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useState, type FC } from 'react';
+import { useForm } from 'react-hook-form';
+import z from 'zod';
+
+export type StaffFormProps = {
+  className?: string;
+};
+
+const formSchema = z
+  .object({
+    userId: z.string().min(1, 'User ID is required'),
+    readAllOrgs: z.boolean(),
+    writeBilling: z.boolean(),
+  })
+  .refine(data => data.readAllOrgs || data.writeBilling, {
+    message: 'Select at least one permission',
+    path: ['readAllOrgs'],
+  });
+
+type FormData = z.infer<typeof formSchema>;
+
+type Pending = {
+  userId: string;
+  readAllOrgs: boolean;
+  writeBilling: boolean;
+};
+
+export const StaffForm: FC<StaffFormProps> = ({ className }) => {
+  const { grantStaffPermissions } = useAppStore();
+  const [pending, setPending] = useState<Pending | null>(null);
+  const [confirmInput, setConfirmInput] = useState('');
+  const [isConfirming, setIsConfirming] = useState(false);
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { userId: '', readAllOrgs: false, writeBilling: false },
+  });
+
+  function onSubmit(formData: FormData): void {
+    setPending({
+      userId: formData.userId,
+      readAllOrgs: formData.readAllOrgs,
+      writeBilling: formData.writeBilling,
+    });
+    setConfirmInput('');
+  }
+
+  async function onConfirm(): Promise<void> {
+    if (pending === null) return;
+    setIsConfirming(true);
+    try {
+      await grantStaffPermissions(pending.userId, {
+        readAllOrgs: pending.readAllOrgs,
+        writeBilling: pending.writeBilling,
+      });
+      form.reset();
+      setPending(null);
+      setConfirmInput('');
+      showSuccessToast('Staff permissions granted');
+    } catch (err) {
+      showErrorToast('Failed to grant staff permissions', err);
+    } finally {
+      setIsConfirming(false);
+    }
+  }
+
+  function onCancel(): void {
+    setPending(null);
+    setConfirmInput('');
+  }
+
+  return (
+    <Card className={className}>
+      <CardHeader>
+        <CardTitle>Grant or Update Staff Permissions</CardTitle>
+      </CardHeader>
+
+      <CardContent>
+        {pending === null ? (
+          <Form {...form}>
+            <form className="space-y-6" onSubmit={form.handleSubmit(onSubmit)}>
+              <FormField
+                control={form.control}
+                name="userId"
+                render={({ field }) => (
+                  <FormItem className="w-full">
+                    <FormLabel>User ID</FormLabel>
+
+                    <FormControl>
+                      <Input
+                        placeholder="00000000-0000-0000-0000-000000000000"
+                        {...field}
+                      />
+                    </FormControl>
+
+                    <FormDescription>
+                      Granting replaces the user&apos;s existing staff
+                      permissions.
+                    </FormDescription>
+
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="readAllOrgs"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Permissions</FormLabel>
+
+                    <div className="flex flex-wrap gap-2">
+                      <Button
+                        type="button"
+                        variant={field.value ? 'default' : 'outline'}
+                        size="sm"
+                        onClick={() => field.onChange(!field.value)}
+                      >
+                        Read all orgs
+                      </Button>
+
+                      <Button
+                        type="button"
+                        variant={
+                          form.watch('writeBilling') ? 'default' : 'outline'
+                        }
+                        size="sm"
+                        onClick={() =>
+                          form.setValue(
+                            'writeBilling',
+                            !form.watch('writeBilling'),
+                            {
+                              shouldValidate: true,
+                            },
+                          )
+                        }
+                      >
+                        Write billing
+                      </Button>
+                    </div>
+
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <Button type="submit" variant="outline">
+                Review &amp; Grant
+              </Button>
+            </form>
+          </Form>
+        ) : (
+          <ConfirmPanel
+            pending={pending}
+            confirmInput={confirmInput}
+            onConfirmInputChange={setConfirmInput}
+            onConfirm={onConfirm}
+            onCancel={onCancel}
+            isConfirming={isConfirming}
+          />
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+type ConfirmPanelProps = {
+  pending: Pending;
+  confirmInput: string;
+  onConfirmInputChange: (value: string) => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isConfirming: boolean;
+};
+
+const ConfirmPanel: FC<ConfirmPanelProps> = ({
+  pending,
+  confirmInput,
+  onConfirmInputChange,
+  onConfirm,
+  onCancel,
+  isConfirming,
+}) => {
+  const { users } = useAppStore();
+  const matches = confirmInput.trim() === pending.userId.trim();
+  const targetUser =
+    users?.find(user => user.id === pending.userId.trim()) ?? null;
+
+  return (
+    <div className="space-y-4">
+      <div className="border-destructive/40 bg-destructive/5 space-y-3 rounded-md border p-4">
+        <p className="text-foreground text-sm font-medium">
+          You are about to grant staff permissions.
+        </p>
+
+        <dl className="space-y-2 text-xs/relaxed">
+          <div className="flex gap-2">
+            <dt className="text-muted-foreground w-24 shrink-0">User</dt>
+            <dd className="space-y-0.5">
+              {targetUser ? (
+                <>
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium">
+                      {targetUser.email ?? 'No email on file'}
+                    </span>
+                    {targetUser.email && (
+                      <Badge
+                        variant={
+                          targetUser.emailVerified ? 'success' : 'secondary'
+                        }
+                      >
+                        {targetUser.emailVerified ? 'Verified' : 'Unverified'}
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="text-muted-foreground font-mono break-all">
+                    {pending.userId}
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className="text-destructive font-medium">
+                    Unknown user &mdash; no profile matches this ID.
+                  </div>
+                  <div className="text-muted-foreground font-mono break-all">
+                    {pending.userId}
+                  </div>
+                </>
+              )}
+            </dd>
+          </div>
+
+          <div className="flex gap-2">
+            <dt className="text-muted-foreground w-24 shrink-0">Permissions</dt>
+            <dd className="space-y-1">
+              {pending.readAllOrgs && (
+                <div>
+                  <span className="font-medium">Read all orgs</span>
+                  <span className="text-muted-foreground">
+                    {' '}
+                    &mdash; can read every organization, project and canister
+                    regardless of membership.
+                  </span>
+                </div>
+              )}
+              {pending.writeBilling && (
+                <div>
+                  <span className="font-medium">Write billing</span>
+                  <span className="text-muted-foreground">
+                    {' '}
+                    &mdash; can modify any organization&apos;s billing plan
+                    (tier, limits, external reference).
+                  </span>
+                </div>
+              )}
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      <div className="space-y-2">
+        <label
+          htmlFor="staff-grant-confirm"
+          className="text-foreground text-xs/relaxed font-medium"
+        >
+          Type the user ID to confirm
+        </label>
+        <Input
+          id="staff-grant-confirm"
+          autoFocus
+          value={confirmInput}
+          onChange={e => onConfirmInputChange(e.target.value)}
+          placeholder={pending.userId}
+        />
+      </div>
+
+      <div className="flex gap-2">
+        <LoadingButton
+          type="button"
+          variant="destructive"
+          disabled={!matches}
+          isLoading={isConfirming}
+          onClick={onConfirm}
+        >
+          Confirm grant
+        </LoadingButton>
+
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onCancel}
+          disabled={isConfirming}
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/frontend/src/routes/admin/staff-permission-badges.tsx
+++ b/src/frontend/src/routes/admin/staff-permission-badges.tsx
@@ -1,0 +1,23 @@
+import { Badge } from '@/components/ui/badge';
+import type { StaffPermissions } from '@/lib/api-models';
+import type { FC } from 'react';
+
+export type StaffPermissionBadgesProps = {
+  permissions: StaffPermissions;
+};
+
+export const StaffPermissionBadges: FC<StaffPermissionBadgesProps> = ({
+  permissions,
+}) => (
+  <div className="flex flex-wrap gap-1">
+    {permissions.readAllOrgs && (
+      <Badge variant="secondary">Read all orgs</Badge>
+    )}
+    {permissions.writeBilling && (
+      <Badge variant="secondary">Write billing</Badge>
+    )}
+    {!permissions.readAllOrgs && !permissions.writeBilling && (
+      <Badge variant="outline">None</Badge>
+    )}
+  </div>
+);

--- a/src/frontend/src/routes/admin/staff-revoke-button.tsx
+++ b/src/frontend/src/routes/admin/staff-revoke-button.tsx
@@ -1,0 +1,67 @@
+import { LoadingButton } from '@/components/loading-button';
+import { Button } from '@/components/ui/button';
+import { useAppStore } from '@/lib/store';
+import { showErrorToast, showSuccessToast } from '@/lib/toast';
+import { useEffect, useState, type FC } from 'react';
+
+export type StaffRevokeButtonProps = {
+  userId: string;
+};
+
+const CONFIRM_TIMEOUT_MS = 5_000;
+
+export const StaffRevokeButton: FC<StaffRevokeButtonProps> = ({ userId }) => {
+  const { revokeStaffPermissions } = useAppStore();
+  const [isConfirming, setIsConfirming] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Auto-revert the confirm prompt so a forgotten armed button doesn't
+  // sit waiting for an accidental click.
+  useEffect(() => {
+    if (!isConfirming) return;
+    const timer = setTimeout(() => setIsConfirming(false), CONFIRM_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [isConfirming]);
+
+  async function onConfirm(): Promise<void> {
+    setIsSaving(true);
+    try {
+      await revokeStaffPermissions(userId);
+      showSuccessToast('Staff permissions revoked');
+    } catch (err) {
+      showErrorToast('Failed to revoke staff permissions', err);
+    } finally {
+      setIsSaving(false);
+      setIsConfirming(false);
+    }
+  }
+
+  if (!isConfirming) {
+    return (
+      <Button variant="outline" size="sm" onClick={() => setIsConfirming(true)}>
+        Revoke
+      </Button>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-1">
+      <LoadingButton
+        variant="destructive"
+        size="sm"
+        onClick={onConfirm}
+        isLoading={isSaving}
+      >
+        Confirm revoke
+      </LoadingButton>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => setIsConfirming(false)}
+        disabled={isSaving}
+      >
+        Cancel
+      </Button>
+    </div>
+  );
+};

--- a/src/frontend/src/routes/admin/staff-tab.tsx
+++ b/src/frontend/src/routes/admin/staff-tab.tsx
@@ -1,7 +1,12 @@
+import { StaffForm } from '@/routes/admin/staff-form';
+import { StaffTable } from '@/routes/admin/staff-table';
 import { type FC } from 'react';
 
 const StaffTab: FC = () => (
-  <p className="text-muted-foreground text-sm">Coming soon.</p>
+  <>
+    <StaffTable />
+    <StaffForm className="mt-12" />
+  </>
 );
 
 export default StaffTab;

--- a/src/frontend/src/routes/admin/staff-table.tsx
+++ b/src/frontend/src/routes/admin/staff-table.tsx
@@ -1,0 +1,76 @@
+import { Badge } from '@/components/ui/badge';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { useAppStore } from '@/lib/store';
+import { StaffPermissionBadges } from '@/routes/admin/staff-permission-badges';
+import { StaffRevokeButton } from '@/routes/admin/staff-revoke-button';
+import type { FC } from 'react';
+
+export type StaffTableProps = {
+  className?: string;
+};
+
+export const StaffTable: FC<StaffTableProps> = ({ className }) => {
+  const { staff } = useAppStore();
+
+  if (staff !== null && staff.length === 0) {
+    return (
+      <p className="text-muted-foreground text-sm">
+        No staff members yet. Use the form below to grant permissions.
+      </p>
+    );
+  }
+
+  return (
+    <Table className={className}>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-1">User ID</TableHead>
+
+          <TableHead>Email</TableHead>
+
+          <TableHead>Permissions</TableHead>
+
+          <TableHead></TableHead>
+        </TableRow>
+      </TableHeader>
+
+      <TableBody>
+        {staff?.map(member => (
+          <TableRow key={member.userId}>
+            <TableCell className="font-mono text-xs">{member.userId}</TableCell>
+
+            <TableCell>
+              <div className="flex items-center gap-2">
+                <span>{member.email ?? 'None provided'}</span>
+                {member.email && (
+                  <Badge
+                    variant={member.emailVerified ? 'success' : 'secondary'}
+                  >
+                    {member.emailVerified ? 'Verified' : 'Unverified'}
+                  </Badge>
+                )}
+              </div>
+            </TableCell>
+
+            <TableCell>
+              <StaffPermissionBadges permissions={member.permissions} />
+            </TableCell>
+
+            <TableCell>
+              <div className="flex items-center justify-end gap-2">
+                <StaffRevokeButton userId={member.userId} />
+              </div>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+};


### PR DESCRIPTION
Exposes a controller-gated list_staff query and ships an admin page that surfaces the staff roster with grant and revoke flows. Staff state lives on its own surface to keep the projection from leaking through user-listing endpoints whose auth may relax in the future.